### PR TITLE
Enable switching to S3 blobstore

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -19,7 +19,13 @@ http_archive(
 package(default_visibility = ["//visibility:public"])
 filegroup(
     name = "cf_deployment",
-    srcs = ["cf-deployment.yml", "operations/bits-service/use-bits-service.yml"],
+    srcs = [
+        "cf-deployment.yml",
+        "operations/bits-service/use-bits-service.yml",
+        "operations/use-external-blobstore.yml",
+        "operations/use-s3-blobstore.yml",
+        "operations/bits-service/configure-bits-service-s3.yml"
+    ],
 )
 """,
     sha256 = project.cf_deployment.sha256,

--- a/deploy/helm/kubecf/assets/operations/instance_groups/eirini.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/eirini.yaml
@@ -103,9 +103,9 @@
           certs_secret_name: eirini-staging-secret
           cc_internal_api: https://cloud-controller-ng.service.cf.internal:9023
           eirini_address: https://{{ .Values.deployment_name }}-eirini.{{ .Release.Namespace }}:8484
-          downloader_image: "eirini/recipe-downloader:0.3.0"
-          uploader_image: "eirini/recipe-uploader:0.3.0"
-          executor_image: "eirini/recipe-executor:0.3.0"
+          downloader_image: "gcr.io/peripli/recipe-downloader:0.3.0-ca-fix"
+          uploader_image: "gcr.io/peripli/recipe-uploader:0.3.0-ca-fix"
+          executor_image: "gcr.io/peripli/recipe-executor:0.3.0-ca-fix"
           # TODO: make this configurable
           metrics_source_address: ""
           loggregator_address: localhost:3458
@@ -138,6 +138,7 @@
     stemcell: {{ include "kubecf.stemcellLookup" (list .Values.releases "eirini") }}
 
 # Set the correct addresses to be reached by the Eirini apps namespace.
+{{- if eq .Values.features.blobstore.provider "singleton" }}
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/buildpacks?/webdav_config/private_endpoint
   value: &blobstore_url "https://{{ .Values.deployment_name }}-singleton-blobstore.{{ .Release.Namespace }}:4443"
@@ -156,6 +157,7 @@
 - type: replace
   path: /variables/name=blobstore_tls/options/alternative_names?/-
   value: "{{ .Values.deployment_name }}-singleton-blobstore.{{ .Release.Namespace }}"
+{{- end }}
 - type: replace
   path: /instance_groups/name=api/jobs/name=cc_uploader/properties/internal_hostname?
   value: "{{ .Values.deployment_name }}-api.{{ .Release.Namespace }}"

--- a/deploy/helm/kubecf/assets/operations/instance_groups/singleton-blobstore.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/singleton-blobstore.yaml
@@ -1,3 +1,4 @@
+{{ if eq  .Values.features.blobstore.provider "singleton" }}
 # Configure the persistent disk in the way that cf-operator can provision.
 - type: remove
   path: /instance_groups/name=singleton-blobstore/persistent_disk_type
@@ -44,4 +45,5 @@
 {{- $root := . -}}
 {{- range $path, $bytes := .Files.Glob "assets/operations/pre_render_scripts/singleton-blobstore_*" }}
 {{ $root.Files.Get $path }}
+{{- end }}
 {{- end }}

--- a/deploy/helm/kubecf/templates/bosh_deployment.yaml
+++ b/deploy/helm/kubecf/templates/bosh_deployment.yaml
@@ -24,8 +24,10 @@ spec:
     type: configmap
   - name: ops-use-s3-blobstore
     type: configmap
+{{- if .Values.features.eirini.enabled }}
   - name: ops-configure-bits-service-s3
     type: configmap
+{{- end }}
 {{- end }}
 {{- if .Values.features.suse_buildpacks }}
   - name: {{ include "kubecf.ops-name" "assets/operations/buildpacks/set_suse_buildpacks.yaml" }}

--- a/deploy/helm/kubecf/templates/bosh_deployment.yaml
+++ b/deploy/helm/kubecf/templates/bosh_deployment.yaml
@@ -15,12 +15,20 @@ spec:
     name: cf-deployment
     type: configmap
   ops:
-{{- if .Values.features.suse_buildpacks }}
-  - name: {{ include "kubecf.ops-name" "assets/operations/buildpacks/set_suse_buildpacks.yaml" }}
-    type: configmap
-{{- end }}
 {{- if .Values.features.eirini.enabled }}
   - name: ops-use-bits-service
+    type: configmap
+{{- end }}
+{{- if eq .Values.features.blobstore.provider "s3" }}
+  - name: ops-use-external-blobstore
+    type: configmap
+  - name: ops-use-s3-blobstore
+    type: configmap
+  - name: ops-configure-bits-service-s3
+    type: configmap
+{{- end }}
+{{- if .Values.features.suse_buildpacks }}
+  - name: {{ include "kubecf.ops-name" "assets/operations/buildpacks/set_suse_buildpacks.yaml" }}
     type: configmap
 {{- end }}
 {{- range $path, $bytes := .Files.Glob "assets/operations/instance_groups/*" }}

--- a/deploy/helm/kubecf/templates/ops-use-s3-blobstore.yaml
+++ b/deploy/helm/kubecf/templates/ops-use-s3-blobstore.yaml
@@ -1,0 +1,152 @@
+{{- if eq .Values.features.blobstore.provider "s3" -}}
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ops-use-s3-blobstore
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: {{ include "kubecf.fullname" . }}
+    app.kubernetes.io/version: {{ default .Chart.Version .Chart.AppVersion | quote }}
+    helm.sh/chart: {{ include "kubecf.chart" . }}
+data:
+  ops: |-
+    {{- .Files.Get "assets/use-s3-blobstore.yml" | nindent 4 }}
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ops-configure-bits-service-s3
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: {{ include "kubecf.fullname" . }}
+    app.kubernetes.io/version: {{ default .Chart.Version .Chart.AppVersion | quote }}
+    helm.sh/chart: {{ include "kubecf.chart" . }}
+data:
+  ops: |-
+    {{- .Files.Get "assets/configure-bits-service-s3.yml" | nindent 4 }}
+---
+apiVersion: "v1"
+kind: "Secret"
+type: Opaque
+metadata:
+  name: {{ .Values.deployment_name }}.var-blobstore-access-key-id
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: {{ default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" | quote }}
+    app.kubernetes.io/version: {{ default .Chart.Version .Chart.AppVersion | quote }}
+    helm.sh/chart: {{ printf "%s-%s" .Chart.Name (.Chart.Version | replace "+" "_") | quote }}
+stringData:
+  value: "{{ .Values.features.blobstore.s3.blobstore_access_key_id }}"
+---
+apiVersion: "v1"
+kind: "Secret"
+type: Opaque
+metadata:
+  name: {{ .Values.deployment_name }}.var-blobstore-secret-access-key
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: {{ default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" | quote }}
+    app.kubernetes.io/version: {{ default .Chart.Version .Chart.AppVersion | quote }}
+    helm.sh/chart: {{ printf "%s-%s" .Chart.Name (.Chart.Version | replace "+" "_") | quote }}
+stringData:
+  value: "{{ .Values.features.blobstore.s3.blobstore_secret_access_key }}"
+---
+apiVersion: "v1"
+kind: "Secret"
+type: Opaque
+metadata:
+  name: {{ .Values.deployment_name }}.var-app-package-directory-key
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: {{ default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" | quote }}
+    app.kubernetes.io/version: {{ default .Chart.Version .Chart.AppVersion | quote }}
+    helm.sh/chart: {{ printf "%s-%s" .Chart.Name (.Chart.Version | replace "+" "_") | quote }}
+stringData:
+  value: "{{ .Values.features.blobstore.s3.app_package_directory_key }}"
+---
+apiVersion: "v1"
+kind: "Secret"
+type: Opaque
+metadata:
+  name: {{ .Values.deployment_name }}.var-buildpack-directory-key
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: {{ default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" | quote }}
+    app.kubernetes.io/version: {{ default .Chart.Version .Chart.AppVersion | quote }}
+    helm.sh/chart: {{ printf "%s-%s" .Chart.Name (.Chart.Version | replace "+" "_") | quote }}
+stringData:
+  value: "{{ .Values.features.blobstore.s3.buildpack_directory_key }}"
+---
+apiVersion: "v1"
+kind: "Secret"
+type: Opaque
+metadata:
+  name: {{ .Values.deployment_name }}.var-droplet-directory-key
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: {{ default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" | quote }}
+    app.kubernetes.io/version: {{ default .Chart.Version .Chart.AppVersion | quote }}
+    helm.sh/chart: {{ printf "%s-%s" .Chart.Name (.Chart.Version | replace "+" "_") | quote }}
+stringData:
+  value: "{{ .Values.features.blobstore.s3.droplet_directory_key }}"
+---
+apiVersion: "v1"
+kind: "Secret"
+type: Opaque
+metadata:
+  name: {{ .Values.deployment_name }}.var-resource-directory-key
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: {{ default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" | quote }}
+    app.kubernetes.io/version: {{ default .Chart.Version .Chart.AppVersion | quote }}
+    helm.sh/chart: {{ printf "%s-%s" .Chart.Name (.Chart.Version | replace "+" "_") | quote }}
+stringData:
+  value: "{{ .Values.features.blobstore.s3.resource_directory_key }}"
+---
+apiVersion: "v1"
+kind: "Secret"
+type: Opaque
+metadata:
+  name: {{ .Values.deployment_name }}.var-blobstore-admin-users-password
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: {{ default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" | quote }}
+    app.kubernetes.io/version: {{ default .Chart.Version .Chart.AppVersion | quote }}
+    helm.sh/chart: {{ printf "%s-%s" .Chart.Name (.Chart.Version | replace "+" "_") | quote }}
+stringData:
+  value: "{{ .Values.features.blobstore.s3.blobstore_admin_users_password }}"
+---
+apiVersion: "v1"
+kind: "Secret"
+type: Opaque
+metadata:
+  name: {{ .Values.deployment_name }}.var-aws-region
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: {{ default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" | quote }}
+    app.kubernetes.io/version: {{ default .Chart.Version .Chart.AppVersion | quote }}
+    helm.sh/chart: {{ printf "%s-%s" .Chart.Name (.Chart.Version | replace "+" "_") | quote }}
+stringData:
+  value: "{{ .Values.features.blobstore.s3.aws_region }}"
+{{- end -}}

--- a/deploy/helm/kubecf/templates/single_availability.yaml
+++ b/deploy/helm/kubecf/templates/single_availability.yaml
@@ -28,9 +28,11 @@ data:
     - type: replace
       path: /instance_groups/name=uaa/instances
       value: 1
+    {{- if eq .Values.features.blobstore.provider "singleton" }}
     - type: replace
       path: /instance_groups/name=singleton-blobstore/instances
       value: 1
+    {{- end }}
     - type: replace
       path: /instance_groups/name=api/instances
       value: 1
@@ -62,8 +64,10 @@ data:
       path: /instance_groups/name=diego-api/azs?
     - type: remove
       path: /instance_groups/name=uaa/azs?
+    {{- if eq .Values.features.blobstore.provider "singleton" }}
     - type: remove
       path: /instance_groups/name=singleton-blobstore/azs?
+    {{- end }}
     - type: remove
       path: /instance_groups/name=api/azs?
     - type: remove

--- a/deploy/helm/kubecf/templates/use-external-blobstore.yml.yaml
+++ b/deploy/helm/kubecf/templates/use-external-blobstore.yml.yaml
@@ -1,0 +1,17 @@
+{{- if eq .Values.features.blobstore.provider "s3" -}}
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ops-use-external-blobstore
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: {{ include "kubecf.fullname" . }}
+    app.kubernetes.io/version: {{ default .Chart.Version .Chart.AppVersion | quote }}
+    helm.sh/chart: {{ include "kubecf.chart" . }}
+data:
+  ops: |-
+    {{- .Files.Get "assets/use-external-blobstore.yml" | nindent 4 }}
+
+{{- end }}

--- a/deploy/helm/kubecf/values.yaml
+++ b/deploy/helm/kubecf/values.yaml
@@ -51,6 +51,16 @@ features:
       key: ~
     annotations: {}
     labels: {}
+  blobstore:
+    provider: singleton
+    s3:
+      aws_region: "eu-central-1"
+      blobstore_access_key_id: ""
+      blobstore_secret_access_key: ""
+      app_package_directory_key: "apps-cf"
+      buildpack_directory_key: "buildpacks-cf"
+      droplet_directory_key: "droplets-cf"
+      resource_directory_key: "resources-cf"
   # TODO: suse_buildpacks should be default to true after the opensuse-stemcell-based images are
   # published to docker.io.
   suse_buildpacks: false

--- a/deploy/helm/kubecf/values.yaml
+++ b/deploy/helm/kubecf/values.yaml
@@ -52,11 +52,13 @@ features:
     annotations: {}
     labels: {}
   blobstore:
+    # possible values for provider: singleton and s3
     provider: singleton
     s3:
       aws_region: "eu-central-1"
       blobstore_access_key_id: ""
       blobstore_secret_access_key: ""
+      # The following values are used as S3 bucket names
       app_package_directory_key: "apps-cf"
       buildpack_directory_key: "buildpacks-cf"
       droplet_directory_key: "droplets-cf"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

We would like to run kubecf with an external blobstore (S3). This patch enables this feature on demand.

It was necessary to use different images for eirini-staging, because the standard images don't trust the standard CA. We opened a [PR for this](https://github.com/cloudfoundry-incubator/eirini-staging/pull/9).

## Description
<!--- Describe your changes in detail -->

We used the standard ops file provided from cf-deployment to provide this feature.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Using the singleton-blobstore is not meant for production.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- An important detail to include is the version of the used cf-operator -->

We installed it manually with `cf-operator` and tested `cf push dora`

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
