### PR TITLE
Add probes for ha igs

### DIFF
--- a/deploy/helm/kubecf/assets/operations/instance_groups/auctioneer.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/auctioneer.yaml
@@ -6,14 +6,13 @@
     - name: auctioneer
       protocol: TCP
       internal: 9016
-    run:
-      healthcheck:
-        auctioneer:
-          readiness:
-            # There is no health check, just depend on the port being open
-            tcpSocket:
-              port: 9016
-
+    activePassiveProbes:
+      auctioneer-auctioneer:
+        exec:
+          command:
+          - bash
+          - -ce
+          - "head -c0 </dev/tcp/${HOSTNAME}/9016"
 # Set the alias auctioneer.service.cf.internal instance group to auctioneer.
 - type: replace
   path: /addons/name=bosh-dns-aliases/jobs/name=bosh-dns-aliases/properties/aliases/domain=auctioneer.service.cf.internal/targets/0/instance_group

--- a/deploy/helm/kubecf/assets/operations/instance_groups/diego-api.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/diego-api.yaml
@@ -62,18 +62,14 @@
     ports:
     - name: cell-bbs-api
       protocol: TCP
-      internal: 8889
-    run:
-      healthcheck:
-        bbs:
-          readiness:
-            # The /ping endpoint on the healthcheck endpoint is unusable for this readiness probe as
-            # it always returns success if the server it up and running. The port 8889, on the other
-            # hand, is useful because bbs will start listening on it only if it acquired the lock
-            # via locket.
-            tcpSocket:
-              port: 8889
-
+      internal: 8889 # If you change this values, change the probe below too
+    activePassiveProbes:
+      bbs-bbs:
+        exec:
+          command:
+          - bash
+          - -ce
+          - "head -c0 </dev/tcp/${HOSTNAME}/8889"
 - type: replace
   path: /instance_groups/name=diego-api/jobs/name=cfdot/properties/quarks?/bpm/processes
   value: []

--- a/deploy/helm/kubecf/assets/operations/instance_groups/routing-api.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/routing-api.yaml
@@ -12,14 +12,13 @@
     - name: routing-api
       protocol: TCP
       internal: 3000
-    run:
-      healthcheck:
-        routing-api:
-          readiness:
-            # routing-api does not expose a health check endpoint.
-            tcpSocket:
-              port: 3000
-
+    activePassiveProbes:
+      routing-api-routing-api:
+        exec:
+          command:
+          - bash
+          - -ce
+          - "head -c0 </dev/tcp/${HOSTNAME}/3000 "
 # Set the alias routing-api.service.cf.internal instance group to routing-api.
 - type: replace
   path: /addons/name=bosh-dns-aliases/jobs/name=bosh-dns-aliases/properties/aliases/domain=routing-api.service.cf.internal/targets/0/instance_group


### PR DESCRIPTION
## Description

- Defines active-passive probes for the roles that need them

## Motivation and Context
It is needed in order to have proper HA for all roles. The workaround up to know was to use a Readiness probe and let the "passive" pod in a not Ready state. With the probes in the PR, traffic is routed to pods using labels and selectors (created by the operator).

Closes #309 

## How Has This Been Tested?

Deployed kubecf with `high_availability: true` and Diego. Then checked the roles that got the probes to see if only one of the pods has the `active` label. The relevant services also got a selector. We checked that traffic is actually reaching only one of the pods by looking at their logs.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
