### PR TITLE
fix: rules/helm: ruby < 2.5.0 compat

### DIFF
--- a/rules/helm/upgrade.tmpl.rb
+++ b/rules/helm/upgrade.tmpl.rb
@@ -20,8 +20,8 @@ args = [
   '--namespace', namespace
 ]
 
-args.append('--install') if install
-args.append('--reuse-values') if reuse_values
+args.push('--install') if install
+args.push('--reuse-values') if reuse_values
 
 values = values_paths.split(path_split_delim).map do |path|
   ['--values', path]


### PR DESCRIPTION
## Description

[Array#append](https://www.rubydoc.info/stdlib/core/Array#append-instance_method) was added in MRI 2.5.0; use the older name [Array#push](https://www.rubydoc.info/stdlib/core/Array#push-instance_method) instead for better compatibility.

## Motivation and Context
This was reported in [a thread on #kubecf](https://cloudfoundry.slack.com/archives/CQ2U3L6DC/p1582553063004200?thread_ts=1582548623.003200&cid=CQ2U3L6DC).

```
/private/var/tmp/_bazel_encalada/4bff13a28ce77172f0d977f092af385b/execroot/kubecf/bazel-out/darwin-fastbuild/bin/dev/cf_operator/apply.rb:23:in `<main>': undefined method `append' for #<Array:0x007fe96c854208> (NoMethodError)
```

## How Has This Been Tested?
Locally re-deployed kubecf; completed with no issues.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
