### PR TITLE
Add kubecf-docs to the links

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ under [Project Quarks].
 [KubeCF]:                   https://github.com/SUSE/kubecf
 [Cloud Foundry Operator]:   https://github.com/cloudfoundry-incubator/cf-operator/
 [Project Quarks]:           https://www.cloudfoundry.org/project-quarks/
+[Docs]:                     https://kubecf.suse.dev/
+
+## Documentation
+
+The Community documentation website is [available here](https://kubecf.suse.dev/).
 
 ## Contributing to KubeCF development
 


### PR DESCRIPTION
## Description
Adds a link to https://kubecf.suse.dev/ in the README

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
