### PR TITLE
Trigger concourse pipeline on kubecf branches

### DIFF
--- a/.concourse/pipeline.yaml
+++ b/.concourse/pipeline.yaml
@@ -37,7 +37,7 @@ resources:
   source:
     repository: cloudfoundry-incubator/kubecf
     access_token: ((github-access-token))
-    disable_forks: false
+    disable_forks: true # Trigger on kubecf branches only
 
 - name: catapult
   type: git
@@ -140,9 +140,7 @@ jobs:
   - get: kubecf-pr
     params:
       integration_tool: checkout
-    # We manually trigger PR builds for security reasons
-    # (protect CI infrastructure from malicious commits)
-    trigger: false
+    trigger: true
   # Use GitHub API to find the remote repository of the PR (it may be a fork)
   # The pr resource doesn't provide this information.
   - task: find-pr-remote


### PR DESCRIPTION
Instead of allowing forks, we just filter for PRs coming from branches of kubecf,
and we automatically trigger on those.

## Motivation and Context
We can have automatic triggers for PR coming from branches, this ensures only who have write access to be able to use the CI

## How Has This Been Tested?
Deployed on https://concourse.suse.dev/teams/main/pipelines/kubecf

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
