### PR TITLE
Fix helm upgrades not applying changed values

### DIFF
--- a/dev/cf_operator/BUILD.bazel
+++ b/dev/cf_operator/BUILD.bazel
@@ -18,7 +18,7 @@ helm_upgrade(
     set_values = {
         "global.operator.watchNamespace": project.namespace,
     },
-    reuse_values = True,
+    reset_values = True,
 )
 
 helm_delete(

--- a/dev/kubecf/BUILD.bazel
+++ b/dev/kubecf/BUILD.bazel
@@ -14,7 +14,7 @@ helm_upgrade(
     namespace = project.namespace,
     chart_package = "//deploy/helm/kubecf",
     values = glob(["**/*values.yaml"]),
-    reuse_values = True,
+    reset_values = True,
 )
 
 helm_delete(

--- a/rules/helm/def.bzl
+++ b/rules/helm/def.bzl
@@ -177,7 +177,7 @@ def _upgrade_impl(ctx):
             "[[chart_package]]": ctx.file.chart_package.short_path,
             "[[namespace]]": ctx.attr.namespace,
             "[[install]]": str(ctx.attr.install),
-            "[[reuse_values]]": str(ctx.attr.reuse_values),
+            "[[reset_values]]": str(ctx.attr.reset_values),
             "[[values_paths]]": path_split_delim.join(
                 [values.short_path for values in ctx.files.values]),
             "[[path_split_delim]]": path_split_delim,
@@ -214,9 +214,9 @@ upgrade = rule(
             default = {},
             doc = "A set of key-value pairs to be passed as --set flag to Helm",
         ),
-        "reuse_values": attr.bool(
+        "reset_values": attr.bool(
             default = False,
-            doc = "Whether the Helm upgrade should reuse the values already applied",
+            doc = "Whether the Helm upgrade should reset the values to the ones provided by the chart",
         ),
         "_script_tmpl": attr.label(
             allow_single_file = True,

--- a/rules/helm/upgrade.tmpl.rb
+++ b/rules/helm/upgrade.tmpl.rb
@@ -10,7 +10,7 @@ install_name = '[[install_name]]'
 chart_package = '[[chart_package]]'
 namespace = '[[namespace]]'
 install = '[[install]]' == 'True'
-reuse_values = '[[reuse_values]]' == 'True'
+reset_values = '[[reset_values]]' == 'True'
 values_paths = '[[values_paths]]'
 path_split_delim = '[[path_split_delim]]'
 set_values = JSON.parse('[[set_values]]')
@@ -21,7 +21,7 @@ args = [
 ]
 
 args.push('--install') if install
-args.push('--reuse-values') if reuse_values
+args.push('--reset-values') if reset_values
 
 values = values_paths.split(path_split_delim).map do |path|
   ['--values', path]


### PR DESCRIPTION
## Description

The bazel targets were using `helm upgrade --reuse-values` but that  reuses the values of the last deployment and applies the ones given on the command line. It discards changed
values in the chart itself.
What we actually want is `--reset-values` which resets the values to the
ones from the chart + command line.


## Motivation and Context

This pr fixes a problem where changes to the `values.yaml` are not applied by running `bazel run //dev/kubecf:apply`.<!--- Describe your changes in detail -->

## How Has This Been Tested?
Manual upgrades of a local deployment using the bazel target.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
