### PR TITLE
Remove template chunks that trim on both ends

### DIFF
--- a/deploy/helm/kubecf/assets/operations/buildpacks/set_suse_buildpacks.yaml
+++ b/deploy/helm/kubecf/assets/operations/buildpacks/set_suse_buildpacks.yaml
@@ -17,7 +17,7 @@
 {{- $buildpacks = append $buildpacks "suse-nginx-buildpack" }}
 {{- $buildpacks = append $buildpacks "suse-binary-buildpack" }}
 
-{{- $root := . -}}
+{{- $root := . }}
 {{- range $buildpack := $buildpacks }}
 - type: replace
   path: /releases/-

--- a/deploy/helm/kubecf/assets/operations/instance_groups/acceptance-tests.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/acceptance-tests.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.testing.cf_acceptance_tests.enabled -}}
+{{- if .Values.testing.cf_acceptance_tests.enabled }}
 
 - path: /instance_groups/-
   type: replace

--- a/deploy/helm/kubecf/assets/operations/instance_groups/api.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/api.yaml
@@ -340,7 +340,7 @@
   path: /instance_groups/name=api/jobs/name=loggr-udp-forwarder/properties/quarks?/run/healthcheck/loggr-udp-forwarder/readiness/exec/command
   value: [sh, -c, ss -nlu sport = 3457 | grep :3457]
 
-{{- $root := . -}}
+{{- $root := . }}
 {{- if .Values.features.suse_buildpacks.enabled }}
 {{- range $path, $bytes := .Files.Glob "assets/operations/pre_render_scripts/api_*" }}
 {{ $root.Files.Get $path }}

--- a/deploy/helm/kubecf/assets/operations/instance_groups/app-autoscaler.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/app-autoscaler.yaml
@@ -1,5 +1,5 @@
-{{- if .Values.features.autoscaler.enabled -}}
-{{- $root := . -}}
+{{- if .Values.features.autoscaler.enabled }}
+{{- $root := . }}
 
 # Add autoscaler uaa client id and secret
 - type: replace
@@ -1001,7 +1001,7 @@
   path: /instance_groups/name=asapi/jobs/name=golangapiserver/properties/autoscaler/cf/skip_ssl_validation?
   value: true
 
-{{- $root := . -}}
+{{- $root := . }}
 {{- range $path, $bytes := .Files.Glob "assets/operations/pre_render_scripts/asdatabase_*" }}
 {{ $root.Files.Get $path }}
 {{- end }}

--- a/deploy/helm/kubecf/assets/operations/instance_groups/auctioneer.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/auctioneer.yaml
@@ -18,7 +18,7 @@
   path: /addons/name=bosh-dns-aliases/jobs/name=bosh-dns-aliases/properties/aliases/domain=auctioneer.service.cf.internal/targets/0/instance_group
   value: auctioneer
 
-{{- $root := . -}}
+{{- $root := . }}
 {{- range $path, $bytes := .Files.Glob "assets/operations/pre_render_scripts/auctioneer_*" }}
 {{ $root.Files.Get $path }}
 {{- end }}

--- a/deploy/helm/kubecf/assets/operations/instance_groups/bits.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/bits.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.features.eirini.enabled -}}
+{{- if .Values.features.eirini.enabled }}
 
 # Add quarks information to the Bits Service jobs.
 - type: replace
@@ -57,7 +57,7 @@
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/bits_service?/enabled?
   value: false
 
-{{- $root := . -}}
+{{- $root := . }}
 {{- range $path, $bytes := .Files.Glob "assets/operations/pre_render_scripts/bits_*" }}
 {{ $root.Files.Get $path }}
 {{- end }}

--- a/deploy/helm/kubecf/assets/operations/instance_groups/brain-tests.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/brain-tests.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.testing.brain_tests.enabled -}}
+{{- if .Values.testing.brain_tests.enabled }}
 
 - path: /instance_groups/-
   type: replace

--- a/deploy/helm/kubecf/assets/operations/instance_groups/diego-api.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/diego-api.yaml
@@ -74,7 +74,7 @@
   path: /instance_groups/name=diego-api/jobs/name=cfdot/properties/quarks?/bpm/processes
   value: []
 
-{{- $root := . -}}
+{{- $root := . }}
 {{- range $path, $bytes := .Files.Glob "assets/operations/pre_render_scripts/diego-api_*" }}
 {{ $root.Files.Get $path }}
 {{- end }}

--- a/deploy/helm/kubecf/assets/operations/instance_groups/diego-cell.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/diego-cell.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.features.eirini.enabled -}}
+{{- if not .Values.features.eirini.enabled }}
 
 {{- if .Values.features.suse_buildpacks.enabled }}
 - type: replace
@@ -160,7 +160,7 @@
   path: /instance_groups/name=diego-cell/jobs/name=garden/properties?/garden?/disable_swap_limit?
   value: true
 
-{{- $root := . -}}
+{{- $root := . }}
 {{- if .Values.features.suse_buildpacks.enabled }}
 {{- range $path, $bytes := .Files.Glob "assets/operations/pre_render_scripts/diego-cell_*" }}
 {{ $root.Files.Get $path }}

--- a/deploy/helm/kubecf/assets/operations/instance_groups/eirini.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/eirini.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.features.eirini.enabled -}}
+{{- if .Values.features.eirini.enabled }}
 
 # Add the eirini BOSH DNS alias.
 - type: replace
@@ -327,7 +327,7 @@
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/app_ssh/host_key_fingerprint?
   value: '((eirini_ssh_proxy_key.public_key_fingerprint))'
 
-{{- $root := . -}}
+{{- $root := . }}
 {{- range $path, $bytes := .Files.Glob "assets/operations/pre_render_scripts/eirini_*" }}
 {{ $root.Files.Get $path }}
 {{- end }}

--- a/deploy/helm/kubecf/assets/operations/instance_groups/router.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/router.yaml
@@ -56,7 +56,7 @@
     ((uaa_ssl.ca))
     ((network_policy_server_external.ca))
 
-{{- if .Values.features.credhub.enabled -}}
+{{- if .Values.features.credhub.enabled }}
 - path: /instance_groups/name=router/jobs/name=gorouter/properties/router/ca_certs
   type: replace
   value: |
@@ -67,7 +67,7 @@
     ((credhub_ca.certificate))
 {{- end }}
 
-{{- $root := . -}}
+{{- $root := . }}
 {{- range $path, $bytes := .Files.Glob "assets/operations/pre_render_scripts/router_*" }}
 {{ $root.Files.Get $path }}
 {{- end }}

--- a/deploy/helm/kubecf/assets/operations/instance_groups/routing-api.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/routing-api.yaml
@@ -24,7 +24,7 @@
   path: /addons/name=bosh-dns-aliases/jobs/name=bosh-dns-aliases/properties/aliases/domain=routing-api.service.cf.internal/targets/0/instance_group
   value: routing-api
 
-{{- $root := . -}}
+{{- $root := . }}
 {{- range $path, $bytes := .Files.Glob "assets/operations/pre_render_scripts/routing-api_*" }}
 {{ $root.Files.Get $path }}
 {{- end }}

--- a/deploy/helm/kubecf/assets/operations/instance_groups/scheduler.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/scheduler.yaml
@@ -56,7 +56,7 @@
 
 # Add necessary labels to the scheduler instance group so that the service can select it to create
 # the endpoint.
-{{- if not .Values.features.eirini.enabled -}}
+{{- if not .Values.features.eirini.enabled }}
 - type: replace
   path: /instance_groups/name=scheduler/env?/bosh/agent/settings/labels/app.kubernetes.io~1component
   value: "ssh-proxy"
@@ -72,7 +72,7 @@
   path: /instance_groups/name=scheduler/jobs/name=cfdot/properties/quarks?/bpm/processes
   value: []
 
-{{- $root := . -}}
+{{- $root := . }}
 {{- range $path, $bytes := .Files.Glob "assets/operations/pre_render_scripts/scheduler_*" }}
 {{ $root.Files.Get $path }}
 {{- end }}

--- a/deploy/helm/kubecf/assets/operations/instance_groups/singleton-blobstore.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/singleton-blobstore.yaml
@@ -46,7 +46,7 @@
       # The route registrar doesn't expose anything to indicate if the
       # routes are healthy.
 
-{{- $root := . -}}
+{{- $root := . }}
 {{- range $path, $bytes := .Files.Glob "assets/operations/pre_render_scripts/singleton-blobstore_*" }}
 {{ $root.Files.Get $path }}
 {{- end }}

--- a/deploy/helm/kubecf/assets/operations/instance_groups/smoke-tests.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/smoke-tests.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.testing.smoke_tests.enabled -}}
+{{- if .Values.testing.smoke_tests.enabled }}
 
 - type: replace
   path: /instance_groups/name=smoke-tests/jobs/name=cf-cli-6-linux/properties?/quarks/bpm/processes
@@ -9,12 +9,12 @@
 # to the cf-cli package. As part of the pre-render scripts added here will patch the cf-cli-6-linux
 # job in order to add a BOSH pre-start script. This script will then copy the cf-cli package into a
 # shared volume that can be accessed by the smoke-tests job.
-{{- $root := . -}}
+{{- $root := . }}
 {{- range $path, $bytes := .Files.Glob "assets/operations/pre_render_scripts/smoke-tests_*" }}
 {{ $root.Files.Get $path }}
 {{- end }}
 
-{{- else -}}
+{{- else }}
 
 - type: remove
   path: /instance_groups/name=smoke-tests

--- a/deploy/helm/kubecf/assets/operations/instance_groups/sync-integration-tests.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/sync-integration-tests.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.testing.sync_integration_tests.enabled -}}
+{{- if .Values.testing.sync_integration_tests.enabled }}
 
 - path: /instance_groups/-
   type: replace

--- a/deploy/helm/kubecf/assets/operations/instance_groups/tcp-router.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/tcp-router.yaml
@@ -1,4 +1,4 @@
-{{- $service := index .Values.services "tcp-router" -}}
+{{- $service := index .Values.services "tcp-router" }}
 
 - type: replace
   path: /instance_groups/name=routing-api/jobs/name=routing-api/properties/routing_api/router_groups/name=default-tcp/reservable_ports

--- a/deploy/helm/kubecf/assets/operations/instance_groups/uaa.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/uaa.yaml
@@ -32,7 +32,7 @@
   value: [/bin/sh, -c, ss -nlu src localhost:8125 | grep :8125]
 
 
-{{- $root := . -}}
+{{- $root := . }}
 {{- range $path, $bytes := .Files.Glob "assets/operations/pre_render_scripts/uaa_*" }}
 {{ $root.Files.Get $path }}
 {{- end }}

--- a/deploy/helm/kubecf/templates/_helpers.tpl
+++ b/deploy/helm/kubecf/templates/_helpers.tpl
@@ -2,41 +2,41 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "kubecf.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- define "kubecf.name" }}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
 
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "kubecf.fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
+{{- define "kubecf.fullname" }}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
 
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "kubecf.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- define "kubecf.chart" }}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
 
 {{/*
 Get the metadata name for an ops file.
 */}}
-{{- define "kubecf.ops-name" -}}
-{{- printf "%s-ops-%s" .ReleaseName (base .Path | trimSuffix (ext .Path) | lower | replace "_" "-") -}}
-{{- end -}}
+{{- define "kubecf.ops-name" }}
+{{- printf "%s-ops-%s" .ReleaseName (base .Path | trimSuffix (ext .Path) | lower | replace "_" "-") }}
+{{- end }}
 
 {{- /*
   Template "kubecf.dig" takes a dict and a list; it indexes the dict with each
@@ -60,7 +60,7 @@ Get the metadata name for an ops file.
 Flatten the `toFlatten` map into `flattened`. The `flattened` map contains only one layer of keys
 flattened and separated by `separator`.
 */}}
-{{- define "kubecf.flatten" -}}
+{{- define "kubecf.flatten" }}
   {{- $flattened := index . "flattened" }}
   {{- $toFlatten := index . "toFlatten" }}
   {{- $separator := hasKey . "separator" | ternary (index . "separator") "/" }}
@@ -76,13 +76,13 @@ flattened and separated by `separator`.
     {{- $value := $toFlatten }}
     {{- $_ := set $flattened $key $value }}
   {{- end }}
-{{- end -}}
+{{- end }}
 
 {{/*
 Returns a JSON map with the stemcell information based on the defaults
 and possible overrides for the respective release.
 */}}
-{{- define "kubecf.stemcellLookup" -}}
+{{- define "kubecf.stemcellLookup" }}
   {{- $releasesMap := index . 0 }}
   {{- $releaseName := index . 1 }}
   {{- $result := dict  "os" (index $releasesMap "defaults" "stemcell" "os")  "version" (index $releasesMap "defaults" "stemcell" "version") }}
@@ -100,7 +100,7 @@ and possible overrides for the respective release.
   {{- end }}
 
   {{- toJson $result }}
-{{- end -}}
+{{- end }}
 
 {{/*
 Returns the release URL to use; if there is an override, use that, otherwise
@@ -111,8 +111,8 @@ Usage:
     type: replace
     value: {{ include "kubecf.releaseURLLookup" (list .Values.releases "foo") }}
 */}}
-{{- define "kubecf.releaseURLLookup" -}}
-  {{- $releasesMap := index . 0 -}}
+{{- define "kubecf.releaseURLLookup" }}
+  {{- $releasesMap := index . 0 }}
   {{- $releaseName := index . 1 }}
   {{- (default (index $releasesMap "defaults" "url") (index (default (dict) (index $releasesMap $releaseName)) "url")) }}
-{{- end -}}
+{{- end }}

--- a/deploy/helm/kubecf/templates/bosh_deployment.yaml
+++ b/deploy/helm/kubecf/templates/bosh_deployment.yaml
@@ -1,4 +1,4 @@
-{{- $root := . -}}
+{{- $root := . }}
 ---
 apiVersion: quarks.cloudfoundry.org/v1alpha1
 kind: BOSHDeployment

--- a/deploy/helm/kubecf/templates/brain-tests.yaml
+++ b/deploy/helm/kubecf/templates/brain-tests.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.testing.brain_tests.enabled -}}
+{{- if .Values.testing.brain_tests.enabled }}
 
 # Service account, roles, and cluster role for the brain tests.
 # Raw kube objects going into the chart.

--- a/deploy/helm/kubecf/templates/database.yaml
+++ b/deploy/helm/kubecf/templates/database.yaml
@@ -1,13 +1,13 @@
-{{- if .Values.features.embedded_database.enabled -}}
+{{- if .Values.features.embedded_database.enabled }}
 
-{{- $pxc_ca := printf "%s.var-pxc-ca" .Release.Name -}}
-{{- $pxc_tls := printf "%s.var-pxc-tls" .Release.Name -}}
-{{- $pxc_root_password := printf "%s.var-pxc-root-password" .Release.Name -}}
-{{- $pxc_password := printf "%s.var-pxc-password" .Release.Name -}}
-{{- $xtrabackup_password := printf "%s.var-xtrabackup-password" .Release.Name -}}
-{{- $repl_service := printf "%s-database-repl" .Release.Name -}}
-{{- $pxc_config_files := printf "%s-database-config-files" .Release.Name -}}
-{{- $pxc_startup_scripts := printf "%s-database-startup-scripts" .Release.Name -}}
+{{- $pxc_ca := printf "%s.var-pxc-ca" .Release.Name }}
+{{- $pxc_tls := printf "%s.var-pxc-tls" .Release.Name }}
+{{- $pxc_root_password := printf "%s.var-pxc-root-password" .Release.Name }}
+{{- $pxc_password := printf "%s.var-pxc-password" .Release.Name }}
+{{- $xtrabackup_password := printf "%s.var-xtrabackup-password" .Release.Name }}
+{{- $repl_service := printf "%s-database-repl" .Release.Name }}
+{{- $pxc_config_files := printf "%s-database-config-files" .Release.Name }}
+{{- $pxc_startup_scripts := printf "%s-database-startup-scripts" .Release.Name }}
 
 ---
 apiVersion: quarks.cloudfoundry.org/v1alpha1
@@ -390,4 +390,4 @@ spec:
           {{- end }}
           restartPolicy: Never
 
-{{- end -}}
+{{- end }}

--- a/deploy/helm/kubecf/templates/eirini.yaml
+++ b/deploy/helm/kubecf/templates/eirini.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.features.eirini.enabled -}}
+{{- if .Values.features.eirini.enabled }}
 
 # eirini-webhook cluster role for eirini service account.
 # Used to implement eirinix extensions.

--- a/deploy/helm/kubecf/templates/ingress.yaml
+++ b/deploy/helm/kubecf/templates/ingress.yaml
@@ -1,6 +1,6 @@
-{{- $root := . -}}
-{{- if .Values.features.ingress.enabled -}}
-{{- if and .Values.features.ingress.tls.crt .Values.features.ingress.tls.key -}}
+{{- $root := . }}
+{{- if .Values.features.ingress.enabled }}
+{{- if and .Values.features.ingress.tls.crt .Values.features.ingress.tls.key }}
 ---
 # The certificate and key for the TLS secret are passed through ingress.tls.crt and ingress.tls.key
 # respectively. If the operator does not provide these values at installation time, the TLS secret
@@ -38,19 +38,19 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   annotations:
     # Inject some annotations if they don't exist in the annotations provided during deployment.
-    {{- if not (hasKey .Values.features.ingress.annotations "kubernetes.io/ingress.class") -}}
+    {{- if not (hasKey .Values.features.ingress.annotations "kubernetes.io/ingress.class") }}
       {{ $_ := set .Values.features.ingress.annotations "kubernetes.io/ingress.class" "nginx" }}
     {{- end }}
-    {{- if not (hasKey .Values.features.ingress.annotations "nginx.ingress.kubernetes.io/secure-backends") -}}
+    {{- if not (hasKey .Values.features.ingress.annotations "nginx.ingress.kubernetes.io/secure-backends") }}
       {{ $_ := set .Values.features.ingress.annotations "nginx.ingress.kubernetes.io/secure-backends" "true" }}
     {{- end }}
-    {{- if not (hasKey .Values.features.ingress.annotations "nginx.ingress.kubernetes.io/backend-protocol") -}}
+    {{- if not (hasKey .Values.features.ingress.annotations "nginx.ingress.kubernetes.io/backend-protocol") }}
       {{ $_ := set .Values.features.ingress.annotations "nginx.ingress.kubernetes.io/backend-protocol" "HTTPS" }}
     {{- end }}
-    {{- if not (hasKey .Values.features.ingress.annotations "nginx.ingress.kubernetes.io/ssl-redirect") -}}
+    {{- if not (hasKey .Values.features.ingress.annotations "nginx.ingress.kubernetes.io/ssl-redirect") }}
       {{ $_ := set .Values.features.ingress.annotations "nginx.ingress.kubernetes.io/ssl-redirect" "false" }}
     {{- end }}
-    {{- if not (hasKey .Values.features.ingress.annotations "nginx.ingress.kubernetes.io/proxy-body-size") -}}
+    {{- if not (hasKey .Values.features.ingress.annotations "nginx.ingress.kubernetes.io/proxy-body-size") }}
       {{ $_ := set .Values.features.ingress.annotations "nginx.ingress.kubernetes.io/proxy-body-size" "8m" }}
     {{- end }}
     {{ $_ := set .Values.features.ingress.annotations "nginx.org/websocket-services" (printf "%s-router" .Release.Name) }}
@@ -58,22 +58,22 @@ metadata:
   labels:
     {{ if not (hasKey .Values.features.ingress.labels "app.kubernetes.io/component") }}
     app.kubernetes.io/component: "ingress"
-    {{- end -}}
+    {{- end }}
     {{ if not (hasKey .Values.features.ingress.labels "app.kubernetes.io/instance") }}
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
-    {{- end -}}
+    {{- end }}
     {{ if not (hasKey .Values.features.ingress.labels "app.kubernetes.io/managed-by") }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    {{- end -}}
+    {{- end }}
     {{ if not (hasKey .Values.features.ingress.labels "app.kubernetes.io/name") }}
     app.kubernetes.io/name: {{ default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" | quote }}
-    {{- end -}}
+    {{- end }}
     {{ if not (hasKey .Values.features.ingress.labels "app.kubernetes.io/version") }}
     app.kubernetes.io/version: {{ default .Chart.Version .Chart.AppVersion | quote }}
-    {{- end -}}
+    {{- end }}
     {{ if not (hasKey .Values.features.ingress.labels "helm.sh/chart") }}
     helm.sh/chart: {{ printf "%s-%s" .Chart.Name (.Chart.Version | replace "+" "_") | quote }}
-    {{- end -}}
+    {{- end }}
 {{ if .Values.features.ingress.labels }}
 {{ toYaml .Values.features.ingress.labels | indent 4 }}
 {{ end }}

--- a/deploy/helm/kubecf/templates/ops-use-bits-service.yaml
+++ b/deploy/helm/kubecf/templates/ops-use-bits-service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.features.eirini.enabled -}}
+{{- if .Values.features.eirini.enabled }}
 
 apiVersion: v1
 kind: ConfigMap

--- a/deploy/helm/kubecf/templates/ops.yaml
+++ b/deploy/helm/kubecf/templates/ops.yaml
@@ -1,5 +1,5 @@
 # This template creates a ConfigMap for each ops file under assets/operations.
-{{- define "kubecf.ops" -}}
+{{- define "kubecf.ops" }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -15,10 +15,10 @@ metadata:
     helm.sh/chart: {{ include "kubecf.chart" .Root }}
 data:
   ops: |-
-    {{- tpl (.Root.Files.Get .Path) .Root | nindent 4 -}}
-{{- end -}}
+    {{- tpl (.Root.Files.Get .Path) .Root | nindent 4 }}
+{{- end }}
 
-{{- $root := . -}}
+{{- $root := . }}
 
 {{ include "kubecf.ops" (dict "Root" $root "Path" "assets/operations/unordered/move_auctioneer.yaml") }}
 {{ include "kubecf.ops" (dict "Root" $root "Path" "assets/operations/unordered/move_routing_api.yaml") }}

--- a/deploy/helm/kubecf/templates/sizing.yaml
+++ b/deploy/helm/kubecf/templates/sizing.yaml
@@ -82,7 +82,7 @@ data:
       value: 1
 {{- end }}
 
-{{- if .Values.features.credhub.enabled -}}
+{{- if .Values.features.credhub.enabled }}
 {{- if .Values.sizing.credhub.instances }}
     - type: replace
       path: /instance_groups/name=credhub/instances
@@ -135,7 +135,7 @@ data:
       value: 1
 {{- end }}
 
-{{- if not .Values.features.eirini.enabled -}}
+{{- if not .Values.features.eirini.enabled }}
 {{- if .Values.sizing.diego_cell.instances }}
     - type: replace
       path: /instance_groups/name=diego-cell/instances

--- a/deploy/helm/kubecf/templates/sync-integration-tests.yaml
+++ b/deploy/helm/kubecf/templates/sync-integration-tests.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.testing.sync_integration_tests.enabled -}}
+{{- if .Values.testing.sync_integration_tests.enabled }}
 
 # Service account, roles, and cluster role for the sync integration tests.
 # Raw kube objects going into the chart.

--- a/dev/linters/helmlint.sh
+++ b/dev/linters/helmlint.sh
@@ -2,4 +2,9 @@
 
 set -o errexit -o nounset
 
+if grep --exclude="helmlint.sh" -r "{{-.*-}}" .; then
+    echo "Found double minus templates {{- ... -}}"
+    exit 1
+fi
+
 exec bazel test //dev/linters:helm


### PR DESCRIPTION
## Description
Using both `{{-` and `-}}` causes line breaks on both ends to be removed, sometimes resulting in unintended consequences.

e.g. 
[This code](https://github.com/cloudfoundry-incubator/kubecf/blob/63d9b24462f7e6a74ffe73ef625d46849e5761f4/deploy/helm/kubecf/assets/operations/instance_groups/scheduler.yaml#L57-L60) results in the following render:

```
- type: replace
  path: /instance_groups/name=scheduler/jobs/name=ssh_proxy/properties/quarks?
  value:
    ports:
    - name: ssh-proxy
      protocol: TCP
      internal: 2222
    run:
      healthcheck:
        ssh_proxy:
          readiness:
            httpGet:
              port: 2223

# Add necessary labels to the scheduler instance group so that the service can select it to create
# the endpoint.- type: replace
  path: /instance_groups/name=scheduler/env?/bosh/agent/settings/labels/app.kubernetes.io~1component
  value: "ssh-proxy"
```

The array dash is no more, and the path and value keys override the ones from the previous element.

## Motivation and Context
Fixes #414.
Fixes #437.

## How Has This Been Tested?
The change contains a script that lints for this, so it doesn't happen again.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
