### PR TITLE
Adding SITs to kubecf concourse CI pipeline

### DIFF
--- a/.concourse/pipeline.yaml
+++ b/.concourse/pipeline.yaml
@@ -50,6 +50,7 @@ resources:
 - name: catapult
   type: git
   source:
+    branch: bisingh/sits
     uri: https://github.com/SUSE/catapult
   version:
     ref: 7eea74f5cab3386b65c08938b25811e99bb829ef
@@ -72,23 +73,23 @@ resources:
     region_name: eu-central-1
     regexp: kubecf-bundle-v(.*).tgz
 
-- name: s3.kubecf
-  type: s3
-  source:
-    bucket: kubecf
-    access_key_id: ((aws-access-key))
-    secret_access_key: ((aws-secret-key))
-    region_name: us-west-2
-    regexp: kubecf-v(.*).tgz
+# - name: s3.kubecf
+#   type: s3
+#   source:
+#     bucket: kubecf
+#     access_key_id: ((aws-access-key))
+#     secret_access_key: ((aws-secret-key))
+#     region_name: us-west-2
+#     regexp: kubecf-v(.*).tgz
 
-- name: s3.kubecf-bundle
-  type: s3
-  source:
-    bucket: kubecf
-    access_key_id: ((aws-access-key))
-    secret_access_key: ((aws-secret-key))
-    region_name: us-west-2
-    regexp: kubecf-bundle-v(.*).tgz
+# - name: s3.kubecf-bundle
+#   type: s3
+#   source:
+#     bucket: kubecf
+#     access_key_id: ((aws-access-key))
+#     secret_access_key: ((aws-secret-key))
+#     region_name: us-west-2
+#     regexp: kubecf-bundle-v(.*).tgz
 
 deploy_args: &deploy_args
 - -xce
@@ -627,7 +628,7 @@ jobs:
           CLUSTER_NAME_PREFIX: "kubecf-diego"
           EKCP_HOST: ((ekcp-host))
 
-- name: cf-acceptance-tests-diego
+- name: sync-integration-tests-diego
   public: true
   plan:
   - get: commit-to-test
@@ -641,6 +642,74 @@ jobs:
   - get: s3.kubecf-ci-bundle
     passed:
     - smoke-tests-diego
+  - get: catapult
+  - task: test-diego
+    privileged: true
+    timeout: 1h30m
+    config:
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: splatform/catapult
+      inputs:
+      - name: catapult
+      - name: commit-to-test
+      outputs:
+      - name: output
+      params:
+        DEFAULT_STACK: cflinuxfs3
+        EKCP_HOST: ((ekcp-host))
+        TEST_SUITE: sits
+        CLUSTER_NAME_PREFIX: kubecf-diego
+      run:
+        path: "/bin/bash"
+        args: *test_args
+    on_success:
+      put: commit-to-test
+      params:
+        description: "Sync Integration tests on Diego succeeded"
+        state: "success"
+        contexts: "sync-integration-tests-diego"
+        commit_path: "commit-to-test/.git/resource/ref"
+        version_path: "commit-to-test/.git/resource/version"
+    on_failure:
+      do:
+      - put: commit-to-test
+        params:
+          description: "Sync Integration tests on Diego failed"
+          state: "failure"
+          commit_path: "commit-to-test/.git/resource/ref"
+          version_path: "commit-to-test/.git/resource/version"
+          contexts: "sync-integration-tests-diego"
+      - task: cleanup-cluster
+        config:
+          <<: *cleanup-cluster
+          params:
+            CLUSTER_NAME_PREFIX: "kubecf-diego"
+            EKCP_HOST: ((ekcp-host))
+    on_abort:
+      task: cleanup-cluster
+      config:
+        <<: *cleanup-cluster
+        params:
+          CLUSTER_NAME_PREFIX: "kubecf-diego"
+          EKCP_HOST: ((ekcp-host))
+
+- name: cf-acceptance-tests-diego
+  max_in_flight: 2
+  public: true
+  plan:
+  - get: commit-to-test
+    passed:
+    - sync-integration-tests-diego
+    trigger: true
+  - get: s3.kubecf-ci
+    passed:
+    - sync-integration-tests-diego
+  - get: s3.kubecf-ci-bundle
+    passed:
+    - sync-integration-tests-diego
   - get: catapult
   - task: test-diego
     privileged: true
@@ -984,7 +1053,7 @@ jobs:
           CLUSTER_NAME_PREFIX: "kubecf-eirini"
           EKCP_HOST: ((ekcp-host))
 
-- name: cf-acceptance-tests-eirini
+- name: sync-integration-tests-eirini
   public: true
   plan:
   - get: commit-to-test
@@ -998,6 +1067,74 @@ jobs:
   - get: s3.kubecf-ci-bundle
     passed:
     - smoke-tests-eirini
+  - get: catapult
+  - task: test
+    timeout: 1h30m
+    privileged: true
+    config:
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: splatform/catapult
+      inputs:
+      - name: catapult
+      - name: commit-to-test
+      outputs:
+      - name: mail-output
+      params:
+        DEFAULT_STACK: cflinuxfs3
+        EKCP_HOST: ((ekcp-host))
+        TEST_SUITE: sits
+        CLUSTER_NAME_PREFIX: kubecf-eirini
+      run:
+        path: "/bin/bash"
+        args: *test_args
+    on_success:
+      put: commit-to-test
+      params:
+        description: "Sync Integration tests on Eirini succeeded"
+        state: "success"
+        contexts: "sync-integration-tests-eirini"
+        commit_path: "commit-to-test/.git/resource/ref"
+        version_path: "commit-to-test/.git/resource/version"
+    on_failure:
+      do:
+      - put: commit-to-test
+        params:
+          description: "Sync Integration tests on Eirini failed"
+          state: "failure"
+          commit_path: "commit-to-test/.git/resource/ref"
+          version_path: "commit-to-test/.git/resource/version"
+          contexts: "sync-integration-tests-eirini"
+      - task: cleanup-cluster
+        config:
+          <<: *cleanup-cluster
+          params:
+            CLUSTER_NAME_PREFIX: "kubecf-eirini"
+            EKCP_HOST: ((ekcp-host))
+    on_abort:
+      task: cleanup-cluster
+      config:
+        <<: *cleanup-cluster
+        params:
+          CLUSTER_NAME_PREFIX: "kubecf-eirini"
+          EKCP_HOST: ((ekcp-host))
+
+- name: cf-acceptance-tests-eirini
+  public: true
+  plan:
+  - get: commit-to-test
+    passed:
+    - sync-integration-tests-eirini
+    # trigger: true
+    version: "every"
+  - get: s3.kubecf-ci
+    passed:
+    - sync-integration-tests-eirini
+  - get: s3.kubecf-ci-bundle
+    passed:
+    - sync-integration-tests-eirini
   - get: catapult
   - task: test
     timeout: 5h30m
@@ -1053,6 +1190,7 @@ jobs:
           EKCP_HOST: ((ekcp-host))
 
 - name: cleanup-eirini-cluster
+  max_in_flight: 2
   public: true
   plan:
   - get: commit-to-test
@@ -1060,7 +1198,6 @@ jobs:
     # - smoke-tests-post-rotate-eirini
     - smoke-tests-eirini
     trigger: true
-    version: "every"
   - task: cleanup-cluster
     config:
       <<: *cleanup-cluster
@@ -1068,49 +1205,48 @@ jobs:
         CLUSTER_NAME_PREFIX: "kubecf-eirini"
         EKCP_HOST: ((ekcp-host))
 
-- name: publish
-  public: true
-  plan:
-  - get: commit-to-test
-    version: "every"
-    passed:
-    - cf-acceptance-tests-diego
-    # TODO: Uncomment as soon as eirini tests are green
-    # TODO: Does this work? It might check the wrong thing
-    # - cf-acceptance-tests-eirini
-    trigger: true
-  - get: s3.kubecf-ci
-    passed:
-    - cf-acceptance-tests-diego
-  - get: s3.kubecf-ci-bundle
-    passed:
-    - cf-acceptance-tests-diego
-  - task: check-if-build-is-master
-    config:
-      platform: linux
-      image_resource:
-        type: registry-image
-        source:
-          repository: splatform/catapult
-      inputs:
-      - name: commit-to-test
-      run:
-        path: "/bin/bash"
-        args:
-        - -xce
-        - |
-          if [ "$(cat commit-to-test/*-*.json | jq -r .trigger)" == "master" ]; then
-            echo "It was a master branch build, we will publish the artifact."
-            exit 0
-          else
-            echo "It was not a master build, we will not publish the artifact."
-            exit 1
-          fi
-    on_success:
-      do:
-      - put: s3.kubecf
-        params:
-          file: s3.kubecf-ci/kubecf-v*.tgz
-      - put: s3.kubecf-bundle
-        params:
-          file: s3.kubecf-ci-bundle/kubecf-bundle-v*.tgz
+# - name: publish
+#   public: true
+#   plan:
+#   - get: commit-to-test
+#     passed:
+#     - cf-acceptance-tests-diego
+#     # TODO: Uncomment as soon as eirini tests are green
+#     # TODO: Does this work? It might check the wrong thing
+#     # - cf-acceptance-tests-eirini
+#     trigger: true
+#   - get: s3.kubecf-ci
+#     passed:
+#     - cf-acceptance-tests-diego
+#   - get: s3.kubecf-ci-bundle
+#     passed:
+#     - cf-acceptance-tests-diego
+#   - task: check-if-build-is-master
+#     config:
+#       platform: linux
+#       image_resource:
+#         type: registry-image
+#         source:
+#           repository: splatform/catapult
+#       inputs:
+#       - name: commit-to-test
+#       run:
+#         path: "/bin/bash"
+#         args:
+#         - -xce
+#         - |
+#           if [ "$(cat commit-to-test/*-*.json | jq -r .trigger)" == "master" ]; then
+#             echo "It was a master branch build, we will publish the artifact."
+#             exit 0
+#           else
+#             echo "It was not a master build, we will not publish the artifact."
+#             exit 1
+#           fi
+#     on_success:
+#       do:
+#       - put: s3.kubecf
+#         params:
+#           file: s3.kubecf-ci/kubecf-v*.tgz
+#       - put: s3.kubecf-bundle
+#         params:
+#           file: s3.kubecf-ci-bundle/kubecf-bundle-v*.tgz

--- a/.concourse/pipeline.yaml
+++ b/.concourse/pipeline.yaml
@@ -50,7 +50,6 @@ resources:
 - name: catapult
   type: git
   source:
-    branch: bisingh/sits
     uri: https://github.com/SUSE/catapult
   version:
     ref: 7eea74f5cab3386b65c08938b25811e99bb829ef
@@ -73,23 +72,23 @@ resources:
     region_name: eu-central-1
     regexp: kubecf-bundle-v(.*).tgz
 
-# - name: s3.kubecf
-#   type: s3
-#   source:
-#     bucket: kubecf
-#     access_key_id: ((aws-access-key))
-#     secret_access_key: ((aws-secret-key))
-#     region_name: us-west-2
-#     regexp: kubecf-v(.*).tgz
+- name: s3.kubecf
+  type: s3
+  source:
+    bucket: kubecf
+    access_key_id: ((aws-access-key))
+    secret_access_key: ((aws-secret-key))
+    region_name: us-west-2
+    regexp: kubecf-v(.*).tgz
 
-# - name: s3.kubecf-bundle
-#   type: s3
-#   source:
-#     bucket: kubecf
-#     access_key_id: ((aws-access-key))
-#     secret_access_key: ((aws-secret-key))
-#     region_name: us-west-2
-#     regexp: kubecf-bundle-v(.*).tgz
+- name: s3.kubecf-bundle
+  type: s3
+  source:
+    bucket: kubecf
+    access_key_id: ((aws-access-key))
+    secret_access_key: ((aws-secret-key))
+    region_name: us-west-2
+    regexp: kubecf-bundle-v(.*).tgz
 
 deploy_args: &deploy_args
 - -xce
@@ -1053,88 +1052,20 @@ jobs:
           CLUSTER_NAME_PREFIX: "kubecf-eirini"
           EKCP_HOST: ((ekcp-host))
 
-- name: sync-integration-tests-eirini
-  public: true
-  plan:
-  - get: commit-to-test
-    passed:
-    - smoke-tests-eirini
-    # trigger: true
-    version: "every"
-  - get: s3.kubecf-ci
-    passed:
-    - smoke-tests-eirini
-  - get: s3.kubecf-ci-bundle
-    passed:
-    - smoke-tests-eirini
-  - get: catapult
-  - task: test
-    timeout: 1h30m
-    privileged: true
-    config:
-      platform: linux
-      image_resource:
-        type: registry-image
-        source:
-          repository: splatform/catapult
-      inputs:
-      - name: catapult
-      - name: commit-to-test
-      outputs:
-      - name: mail-output
-      params:
-        DEFAULT_STACK: cflinuxfs3
-        EKCP_HOST: ((ekcp-host))
-        TEST_SUITE: sits
-        CLUSTER_NAME_PREFIX: kubecf-eirini
-      run:
-        path: "/bin/bash"
-        args: *test_args
-    on_success:
-      put: commit-to-test
-      params:
-        description: "Sync Integration tests on Eirini succeeded"
-        state: "success"
-        contexts: "sync-integration-tests-eirini"
-        commit_path: "commit-to-test/.git/resource/ref"
-        version_path: "commit-to-test/.git/resource/version"
-    on_failure:
-      do:
-      - put: commit-to-test
-        params:
-          description: "Sync Integration tests on Eirini failed"
-          state: "failure"
-          commit_path: "commit-to-test/.git/resource/ref"
-          version_path: "commit-to-test/.git/resource/version"
-          contexts: "sync-integration-tests-eirini"
-      - task: cleanup-cluster
-        config:
-          <<: *cleanup-cluster
-          params:
-            CLUSTER_NAME_PREFIX: "kubecf-eirini"
-            EKCP_HOST: ((ekcp-host))
-    on_abort:
-      task: cleanup-cluster
-      config:
-        <<: *cleanup-cluster
-        params:
-          CLUSTER_NAME_PREFIX: "kubecf-eirini"
-          EKCP_HOST: ((ekcp-host))
-
 - name: cf-acceptance-tests-eirini
   public: true
   plan:
   - get: commit-to-test
     passed:
-    - sync-integration-tests-eirini
+    - smoke-tests-eirini
     # trigger: true
     version: "every"
   - get: s3.kubecf-ci
     passed:
-    - sync-integration-tests-eirini
+    - smoke-tests-eirini
   - get: s3.kubecf-ci-bundle
     passed:
-    - sync-integration-tests-eirini
+    - smoke-tests-eirini
   - get: catapult
   - task: test
     timeout: 5h30m
@@ -1190,7 +1121,6 @@ jobs:
           EKCP_HOST: ((ekcp-host))
 
 - name: cleanup-eirini-cluster
-  max_in_flight: 2
   public: true
   plan:
   - get: commit-to-test
@@ -1198,6 +1128,7 @@ jobs:
     # - smoke-tests-post-rotate-eirini
     - smoke-tests-eirini
     trigger: true
+    version: "every"
   - task: cleanup-cluster
     config:
       <<: *cleanup-cluster
@@ -1205,48 +1136,48 @@ jobs:
         CLUSTER_NAME_PREFIX: "kubecf-eirini"
         EKCP_HOST: ((ekcp-host))
 
-# - name: publish
-#   public: true
-#   plan:
-#   - get: commit-to-test
-#     passed:
-#     - cf-acceptance-tests-diego
-#     # TODO: Uncomment as soon as eirini tests are green
-#     # TODO: Does this work? It might check the wrong thing
-#     # - cf-acceptance-tests-eirini
-#     trigger: true
-#   - get: s3.kubecf-ci
-#     passed:
-#     - cf-acceptance-tests-diego
-#   - get: s3.kubecf-ci-bundle
-#     passed:
-#     - cf-acceptance-tests-diego
-#   - task: check-if-build-is-master
-#     config:
-#       platform: linux
-#       image_resource:
-#         type: registry-image
-#         source:
-#           repository: splatform/catapult
-#       inputs:
-#       - name: commit-to-test
-#       run:
-#         path: "/bin/bash"
-#         args:
-#         - -xce
-#         - |
-#           if [ "$(cat commit-to-test/*-*.json | jq -r .trigger)" == "master" ]; then
-#             echo "It was a master branch build, we will publish the artifact."
-#             exit 0
-#           else
-#             echo "It was not a master build, we will not publish the artifact."
-#             exit 1
-#           fi
-#     on_success:
-#       do:
-#       - put: s3.kubecf
-#         params:
-#           file: s3.kubecf-ci/kubecf-v*.tgz
-#       - put: s3.kubecf-bundle
-#         params:
-#           file: s3.kubecf-ci-bundle/kubecf-bundle-v*.tgz
+- name: publish
+  public: true
+  plan:
+  - get: commit-to-test
+    passed:
+    - cf-acceptance-tests-diego
+    # TODO: Uncomment as soon as eirini tests are green
+    # TODO: Does this work? It might check the wrong thing
+    # - cf-acceptance-tests-eirini
+    trigger: true
+  - get: s3.kubecf-ci
+    passed:
+    - cf-acceptance-tests-diego
+  - get: s3.kubecf-ci-bundle
+    passed:
+    - cf-acceptance-tests-diego
+  - task: check-if-build-is-master
+    config:
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: splatform/catapult
+      inputs:
+      - name: commit-to-test
+      run:
+        path: "/bin/bash"
+        args:
+        - -xce
+        - |
+          if [ "$(cat commit-to-test/*-*.json | jq -r .trigger)" == "master" ]; then
+            echo "It was a master branch build, we will publish the artifact."
+            exit 0
+          else
+            echo "It was not a master build, we will not publish the artifact."
+            exit 1
+          fi
+    on_success:
+      do:
+      - put: s3.kubecf
+        params:
+          file: s3.kubecf-ci/kubecf-v*.tgz
+      - put: s3.kubecf-bundle
+        params:
+          file: s3.kubecf-ci-bundle/kubecf-bundle-v*.tgz

--- a/.concourse/pipeline.yaml
+++ b/.concourse/pipeline.yaml
@@ -694,13 +694,13 @@ jobs:
           EKCP_HOST: ((ekcp-host))
 
 - name: cf-acceptance-tests-diego
-  max_in_flight: 2
   public: true
   plan:
   - get: commit-to-test
     passed:
     - sync-integration-tests-diego
     trigger: true
+    version: "every"
   - get: s3.kubecf-ci
     passed:
     - sync-integration-tests-diego
@@ -1144,6 +1144,7 @@ jobs:
     # TODO: Does this work? It might check the wrong thing
     # - cf-acceptance-tests-eirini
     trigger: true
+    version: "every"
   - get: s3.kubecf-ci
     passed:
     - cf-acceptance-tests-diego

--- a/.concourse/pipeline.yaml
+++ b/.concourse/pipeline.yaml
@@ -183,7 +183,7 @@ jobs:
       contexts: >
         lint,build,deploy-diego,smoke-diego,rotate-diego,smoke-rotated-diego,
         acceptance-diego,deploy-eirini,smoke-eirini,rotate-eirini,
-        smoke-rotated-eirini,acceptance-eirini
+        smoke-rotated-eirini,acceptance-eirini,sync-integration-tests-diego
       trigger: "PR"
       metadata_path: "kubecf-pr/.git/resource/url"
 - name: queue-fork-pr
@@ -217,15 +217,13 @@ jobs:
           curl -s -L -X GET "https://api.github.com/repos/${REPO}/pulls/$(cat kubecf-fork-pr/.git/resource/pr)" | \
             jq -r .head.repo.full_name > output/remote
   - put: commit-to-test
-    params: &commit-status
+    params:
+      <<: *commit-status
       commit_path: "kubecf-fork-pr/.git/resource/head_sha"
       remote_path: "output/remote"
+      remote: ""
       description: "Queued"
       state: "pending"
-      contexts: >
-        lint,build,deploy-diego,smoke-diego,rotate-diego,smoke-rotated-diego,
-        acceptance-diego,deploy-eirini,smoke-eirini,rotate-eirini,
-        smoke-rotated-eirini,acceptance-eirini
       trigger: "PR"
       metadata_path: "kubecf-fork-pr/.git/resource/url"
 - name: queue-master

--- a/deploy/helm/kubecf/assets/operations/instance_groups/sync-integration-tests.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/sync-integration-tests.yaml
@@ -20,7 +20,7 @@
         sync_integration_tests:
           bbs:
             svc:
-              name: {{ .Release.Namespace }}-diego-api
+              name: {{ .Release.Name }}-diego-api
               namespace: {{ .Release.Namespace }}
               port: 8889
           config:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR intends to add [sync-integration-tests](https://github.com/SUSE/sync-integration-tests-release) to the [kubecf](https://concourse.suse.dev/teams/main/pipelines/kubecf) pipeline.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
SITs form an important part of CF test suite.
fixes: https://github.com/cloudfoundry-incubator/kubecf/issues/423

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- An important detail to include is the version of the used cf-operator -->
- Locally on catapult/kind.
- concourse.suse.dev CI.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
