### PR TITLE
fix: helm: reduce duplication in sizing ops

### DIFF
--- a/deploy/helm/kubecf/assets/operations/releases.yaml
+++ b/deploy/helm/kubecf/assets/operations/releases.yaml
@@ -83,18 +83,17 @@
   {{- end }}
 
 # Loop over the releases, replacing the url and stemcell, and the version when appropriate.
-{{- $root := . }}
 {{- range $release := $releases }}
 - type: replace
   path: /releases/name={{ $release }}/url?
-  value: {{ include "kubecf.releaseURLLookup" (list $root.Values.releases $release) }}
+  value: {{ include "kubecf.releaseURLLookup" (list $.Values.releases $release) }}
 - type: replace
   path: /releases/name={{ $release }}/stemcell?
-  value: {{ include "kubecf.stemcellLookup" (list $root.Values.releases $release) }}
-{{- if (index $root.Values.releases $release).version }}
+  value: {{ include "kubecf.stemcellLookup" (list $.Values.releases $release) }}
+{{- if (index $.Values.releases $release).version }}
 - type: replace
   path: /releases/name={{ $release }}/version?
-  value: {{ (index $root.Values.releases $release).version | quote }}
+  value: {{ (index $.Values.releases $release).version | quote }}
 {{- end }}
 - type: remove
   path: /releases/name={{ $release }}/sha1?

--- a/deploy/helm/kubecf/templates/sizing.yaml
+++ b/deploy/helm/kubecf/templates/sizing.yaml
@@ -13,139 +13,42 @@ metadata:
     helm.sh/chart: {{ include "kubecf.chart" . }}
 data:
   ops: |
-{{- if .Values.sizing.adapter.instances }}
-    - type: replace
-      path: /instance_groups/name=adapter/instances
-      value: {{.Values.sizing.adapter.instances}}
-{{- else if not .Values.high_availability }}
-    - type: replace
-      path: /instance_groups/name=adapter/instances
-      value: 1
-{{- end }}
+    {{- $instance_groups := list }}
 
-{{- if .Values.sizing.api.instances }}
-    - type: replace
-      path: /instance_groups/name=api/instances
-      value: {{.Values.sizing.api.instances}}
-{{- else if not .Values.high_availability }}
-    - type: replace
-      path: /instance_groups/name=api/instances
-      value: 1
-{{- end }}
+    {{- /* Core instance groups that always exist */}}
+    {{- $instance_groups = append $instance_groups "adapter" }}
+    {{- $instance_groups = append $instance_groups "api" }}
+    {{- $instance_groups = append $instance_groups "auctioneer" }}
+    {{- $instance_groups = append $instance_groups "cc-worker" }}
+    {{- $instance_groups = append $instance_groups "diego-api" }}
+    {{- $instance_groups = append $instance_groups "log-api" }}
+    {{- $instance_groups = append $instance_groups "nats" }}
+    {{- $instance_groups = append $instance_groups "router" }}
+    {{- $instance_groups = append $instance_groups "routing-api" }}
+    {{- $instance_groups = append $instance_groups "scheduler" }}
+    {{- $instance_groups = append $instance_groups "uaa" }}
+    {{- $instance_groups = append $instance_groups "tcp-router" }}
 
-{{- if .Values.features.autoscaler.enabled }}
-{{- if .Values.sizing.asapi.instances }}
-    - type: replace
-      path: /instance_groups/name=asapi/instances
-      value: {{.Values.sizing.asapi.instances}}
-{{- else if not .Values.high_availability }}
-    - type: replace
-      path: /instance_groups/name=asapi/instances
-      value: 1
-{{- end }}
-{{- if .Values.sizing.asactors.instances }}
-    - type: replace
-      path: /instance_groups/name=asactors/instances
-      value: {{.Values.sizing.asactors.instances}}
-{{- else if not .Values.high_availability }}
-    - type: replace
-      path: /instance_groups/name=asactors/instances
-      value: 1
-{{- end }}
-{{- if .Values.sizing.asmetrics.instances }}
-    - type: replace
-      path: /instance_groups/name=asmetrics/instances
-      value: {{.Values.sizing.asmetrics.instances}}
-{{- else if not .Values.high_availability }}
-    - type: replace
-      path: /instance_groups/name=asmetrics/instances
-      value: 1
-{{- end }}
-{{- if .Values.sizing.asnozzle.instances }}
-    - type: replace
-      path: /instance_groups/name=asnozzle/instances
-      value: {{.Values.sizing.asnozzle.instances}}
-{{- else if not .Values.high_availability }}
-    - type: replace
-      path: /instance_groups/name=asnozzle/instances
-      value: 1
-{{- end }}
-{{- end }}
+    {{- /* Autoscaler-only instance groups */}}
+    {{- if .Values.features.autoscaler.enabled }}
+    {{- $instance_groups = append $instance_groups "asapi" }}
+    {{- $instance_groups = append $instance_groups "asactors" }}
+    {{- $instance_groups = append $instance_groups "asmetrics" }}
+    {{- $instance_groups = append $instance_groups "asnozzle" }}
+    {{- end }}{{/* if autoscaler */}}
 
-{{- if .Values.sizing.auctioneer.instances }}
-    - type: replace
-      path: /instance_groups/name=auctioneer/instances
-      value: {{.Values.sizing.auctioneer.instances}}
-{{- else if not .Values.high_availability }}
-    - type: replace
-      path: /instance_groups/name=auctioneer/instances
-      value: 1
-{{- end }}
+    {{- /* CredHub */}}
+    {{- if .Values.features.credhub.enabled }}
+    {{- $instance_groups = append $instance_groups "credhub" }}
+    {{- end }}{{/* if credhub */}}
 
-{{- if .Values.features.credhub.enabled }}
-{{- if .Values.sizing.credhub.instances }}
-    - type: replace
-      path: /instance_groups/name=credhub/instances
-      value: {{.Values.sizing.credhub.instances}}
-{{- else if not .Values.high_availability }}
-    - type: replace
-      path: /instance_groups/name=credhub/instances
-      value: 1
-{{- end }}
-{{- end }}
-
-{{- if .Values.features.eirini.enabled }}
-{{- if .Values.sizing.bits.instances }}
-    - type: replace
-      path: /instance_groups/name=bits/instances
-      value: {{.Values.sizing.bits.instances}}
-{{- else if not .Values.high_availability }}
-    - type: replace
-      path: /instance_groups/name=bits/instances
-      value: 1
-{{- end }}
-{{- if .Values.sizing.eirini.instances }}
-    - type: replace
-      path: /instance_groups/name=eirini/instances
-      value: {{.Values.sizing.eirini.instances}}
-{{- else if not .Values.high_availability }}
-    - type: replace
-      path: /instance_groups/name=eirini/instances
-      value: 1
-{{- end }}
-{{- end }}
-
-{{- if .Values.sizing.cc_worker.instances }}
-    - type: replace
-      path: /instance_groups/name=cc-worker/instances
-      value: {{.Values.sizing.cc_worker.instances}}
-{{- else if not .Values.high_availability }}
-    - type: replace
-      path: /instance_groups/name=cc-worker/instances
-      value: 1
-{{- end }}
-
-{{- if .Values.sizing.diego_api.instances }}
-    - type: replace
-      path: /instance_groups/name=diego-api/instances
-      value: {{.Values.sizing.diego_api.instances}}
-{{- else if not .Values.high_availability }}
-    - type: replace
-      path: /instance_groups/name=diego-api/instances
-      value: 1
-{{- end }}
-
-{{- if not .Values.features.eirini.enabled }}
-{{- if .Values.sizing.diego_cell.instances }}
-    - type: replace
-      path: /instance_groups/name=diego-cell/instances
-      value: {{.Values.sizing.diego_cell.instances}}
-{{- else if not .Values.high_availability }}
-    - type: replace
-      path: /instance_groups/name=diego-cell/instances
-      value: 1
-{{- end }}
-{{- end }}
+    {{- /* Instances groups where existance depends on whether Eirini is enabled */}}
+    {{- if .Values.features.eirini.enabled }}
+    {{- $instance_groups = append $instance_groups "bits" }}
+    {{- $instance_groups = append $instance_groups "eirini" }}
+    {{- else }}
+    {{- $instance_groups = append $instance_groups "diego-cell" }}
+    {{- end }}{{/* if eirini */}}
 
     # Temporarily fixes https://github.com/SUSE/kubecf/issues/241.
     # TODO: properly investigate and fix log-cache.
@@ -153,72 +56,15 @@ data:
       path: /instance_groups/name=doppler/instances
       value: 1
 
-{{- if .Values.sizing.log_api.instances }}
+{{- $root := . }}
+{{- range $instance_group := $instance_groups }}
+{{- if index (snakecase $instance_group | index $root.Values.sizing) "instances" | kindIs "invalid" | not }}
     - type: replace
-      path: /instance_groups/name=log-api/instances
-      value: {{.Values.sizing.log_api.instances}}
-{{- else if not .Values.high_availability }}
+      path: /instance_groups/name={{ $instance_group }}/instances
+      value: {{ index (snakecase $instance_group | index $root.Values.sizing) "instances" }}
+{{- else if not $root.Values.high_availability }}
     - type: replace
-      path: /instance_groups/name=log-api/instances
+      path: /instance_groups/name={{ $instance_group }}/instances
       value: 1
-{{- end }}
-
-{{- if .Values.sizing.nats.instances }}
-    - type: replace
-      path: /instance_groups/name=nats/instances
-      value: {{.Values.sizing.nats.instances}}
-{{- else if not .Values.high_availability }}
-    - type: replace
-      path: /instance_groups/name=nats/instances
-      value: 1
-{{- end }}
-
-{{- if .Values.sizing.router.instances }}
-    - type: replace
-      path: /instance_groups/name=router/instances
-      value: {{.Values.sizing.router.instances}}
-{{- else if not .Values.high_availability }}
-    - type: replace
-      path: /instance_groups/name=router/instances
-      value: 1
-{{- end }}
-
-{{- if .Values.sizing.routing_api.instances }}
-    - type: replace
-      path: /instance_groups/name=routing-api/instances
-      value: {{.Values.sizing.routing_api.instances}}
-{{- else if not .Values.high_availability }}
-    - type: replace
-      path: /instance_groups/name=routing-api/instances
-      value: 1
-{{- end }}
-
-{{- if .Values.sizing.scheduler.instances }}
-    - type: replace
-      path: /instance_groups/name=scheduler/instances
-      value: {{.Values.sizing.scheduler.instances}}
-{{- else if not .Values.high_availability }}
-    - type: replace
-      path: /instance_groups/name=scheduler/instances
-      value: 1
-{{- end }}
-
-{{- if .Values.sizing.uaa.instances }}
-    - type: replace
-      path: /instance_groups/name=uaa/instances
-      value: {{.Values.sizing.uaa.instances}}
-{{- else if not .Values.high_availability }}
-    - type: replace
-      path: /instance_groups/name=uaa/instances
-      value: 1
-{{- end }}
-
-{{- if .Values.sizing.tcp_router.instances }}
-    - type: replace
-      path: /instance_groups/name=tcp-router/instances
-      value: {{.Values.sizing.tcp_router.instances}}
-{{- else if not .Values.high_availability }}
-    - type: replace
-      path: /instance_groups/name=tcp-router/instances
-      value: 1
-{{- end }}
+{{- end }}{{/* if */}}
+{{- end }}{{/* range $instance_group */}}

--- a/deploy/helm/kubecf/templates/sizing.yaml
+++ b/deploy/helm/kubecf/templates/sizing.yaml
@@ -56,13 +56,12 @@ data:
       path: /instance_groups/name=doppler/instances
       value: 1
 
-{{- $root := . }}
 {{- range $instance_group := $instance_groups }}
-{{- if index (snakecase $instance_group | index $root.Values.sizing) "instances" | kindIs "invalid" | not }}
+{{- if index (snakecase $instance_group | index $.Values.sizing) "instances" | kindIs "invalid" | not }}
     - type: replace
       path: /instance_groups/name={{ $instance_group }}/instances
-      value: {{ index (snakecase $instance_group | index $root.Values.sizing) "instances" }}
-{{- else if not $root.Values.high_availability }}
+      value: {{ index (snakecase $instance_group | index $.Values.sizing) "instances" }}
+{{- else if not $.Values.high_availability }}
     - type: replace
       path: /instance_groups/name={{ $instance_group }}/instances
       value: 1


### PR DESCRIPTION
## Description
This makes [`sizing.yaml`] repeat itself less, like [`releases.yaml`].

[`sizing.yaml`]: https://github.com/cloudfoundry-incubator/kubecf/blob/master/deploy/helm/kubecf/templates/sizing.yaml
[`releases.yaml`]: https://github.com/cloudfoundry-incubator/kubecf/blob/master/deploy/helm/kubecf/assets/operations/releases.yaml

## Motivation and Context
This makes sure we don't end up with a copy/paste error somewhere in _one_ sizing block: we move all the complicated logic on setting the sizes to one shared block, where we can focus our attention, and adding a new instance group is much simpler now.

As a side effect, also makes it possible to set size to 0 (since I'm now doing an explicit nil check).

## How Has This Been Tested?
Rendered the ops file manually (via `helm template`) to check that the output looks reasonable.  Checked HA mode (a much reduced output), setting explicit sizes on `api` and `cc-worker` (to test the snake case thing).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
