### PR TITLE
Bump catapult to support helm3

### DIFF
--- a/.concourse/pipeline.yaml
+++ b/.concourse/pipeline.yaml
@@ -52,7 +52,7 @@ resources:
   source:
     uri: https://github.com/SUSE/catapult
   version:
-    ref: eb4b8fe1453c7a5f1c6a2082e5f490dd6e953664
+    ref: 7eea74f5cab3386b65c08938b25811e99bb829ef
 
 - name: s3.kubecf-ci
   type: s3
@@ -97,6 +97,7 @@ deploy_args: &deploy_args
   export SCF_CHART="$(readlink -f s3.kubecf-ci/*.tgz)"
   export SCF_OPERATOR=true
   export FORCE_DELETE=true
+  export HELM_VERSION="v3.1.1"
   export SCF_TESTGROUP=true
   export BACKEND=ekcp
   export DOCKER_ORG=cap-staging


### PR DESCRIPTION
Also pin helm3 version in the pipeline

Signed-off-by: Dimitris Karakasilis <DKarakasilis@suse.com>

master branch no longer works with helm 2. This PR is adding CI support for helm 3.
