### PR TITLE
fix: trust router CA cert on sec group setup

### DIFF
--- a/deploy/helm/kubecf/assets/operations/instance_groups/credhub.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/credhub.yaml
@@ -43,6 +43,7 @@
         bpm:
           processes:
           - name: credhub-internal-security-group-setup
+            ephemeral_disk: true
             executable: /bin/bash
             args:
             - -c
@@ -78,7 +79,7 @@
         - name: PORTS
           value: *credhub_port
         - name: DATA_DIR
-          value: /var/vcap/data/credhub-internal-security-group-setup
+          value: /var/vcap/data/cf-cli-6-linux
 
 {{- else }}
 

--- a/deploy/helm/kubecf/assets/operations/instance_groups/credhub.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/credhub.yaml
@@ -53,6 +53,11 @@
           value: /var/vcap/packages/cf-cli-6-linux/bin
         - name: CF_API
           value: https://api.((system_domain))
+        - name: CF_API_CA_CERT
+          valueFrom:
+            secretKeyRef:
+              name: {{ printf "%s.var-router-ssl" .Release.Name | quote }}
+              key: ca
         - name: CF_USERNAME
           value: admin
         - name: CF_PASSWORD

--- a/deploy/helm/kubecf/assets/operations/instance_groups/credhub.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/credhub.yaml
@@ -77,6 +77,8 @@
               fieldPath: metadata.name
         - name: PORTS
           value: *credhub_port
+        - name: DATA_DIR
+          value: /var/vcap/data/credhub-internal-security-group-setup
 
 {{- else }}
 

--- a/deploy/helm/kubecf/assets/operations/instance_groups/uaa.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/uaa.yaml
@@ -43,6 +43,7 @@
         bpm:
           processes:
           - name: uaa-internal-security-group-setup
+            ephemeral_disk: true
             executable: /bin/bash
             args:
             - -c
@@ -78,7 +79,7 @@
         - name: PORTS
           value: *uaa_https_port
         - name: DATA_DIR
-          value: /var/vcap/data/uaa-internal-security-group-setup
+          value: /var/vcap/data/cf-cli-6-linux
 
 {{- end }}
 

--- a/deploy/helm/kubecf/assets/operations/instance_groups/uaa.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/uaa.yaml
@@ -77,6 +77,8 @@
               fieldPath: metadata.name
         - name: PORTS
           value: *uaa_https_port
+        - name: DATA_DIR
+          value: /var/vcap/data/uaa-internal-security-group-setup
 
 {{- end }}
 

--- a/deploy/helm/kubecf/assets/operations/instance_groups/uaa.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/uaa.yaml
@@ -53,6 +53,11 @@
           value: /var/vcap/packages/cf-cli-6-linux/bin
         - name: CF_API
           value: https://api.((system_domain))
+        - name: CF_API_CA_CERT
+          valueFrom:
+            secretKeyRef:
+              name: {{ printf "%s.var-router-ssl" .Release.Name | quote }}
+              key: ca
         - name: CF_USERNAME
           value: admin
         - name: CF_PASSWORD

--- a/deploy/helm/kubecf/assets/scripts/jobs/cf-cli-6-linux/setup_internal_security_group.sh
+++ b/deploy/helm/kubecf/assets/scripts/jobs/cf-cli-6-linux/setup_internal_security_group.sh
@@ -5,7 +5,8 @@ set -o errexit -o nounset -o pipefail
 
 export PATH="${CF_CLI_PATH}:${PATH}"
 
-cf_api_ca_cert_pem="/etc/ssl/cf_api_ca_cert.pem"
+cf_api_ca_cert_pem="${DATA_DIR}/cf_api_ca_cert.pem"
+mkdir -p "$(dirname "${cf_api_ca_cert_pem}")"
 echo -n "${CF_API_CA_CERT}" > "${cf_api_ca_cert_pem}"
 export SSL_CERT_FILE="${cf_api_ca_cert_pem}"
 

--- a/deploy/helm/kubecf/assets/scripts/jobs/cf-cli-6-linux/setup_internal_security_group.sh
+++ b/deploy/helm/kubecf/assets/scripts/jobs/cf-cli-6-linux/setup_internal_security_group.sh
@@ -1,15 +1,20 @@
 #!/bin/bash
 
-set -o errexit -o nounset -o xtrace
+# Never use -x or -o xtrace here because of security reasons.
+set -o errexit -o nounset -o pipefail
 
 export PATH="${CF_CLI_PATH}:${PATH}"
 
+cf_api_ca_cert_pem="/etc/ssl/cf_api_ca_cert.pem"
+echo -n "${CF_API_CA_CERT}" > "${cf_api_ca_cert_pem}"
+export SSL_CERT_FILE="${cf_api_ca_cert_pem}"
+
 echo "Waiting for the API to be accessible..."
-until curl --insecure --fail --head "${CF_API}/v2/info" 1> /dev/null 2> /dev/null; do
+until curl --fail --head "${CF_API}/v2/info" 1> /dev/null 2> /dev/null; do
     sleep 1
 done
 
-cf api --skip-ssl-validation "${CF_API}"
+cf api "${CF_API}"
 cf auth
 
 sec_group_json=$(cat <<EOF

--- a/deploy/helm/kubecf/assets/scripts/jobs/cf-cli-6-linux/setup_internal_security_group.sh
+++ b/deploy/helm/kubecf/assets/scripts/jobs/cf-cli-6-linux/setup_internal_security_group.sh
@@ -6,7 +6,7 @@ set -o errexit -o nounset -o pipefail
 export PATH="${CF_CLI_PATH}:${PATH}"
 
 cf_api_ca_cert_pem="${DATA_DIR}/cf_api_ca_cert.pem"
-mkdir -p "$(dirname "${cf_api_ca_cert_pem}")"
+mkdir -p "${DATA_DIR}"
 echo -n "${CF_API_CA_CERT}" > "${cf_api_ca_cert_pem}"
 export SSL_CERT_FILE="${cf_api_ca_cert_pem}"
 

--- a/deploy/helm/kubecf/assets/scripts/jobs/cf-cli-6-linux/setup_internal_security_group.sh
+++ b/deploy/helm/kubecf/assets/scripts/jobs/cf-cli-6-linux/setup_internal_security_group.sh
@@ -6,7 +6,6 @@ set -o errexit -o nounset -o pipefail
 export PATH="${CF_CLI_PATH}:${PATH}"
 
 cf_api_ca_cert_pem="${DATA_DIR}/cf_api_ca_cert.pem"
-mkdir -p "${DATA_DIR}"
 echo -n "${CF_API_CA_CERT}" > "${cf_api_ca_cert_pem}"
 export SSL_CERT_FILE="${cf_api_ca_cert_pem}"
 


### PR DESCRIPTION
## Description

Fixes #451.

## Motivation and Context

We don't want to use `--insecure` and `--skip-ssl-validation`. This PR fixes that by trusting the CA cert that the router cert was signed with.

## How Has This Been Tested?

The same behaviour for the security group setup was kept. CATS passed.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
