### PR TITLE
Fix secret names used in the db seeder when ns != deployment name

### DIFF
--- a/deploy/helm/kubecf/templates/database.yaml
+++ b/deploy/helm/kubecf/templates/database.yaml
@@ -386,7 +386,7 @@ spec:
           {{- range $database := $databases }}
           - name: {{ printf  "%s-database-password" (get $database "name") | quote }}
             secret:
-              secretName: {{ printf "%s.var-%s-database-password" $.Release.Namespace (get $database "secretName") | quote }}
+              secretName: {{ printf "%s.var-%s-database-password" $.Release.Name (get $database "secretName") | quote }}
           {{- end }}
           restartPolicy: Never
 


### PR DESCRIPTION
The seeder job was wrongly using the namespace for building the secret
names instead of the deployment name. That led to failing deployments
when those two were different.

## How Has This Been Tested?
Local deployment with different namespace and deployment name.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
