### PR TITLE
Remove max in flight and add every in the concourse pipeline

### DIFF
--- a/.concourse/pipeline.yaml
+++ b/.concourse/pipeline.yaml
@@ -150,6 +150,7 @@ jobs:
     params:
       integration_tool: checkout
     trigger: true
+    version: "every"
   # Use GitHub API to find the remote repository of the PR (it may be a fork)
   # The pr resource doesn't provide this information.
   - task: find-pr-remote
@@ -249,6 +250,7 @@ jobs:
   plan:
   - get: commit-to-test
     trigger: true
+    version: "every"
   - task: lint
     config:
       platform: linux
@@ -289,6 +291,7 @@ jobs:
   plan:
   - get: commit-to-test
     trigger: true
+    version: "every"
     passed:
     - lint
   - task: build
@@ -342,6 +345,7 @@ jobs:
   plan:
   - get: commit-to-test
     trigger: true
+    version: "every"
     passed:
     - build
   - get: s3.kubecf-ci
@@ -421,13 +425,13 @@ jobs:
           EKCP_HOST: ((ekcp-host))
 
 - name: smoke-tests-diego
-  max_in_flight: 2
   public: true
   plan:
   - get: commit-to-test
     passed:
     - deploy-diego
     trigger: true
+    version: "every"
   - get: s3.kubecf-ci
     passed:
     - deploy-diego
@@ -490,12 +494,12 @@ jobs:
 
 - name: ccdb-rotate-diego
   public: true
-  max_in_flight: 2
   plan:
   - get: commit-to-test
     passed:
     - cf-acceptance-tests-diego
     trigger: true
+    version: "every"
   - get: s3.kubecf-ci
     passed:
     - cf-acceptance-tests-diego
@@ -556,13 +560,13 @@ jobs:
           EKCP_HOST: ((ekcp-host))
 
 - name: smoke-tests-post-rotate-diego
-  max_in_flight: 2
   public: true
   plan:
   - get: commit-to-test
     passed:
     - ccdb-rotate-diego
     trigger: true
+    version: "every"
   - get: s3.kubecf-ci
     passed:
     - ccdb-rotate-diego
@@ -624,13 +628,13 @@ jobs:
           EKCP_HOST: ((ekcp-host))
 
 - name: cf-acceptance-tests-diego
-  max_in_flight: 2
   public: true
   plan:
   - get: commit-to-test
     passed:
     - smoke-tests-diego
     trigger: true
+    version: "every"
   - get: s3.kubecf-ci
     passed:
     - smoke-tests-diego
@@ -692,13 +696,13 @@ jobs:
           EKCP_HOST: ((ekcp-host))
 
 - name: cleanup-diego-cluster
-  max_in_flight: 2
   public: true
   plan:
   - get: commit-to-test
     passed:
     - smoke-tests-post-rotate-diego
     trigger: true
+    version: "every"
   - task: cleanup-cluster
     config:
       <<: *cleanup-cluster
@@ -713,6 +717,7 @@ jobs:
   plan:
   - get: commit-to-test
     trigger: true
+    version: "every"
     passed:
     - build
   - get: s3.kubecf-ci
@@ -777,13 +782,13 @@ jobs:
           EKCP_HOST: ((ekcp-host))
 
 - name: smoke-tests-eirini
-  max_in_flight: 2
   public: true
   plan:
   - get: commit-to-test
     passed:
     - deploy-eirini
     trigger: true
+    version: "every"
   - get: s3.kubecf-ci
     passed:
     - deploy-eirini
@@ -846,12 +851,12 @@ jobs:
 
 - name: ccdb-rotate-eirini
   public: true
-  max_in_flight: 2
   plan:
   - get: commit-to-test
     passed:
     - cf-acceptance-tests-eirini
     trigger: true
+    version: "every"
   - get: s3.kubecf-ci
     passed:
     - cf-acceptance-tests-eirini
@@ -912,13 +917,13 @@ jobs:
           EKCP_HOST: ((ekcp-host))
 
 - name: smoke-tests-post-rotate-eirini
-  max_in_flight: 2
   public: true
   plan:
   - get: commit-to-test
     passed:
     - ccdb-rotate-eirini
     trigger: true
+    version: "every"
   - get: s3.kubecf-ci
     passed:
     - ccdb-rotate-eirini
@@ -980,13 +985,13 @@ jobs:
           EKCP_HOST: ((ekcp-host))
 
 - name: cf-acceptance-tests-eirini
-  max_in_flight: 2
   public: true
   plan:
   - get: commit-to-test
     passed:
     - smoke-tests-eirini
     # trigger: true
+    version: "every"
   - get: s3.kubecf-ci
     passed:
     - smoke-tests-eirini
@@ -1048,7 +1053,6 @@ jobs:
           EKCP_HOST: ((ekcp-host))
 
 - name: cleanup-eirini-cluster
-  max_in_flight: 2
   public: true
   plan:
   - get: commit-to-test
@@ -1056,6 +1060,7 @@ jobs:
     # - smoke-tests-post-rotate-eirini
     - smoke-tests-eirini
     trigger: true
+    version: "every"
   - task: cleanup-cluster
     config:
       <<: *cleanup-cluster
@@ -1067,6 +1072,7 @@ jobs:
   public: true
   plan:
   - get: commit-to-test
+    version: "every"
     passed:
     - cf-acceptance-tests-diego
     # TODO: Uncomment as soon as eirini tests are green


### PR DESCRIPTION
we introduced max-in-flight hoping to limit the number of clusters we
run at the same time. It turns out it doesn't work that way. As soon as
a deploy job is done the next one will be queued although no cluster has
been deleted. This will allow for as many clusters as we have time to
deploy until the first cluster is deleteted.

We also add the "version: every" setting to make sure we don't skip
versions if jobs complete in random order. See also here:

https://github.com/concourse/concourse/issues/736

Signed-off-by: Dimitris Karakasilis <DKarakasilis@suse.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- An important detail to include is the version of the used cf-operator -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
