### PR TITLE
fix: use client credentials over admin password

### DIFF
--- a/deploy/helm/kubecf/assets/operations/instance_groups/credhub.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/credhub.yaml
@@ -60,11 +60,11 @@
               name: {{ printf "%s.var-router-ssl" .Release.Name | quote }}
               key: ca
         - name: CF_USERNAME
-          value: admin
+          value: credhub_setup
         - name: CF_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ printf "%s.var-cf-admin-password" .Release.Name | quote }}
+              name: {{ printf "%s.var-credhub-setup-client-secret" .Release.Name | quote }}
               key: password
         - name: POD_IP
           valueFrom:
@@ -80,6 +80,19 @@
           value: *credhub_port
         - name: DATA_DIR
           value: /var/vcap/data/cf-cli-6-linux
+
+- type: replace
+  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/credhub_setup?
+  value:
+    authorities: cloud_controller.admin
+    authorized-grant-types: client_credentials
+    secret: ((credhub_setup_client_secret))
+
+- type: replace
+  path: /variables/name=credhub_setup_client_secret?
+  value:
+    name: credhub_setup_client_secret
+    type: password
 
 {{- else }}
 

--- a/deploy/helm/kubecf/assets/operations/instance_groups/uaa.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/uaa.yaml
@@ -60,11 +60,11 @@
               name: {{ printf "%s.var-router-ssl" .Release.Name | quote }}
               key: ca
         - name: CF_USERNAME
-          value: admin
+          value: uaa_setup
         - name: CF_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ printf "%s.var-cf-admin-password" .Release.Name | quote }}
+              name: {{ printf "%s.var-uaa-setup-client-secret" .Release.Name | quote }}
               key: password
         - name: POD_IP
           valueFrom:
@@ -80,6 +80,19 @@
           value: *uaa_https_port
         - name: DATA_DIR
           value: /var/vcap/data/cf-cli-6-linux
+
+- type: replace
+  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/clients/uaa_setup?
+  value:
+    authorities: cloud_controller.admin
+    authorized-grant-types: client_credentials
+    secret: ((uaa_setup_client_secret))
+
+- type: replace
+  path: /variables/name=uaa_setup_client_secret?
+  value:
+    name: uaa_setup_client_secret
+    type: password
 
 {{- end }}
 

--- a/deploy/helm/kubecf/assets/scripts/jobs/cf-cli-6-linux/setup_internal_security_group.sh
+++ b/deploy/helm/kubecf/assets/scripts/jobs/cf-cli-6-linux/setup_internal_security_group.sh
@@ -15,7 +15,7 @@ until curl --fail --head "${CF_API}/v2/info" 1> /dev/null 2> /dev/null; do
 done
 
 cf api "${CF_API}"
-cf auth
+cf auth --client-credentials
 
 sec_group_json=$(cat <<EOF
 [{


### PR DESCRIPTION
## Description

Fixes https://github.com/cloudfoundry-incubator/kubecf/issues/450.

## Motivation and Context

If the admin password is changed, the credhub and uaa setups will fail.

## How Has This Been Tested?

Locally, checked that the security groups were created as expected not using the admin password.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
