### PR TITLE
feat: increase CATS scale timeout

### DIFF
--- a/deploy/helm/kubecf/assets/operations/instance_groups/acceptance-tests.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/acceptance-tests.yaml
@@ -21,6 +21,7 @@
           {{- end }}
           include: '+tcp_routing'
           skip_ssl_validation: true
+          timeout_scale: 3
         bpm:
           enabled: true
       release: cf-acceptance-tests


### PR DESCRIPTION
## Description

This helps with concurrent test jobs, given that each job will be executed slower.

## Motivation and Context

Generally, increasing concurrent test jobs decreases the total time spent running CATS, but also makes each individual test routines slower. Some of them times out and flake the tests.

## How Has This Been Tested?

Running CATS locally.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
