### PR TITLE
Added brain tests to kubecf pipeline

### DIFF
--- a/.concourse/pipeline.yaml
+++ b/.concourse/pipeline.yaml
@@ -182,8 +182,8 @@ jobs:
       state: "pending"
       contexts: >
         lint,build,deploy-diego,smoke-diego,rotate-diego,smoke-rotated-diego,
-        acceptance-diego,deploy-eirini,smoke-eirini,rotate-eirini,
-        smoke-rotated-eirini,acceptance-eirini,sync-integration-tests-diego
+        acceptance-diego,deploy-eirini,smoke-eirini,rotate-eirini,brain-eirini,
+        smoke-rotated-eirini,acceptance-eirini,sync-integration-tests-diego,brain-tests-diego
       trigger: "PR"
       metadata_path: "kubecf-pr/.git/resource/url"
 - name: queue-fork-pr
@@ -693,7 +693,7 @@ jobs:
           CLUSTER_NAME_PREFIX: "kubecf-diego"
           EKCP_HOST: ((ekcp-host))
 
-- name: cf-acceptance-tests-diego
+- name: brain-tests-diego
   public: true
   plan:
   - get: commit-to-test
@@ -707,6 +707,74 @@ jobs:
   - get: s3.kubecf-ci-bundle
     passed:
     - sync-integration-tests-diego
+  - get: catapult
+  - task: test-diego
+    privileged: true
+    timeout: 1h30m
+    config:
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: splatform/catapult
+      inputs:
+      - name: catapult
+      - name: commit-to-test
+      outputs:
+      - name: output
+      params:
+        DEFAULT_STACK: cflinuxfs3
+        EKCP_HOST: ((ekcp-host))
+        TEST_SUITE: brain
+        CLUSTER_NAME_PREFIX: kubecf-diego
+      run:
+        path: "/bin/bash"
+        args: *test_args
+    on_success:
+      put: commit-to-test
+      params:
+        description: "Brain tests on Diego succeeded"
+        state: "success"
+        contexts: "brain-tests-diego"
+        commit_path: "commit-to-test/.git/resource/ref"
+        version_path: "commit-to-test/.git/resource/version"
+    on_failure:
+      do:
+      - put: commit-to-test
+        params:
+          description: "Brain tests on Diego failed"
+          state: "failure"
+          commit_path: "commit-to-test/.git/resource/ref"
+          version_path: "commit-to-test/.git/resource/version"
+          contexts: "brain-tests-diego"
+      - task: cleanup-cluster
+        config:
+          <<: *cleanup-cluster
+          params:
+            CLUSTER_NAME_PREFIX: "kubecf-diego"
+            EKCP_HOST: ((ekcp-host))
+    on_abort:
+      task: cleanup-cluster
+      config:
+        <<: *cleanup-cluster
+        params:
+          CLUSTER_NAME_PREFIX: "kubecf-diego"
+          EKCP_HOST: ((ekcp-host))
+
+- name: cf-acceptance-tests-diego
+  public: true
+  plan:
+  - get: commit-to-test
+    passed:
+    - brain-tests-diego
+    trigger: true
+    version: "every"
+  - get: s3.kubecf-ci
+    passed:
+    - brain-tests-diego
+  - get: s3.kubecf-ci-bundle
+    passed:
+    - brain-tests-diego
   - get: catapult
   - task: test-diego
     privileged: true
@@ -915,6 +983,74 @@ jobs:
           CLUSTER_NAME_PREFIX: "kubecf-eirini"
           EKCP_HOST: ((ekcp-host))
 
+- name: brain-tests-eirini
+  public: true
+  plan:
+  - get: commit-to-test
+    passed:
+    - smoke-tests-eirini
+    trigger: true
+    version: "every"
+  - get: s3.kubecf-ci
+    passed:
+    - smoke-tests-eirini
+  - get: s3.kubecf-ci-bundle
+    passed:
+    - smoke-tests-eirini
+  - get: catapult
+  - task: test
+    privileged: true
+    timeout: 1h30m
+    config:
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: splatform/catapult
+      inputs:
+      - name: catapult
+      - name: commit-to-test
+      outputs:
+      - name: mail-output
+      params:
+        DEFAULT_STACK: cflinuxfs3
+        EKCP_HOST: ((ekcp-host))
+        TEST_SUITE: brain
+        CLUSTER_NAME_PREFIX: kubecf-eirini
+      run:
+        path: "/bin/bash"
+        args: *test_args
+    on_success:
+      put: commit-to-test
+      params:
+        description: "Brain tests on Eirini succeeded"
+        state: "success"
+        contexts: "brain-eirini"
+        commit_path: "commit-to-test/.git/resource/ref"
+        version_path: "commit-to-test/.git/resource/version"
+    on_failure:
+      do:
+      - put: commit-to-test
+        params:
+          description: "Brain tests on Eirini failed"
+          state: "failure"
+          contexts: "brain-eirini"
+          commit_path: "commit-to-test/.git/resource/ref"
+          version_path: "commit-to-test/.git/resource/version"
+      - task: cleanup-cluster
+        config:
+          <<: *cleanup-cluster
+          params:
+            CLUSTER_NAME_PREFIX: "kubecf-eirini"
+            EKCP_HOST: ((ekcp-host))
+    on_abort:
+      task: cleanup-cluster
+      config:
+        <<: *cleanup-cluster
+        params:
+          CLUSTER_NAME_PREFIX: "kubecf-eirini"
+          EKCP_HOST: ((ekcp-host))
+
 - name: ccdb-rotate-eirini
   public: true
   plan:
@@ -1055,15 +1191,15 @@ jobs:
   plan:
   - get: commit-to-test
     passed:
-    - smoke-tests-eirini
+    - brain-tests-eirini
     # trigger: true
     version: "every"
   - get: s3.kubecf-ci
     passed:
-    - smoke-tests-eirini
+    - brain-tests-eirini
   - get: s3.kubecf-ci-bundle
     passed:
-    - smoke-tests-eirini
+    - brain-tests-eirini
   - get: catapult
   - task: test
     timeout: 5h30m


### PR DESCRIPTION
## Description
Added brain tests to the kubecf pipeline.
This is analogous to #436.
Note, this PR sits on top of that PR at the moment.

## Motivation and Context
See ticket https://jira.suse.com/browse/CAP-1247
This is analogous to ticket https://jira.suse.com/browse/CAP-1280 for sits (and its PR).
This PR __requires__ the catapult PR https://github.com/SUSE/catapult/pull/117 (merged over the weekend)

## How Has This Been Tested?
Not tested. Unclear how to perform local testing of the changed pipeline.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
