### PR TITLE
Add Helm templates to enable KubeCF with native Eirini

### DIFF
--- a/deploy/helm/kubecf/assets/operations/instance_groups/bits.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/bits.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.features.eirini.enabled }}
+{{- if and .Values.features.eirini.enabled (not .Values.features.eirini.use_helm_release) }}
 
 # Add quarks information to the Bits Service jobs.
 - type: replace

--- a/deploy/helm/kubecf/assets/operations/instance_groups/eirini-helm.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/eirini-helm.yaml
@@ -1,56 +1,35 @@
-{{- if .Values.features.eirini-native.enabled }}
-- type: remove
-  path: /instance_groups/name=diego-cell
-
-# Remove bbs from diego-api.
-# TODO: remove bbs in the future - when the clock and worker no longer need it.
-# - type: remove
-#   path: /instance_groups/name=diego-api/jobs/name=bbs
-
-# Remove auctioneer, tps and ssh_proxy from scheduler.
-- type: remove
-  path: /instance_groups/name=auctioneer
-- type: remove
-  path: /instance_groups/name=scheduler/jobs/name=tps
-- type: remove
-  path: /instance_groups/name=scheduler/jobs/name=ssh_proxy
-
-# Enable OPI in CC
-# cloud_controller_ng
+{{- if and (.Values.features.eirini.enabled) (.Values.features.eirini.use_helm_release) }}
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/opi?/enabled?
   value: true
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/opi?/url?
-  value: https://eirini-opi.{{ .Release.Namespace }}:8085 
+  value: "https://eirini-opi.{{ .Release.Namespace }}.svc.cluster.local:8085"
 
-  # --- Set endpoints and alternative names for eirini staging.
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/packages?/webdav_config?/private_endpoint?
-  value: https://{{ .Release.Name }}-singleton-blobstore.{{ .Release.Namespace }}:4443
+  value: "https://{{ .Release.Name }}-singleton-blobstore.{{ .Release.Namespace }}.svc.cluster.local:4443"
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/buildpacks?/webdav_config?/private_endpoint?
-  value: https://{{ .Release.Name }}-singleton-blobstore.{{ .Release.Namespace }}:4443
+  value: "https://{{ .Release.Name }}-singleton-blobstore.{{ .Release.Namespace }}.svc.cluster.local:4443"
 - type: replace
   path: /variables/name=blobstore_tls/options/alternative_names?/-
-  value: "{{ .Release.Name }}-singleton-blobstore.{{ .Release.Namespace }}"
+  value: "{{ .Release.Name }}-singleton-blobstore.{{ .Release.Namespace }}.svc.cluster.local"
 - type: replace
   path: /variables/name=cc_bridge_cc_uploader_server/options/alternative_names?/-
-  value: "{{ .Release.Name }}-api.{{ .Release.Namespace }}"
+  value: "{{ .Release.Name }}-api.{{ .Release.Namespace }}.svc.cluster.local"
 - type: replace
   path: /instance_groups/name=api/jobs/name=cc_uploader/properties/internal_hostname?
-  value: "{{ .Release.Name }}-api.{{ .Release.Namespace }}"
+  value: "{{ .Release.Name }}-api.{{ .Release.Namespace }}.svc.cluster.local"
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/internal_service_hostname?
-  value: "{{ .Release.Name }}-api.{{ .Release.Namespace }}"
+  value: "{{ .Release.Name }}-api.{{ .Release.Namespace }}.svc.cluster.local"
 - type: replace
   path: /variables/name=cc_public_tls/options/alternative_names?/-
-  value: "{{ .Release.Name }}-api.{{ .Release.Namespace }}"
+  value: "{{ .Release.Name }}-api.{{ .Release.Namespace }}.svc.cluster.local"
 - type: replace
   path: /variables/name=cc_tls/options/alternative_names?/-
-  value: "{{ .Release.Name }}-api.{{ .Release.Namespace }}"
-
-  #---------------
+  value: "{{ .Release.Name }}-api.{{ .Release.Namespace }}.svc.cluster.local"
 
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/opi?/opi_staging?
@@ -65,13 +44,12 @@
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/opi?/ca_cert?
   value: ((eirini_tls_server_cert.ca))
 
-# cloud_controller_worker
 - type: replace
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/opi?/enabled?
   value: true
 - type: replace
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/opi?/url?
-  value: https://eirini-opi.{{ .Release.Namespace }}:8085 
+  value: "https://eirini-opi.{{ .Release.Namespace }}.svc.cluster.local:8085" 
 - type: replace
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/opi?/opi_staging?
   value: true
@@ -85,13 +63,12 @@
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/opi?/ca_cert?
   value: ((eirini_tls_server_cert.ca))
 
-# cloud_controller_clock
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/opi?/enabled?
   value: true
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/opi?/url?
-  value: https://eirini-opi.{{ .Release.Namespace }}:8085 
+  value: "https://eirini-opi.{{ .Release.Namespace }}.svc.cluster.local:8085"
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/opi?/opi_staging?
   value: true
@@ -105,7 +82,6 @@
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/opi?/ca_cert?
   value: ((eirini_tls_server_cert.ca))
 
-# Make loggregator agent cert validate correctly for fluentd in k8s nodes
 - type: replace
   path: /variables/name=loggregator_tls_agent/options/alternative_names?
   value:
@@ -124,7 +100,7 @@
       ca: service_cf_internal_ca
       common_name: "eirini-opi"
       alternative_names:
-      - eirini-opi.{{ .Release.Namespace }}
+      - "eirini-opi.{{ .Release.Namespace }}.svc.cluster.local"
       extended_key_usage:
       - server_auth
 - type: replace

--- a/deploy/helm/kubecf/assets/operations/instance_groups/eirini-helm.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/eirini-helm.yaml
@@ -1,0 +1,140 @@
+{{- if .Values.features.eirini-native.enabled }}
+- type: remove
+  path: /instance_groups/name=diego-cell
+
+# Remove bbs from diego-api.
+# TODO: remove bbs in the future - when the clock and worker no longer need it.
+# - type: remove
+#   path: /instance_groups/name=diego-api/jobs/name=bbs
+
+# Remove auctioneer, tps and ssh_proxy from scheduler.
+- type: remove
+  path: /instance_groups/name=auctioneer
+- type: remove
+  path: /instance_groups/name=scheduler/jobs/name=tps
+- type: remove
+  path: /instance_groups/name=scheduler/jobs/name=ssh_proxy
+
+# Enable OPI in CC
+# cloud_controller_ng
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/opi?/enabled?
+  value: true
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/opi?/url?
+  value: https://eirini-opi.{{ .Release.Namespace }}:8085 
+
+  # --- Set endpoints and alternative names for eirini staging.
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/packages?/webdav_config?/private_endpoint?
+  value: https://{{ .Release.Name }}-singleton-blobstore.{{ .Release.Namespace }}:4443
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/buildpacks?/webdav_config?/private_endpoint?
+  value: https://{{ .Release.Name }}-singleton-blobstore.{{ .Release.Namespace }}:4443
+- type: replace
+  path: /variables/name=blobstore_tls/options/alternative_names?/-
+  value: "{{ .Release.Name }}-singleton-blobstore.{{ .Release.Namespace }}"
+- type: replace
+  path: /variables/name=cc_bridge_cc_uploader_server/options/alternative_names?/-
+  value: "{{ .Release.Name }}-api.{{ .Release.Namespace }}"
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cc_uploader/properties/internal_hostname?
+  value: "{{ .Release.Name }}-api.{{ .Release.Namespace }}"
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/internal_service_hostname?
+  value: "{{ .Release.Name }}-api.{{ .Release.Namespace }}"
+- type: replace
+  path: /variables/name=cc_public_tls/options/alternative_names?/-
+  value: "{{ .Release.Name }}-api.{{ .Release.Namespace }}"
+- type: replace
+  path: /variables/name=cc_tls/options/alternative_names?/-
+  value: "{{ .Release.Name }}-api.{{ .Release.Namespace }}"
+
+  #---------------
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/opi?/opi_staging?
+  value: true
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/opi?/client_cert?
+  value: ((eirini_tls_client_cert.certificate))
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/opi?/client_key?
+  value: ((eirini_tls_client_cert.private_key))
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/opi?/ca_cert?
+  value: ((eirini_tls_server_cert.ca))
+
+# cloud_controller_worker
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/opi?/enabled?
+  value: true
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/opi?/url?
+  value: https://eirini-opi.{{ .Release.Namespace }}:8085 
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/opi?/opi_staging?
+  value: true
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/opi?/client_cert?
+  value: ((eirini_tls_client_cert.certificate))
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/opi?/client_key?
+  value: ((eirini_tls_client_cert.private_key))
+- type: replace
+  path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/opi?/ca_cert?
+  value: ((eirini_tls_server_cert.ca))
+
+# cloud_controller_clock
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/opi?/enabled?
+  value: true
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/opi?/url?
+  value: https://eirini-opi.{{ .Release.Namespace }}:8085 
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/opi?/opi_staging?
+  value: true
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/opi?/client_cert?
+  value: ((eirini_tls_client_cert.certificate))
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/opi?/client_key?
+  value: ((eirini_tls_client_cert.private_key))
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/opi?/ca_cert?
+  value: ((eirini_tls_server_cert.ca))
+
+# Make loggregator agent cert validate correctly for fluentd in k8s nodes
+- type: replace
+  path: /variables/name=loggregator_tls_agent/options/alternative_names?
+  value:
+    - localhost
+    - metron
+- type: replace
+  path: /variables/name=loggregator_tls_doppler/options/alternative_names?/-
+  value: metron
+
+- type: replace
+  path: /variables/name=eirini_tls_server_cert?
+  value:
+    name: eirini_tls_server_cert
+    type: certificate
+    options:
+      ca: service_cf_internal_ca
+      common_name: "eirini-opi"
+      alternative_names:
+      - eirini-opi.{{ .Release.Namespace }}
+      extended_key_usage:
+      - server_auth
+- type: replace
+  path: /variables/name=eirini_tls_client_cert?
+  value:
+    name: eirini_tls_client_cert
+    type: certificate
+    options:
+      ca: service_cf_internal_ca
+      common_name: cloud_controller
+      extended_key_usage:
+      - client_auth
+{{- end }}

--- a/deploy/helm/kubecf/assets/operations/instance_groups/eirini.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/eirini.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.features.eirini.enabled }}
+{{- if and .Values.features.eirini.enabled (not .Values.features.eirini.use_helm_release) }}
 
 # Add the eirini BOSH DNS alias.
 - type: replace

--- a/deploy/helm/kubecf/assets/operations/releases.yaml
+++ b/deploy/helm/kubecf/assets/operations/releases.yaml
@@ -69,7 +69,7 @@
     name: postgres
 {{- end }}
 
-{{- if .Values.features.eirini.enabled }}
+{{- if and .Values.features.eirini.enabled (not .Values.features.eirini.use_helm_release) }}
 {{- $releases = append $releases "bits-service" }}
 {{- $releases = append $releases "eirini" }}
 - type: replace

--- a/deploy/helm/kubecf/templates/azs.yaml
+++ b/deploy/helm/kubecf/templates/azs.yaml
@@ -47,7 +47,7 @@ data:
     - type: remove
       path: /instance_groups/name=tcp-router/azs?
 
-    {{- if .Values.features.eirini.enabled }}
+    {{- if and .Values.features.eirini.enabled (not .Values.features.eirini.use_helm_release) }}
     - type: remove
       path: /instance_groups/name=bits/azs?
     - type: remove

--- a/deploy/helm/kubecf/templates/bosh_deployment.yaml
+++ b/deploy/helm/kubecf/templates/bosh_deployment.yaml
@@ -44,7 +44,7 @@ spec:
   - name: {{ include "kubecf.ops-name" (dict "ReleaseName" $root.Release.Name "Path" $path) }}
     type: configmap
 {{- end }}
-{{- if or (.Values.features.eirini.enabled) }}
+{{- if .Values.features.eirini.enabled }}
   - name: {{ $root.Release.Name }}-ops-remove-diego
     type: configmap
 {{- end }}

--- a/deploy/helm/kubecf/templates/bosh_deployment.yaml
+++ b/deploy/helm/kubecf/templates/bosh_deployment.yaml
@@ -24,7 +24,7 @@ spec:
   - name: {{ include "kubecf.ops-name" (dict "ReleaseName" $root.Release.Name "Path" "assets/operations/buildpacks/set_suse_buildpacks.yaml") }}
     type: configmap
 {{- end }}
-{{- if .Values.features.eirini.enabled }}
+{{- if and .Values.features.eirini.enabled (not .Values.features.eirini.use_helm_release) }}
   - name: {{ $root.Release.Name }}-ops-use-bits-service
     type: configmap
 {{- end }}
@@ -44,7 +44,7 @@ spec:
   - name: {{ include "kubecf.ops-name" (dict "ReleaseName" $root.Release.Name "Path" $path) }}
     type: configmap
 {{- end }}
-{{- if .Values.features.eirini.enabled }}
+{{- if or (.Values.features.eirini.enabled) }}
   - name: {{ $root.Release.Name }}-ops-remove-diego
     type: configmap
 {{- end }}

--- a/deploy/helm/kubecf/templates/eirini.yaml
+++ b/deploy/helm/kubecf/templates/eirini.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.features.eirini.enabled }}
+{{- if and .Values.features.eirini.enabled (not .Values.features.eirini.use_helm_release) }}
 
 # eirini-webhook cluster role for eirini service account.
 # Used to implement eirinix extensions.

--- a/deploy/helm/kubecf/templates/eirini.yaml
+++ b/deploy/helm/kubecf/templates/eirini.yaml
@@ -151,36 +151,4 @@ subjects:
   - kind: ServiceAccount
     name: {{ .Release.Name }}-eirini
     namespace: {{ .Release.Namespace | quote }}
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: {{ .Release.Name }}-ops-remove-diego
-  namespace: {{ .Release.Namespace | quote }}
-  labels:
-    app.kubernetes.io/component: operations
-    app.kubernetes.io/instance: {{ .Release.Name | quote }}
-    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/name: {{ include "kubecf.fullname" . }}
-    app.kubernetes.io/version: {{ default .Chart.Version .Chart.AppVersion | quote }}
-    helm.sh/chart: {{ include "kubecf.chart" . }}
-data:
-  ops: |
-    # Remove the whole diego-cell instance group.
-    - type: remove
-      path: /instance_groups/name=diego-cell
-
-    # Remove bbs from diego-api.
-    # TODO: remove bbs in the future - when the clock and worker no longer need it.
-    # - type: remove
-    #   path: /instance_groups/name=diego-api/jobs/name=bbs
-
-    # Remove auctioneer, tps and ssh_proxy from scheduler.
-    - type: remove
-      path: /instance_groups/name=auctioneer
-    - type: remove
-      path: /instance_groups/name=scheduler/jobs/name=tps
-    - type: remove
-      path: /instance_groups/name=scheduler/jobs/name=ssh_proxy
-
 {{- end }}

--- a/deploy/helm/kubecf/templates/ops-remove-diego.yaml
+++ b/deploy/helm/kubecf/templates/ops-remove-diego.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.features.eirini.use_helm_release }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-ops-remove-diego
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app.kubernetes.io/component: operations
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: {{ include "kubecf.fullname" . }}
+    app.kubernetes.io/version: {{ default .Chart.Version .Chart.AppVersion | quote }}
+    helm.sh/chart: {{ include "kubecf.chart" . }}
+data:
+  ops: |
+    # Remove the whole diego-cell instance group.
+    - type: remove
+      path: /instance_groups/name=diego-cell
+
+    # Remove bbs from diego-api.
+    # TODO: remove bbs in the future - when the clock and worker no longer need it.
+    # - type: remove
+    #   path: /instance_groups/name=diego-api/jobs/name=bbs
+
+    # Remove auctioneer, tps and ssh_proxy from scheduler.
+    - type: remove
+      path: /instance_groups/name=auctioneer
+    - type: remove
+      path: /instance_groups/name=scheduler/jobs/name=tps
+    - type: remove
+      path: /instance_groups/name=scheduler/jobs/name=ssh_proxy
+{{- end }}

--- a/deploy/helm/kubecf/templates/ops-remove-diego.yaml
+++ b/deploy/helm/kubecf/templates/ops-remove-diego.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.features.eirini.use_helm_release }}
+{{- if .Values.features.eirini.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/deploy/helm/kubecf/templates/ops-use-bits-service.yaml
+++ b/deploy/helm/kubecf/templates/ops-use-bits-service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.features.eirini.enabled }}
+{{- if and .Values.features.eirini.enabled (not .Values.features.eirini.use_helm_release) }}
 
 apiVersion: v1
 kind: ConfigMap

--- a/deploy/helm/kubecf/templates/sizing.yaml
+++ b/deploy/helm/kubecf/templates/sizing.yaml
@@ -43,7 +43,7 @@ data:
     {{- end }}{{/* if credhub */}}
 
     {{- /* Instances groups where existance depends on whether Eirini is enabled */}}
-    {{- if .Values.features.eirini.enabled }}
+    {{- if and .Values.features.eirini.enabled (not .Values.features.eirini.use_helm_release) }}
     {{- $instance_groups = append $instance_groups "bits" }}
     {{- $instance_groups = append $instance_groups "eirini" }}
     {{- else }}

--- a/deploy/helm/kubecf/values.yaml
+++ b/deploy/helm/kubecf/values.yaml
@@ -215,6 +215,7 @@ services:
 features:
   eirini:
     enabled: false
+    use_helm_release: false
     registry:
       service:
         nodePort: 32123


### PR DESCRIPTION
"Native" Eirini here means the standalone Helm Chart that the official Eirini team provides to deploy Eirini along a CF on Kubernetes.

## Description

We added additional Helm charts and ops files to the helm release. These files disable Diego and set all the required Eirini properties as well as required certificates.

What this PR does not include is the copy of required certificates from the KubeCF to the Eirini apps namespace.

In Eirini we used to have a job (called "secret-smuggler") for SCF which does this, but as this is not a generic approach for different CF deployments on top of Kubernetes (eg CF-for-K8s) we decided to remove it completely and let whoever is consuming Eirini handle this. We don't have enough context on KubeCF on how to do it in a native way, so if you have any suggestions let us know. If it turns out to be a manual step, it should be documented somewhere.

These changes will work with the upcoming Eirini-Release (~v1.4.0) or with any eirini-release branch containing the following commits: 
https://github.com/cloudfoundry-incubator/eirini-release/commit/711df88387e401bd08d8432d0e3b25b3eff992b3 and https://github.com/cloudfoundry-incubator/eirini-release/commit/609640ad43009dec187d59cd1e4f367771e7d2ff

## Motivation and Context
The eirini-bosh-release is not supported by the official Eirini team (or not supported at all). So in order to consume the latest-and-greatest Eirini, using our Helm-Chart is the way. 

## How Has This Been Tested?
We deployed it with KubeCF version `0.2.0-1ed5484`, CF-Operator version `v2.0.0-0` on IKS. We ran the set of CF-CATs that Eirini usually runs successfully.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code has security implications.
- [ x ] My code follows the code style of this project.
- [ x ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

Thx to @HeavyWombat for helping us on this!

/cc @gdankov