### PR TITLE
feat: cf_operator: allow values overrides

### DIFF
--- a/dev/cf_operator/.gitignore
+++ b/dev/cf_operator/.gitignore
@@ -1,0 +1,1 @@
+*values.yaml

--- a/dev/cf_operator/BUILD.bazel
+++ b/dev/cf_operator/BUILD.bazel
@@ -18,6 +18,7 @@ helm_upgrade(
     set_values = {
         "global.operator.watchNamespace": project.namespace,
     },
+    values = glob(["**/*values.yaml"]),
     reset_values = True,
 )
 

--- a/dev/cf_operator/README.md
+++ b/dev/cf_operator/README.md
@@ -1,0 +1,11 @@
+# cf-operator
+
+The target defined in directory `dev/cf_operator` is used to install
+[cf-operator] to a Kubernetes cluster.
+
+__Attention__: While any files matching the glob pattern `*values.yaml` and
+found in this directory are ignored by git, they are used by Bazel to install
+the [cf-operator chart].
+
+[cf-operator]: https://github.com/cloudfoundry-incubator/cf-operator
+[cf-operator chart]: https://hub.helm.sh/charts/quarks/cf-operator


### PR DESCRIPTION
## Description

This makes the `cf-operator` deployment match that of the `kubecf` deployment, such that we can place `*values.yaml` files in `/dev/cf_operator` to customize the settings there.

We will also (by default) ignore all such files in git.

By default this has no effect (as there are no such files).

## Motivation and Context
I wanted to be able to locally modify the cf-operator deployment.

## How Has This Been Tested?
Deployed locally.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
