### PR TITLE
fix: release versioning

### DIFF
--- a/rules/helm/def.bzl
+++ b/rules/helm/def.bzl
@@ -15,6 +15,7 @@ def _package_impl(ctx):
             "[[multipath_sep]]": multipath_sep,
             "[[tars]]": multipath_sep.join([f.path for f in ctx.files.tars]),
             "[[generated]]": multipath_sep.join([f.path for f in ctx.files.generated]),
+            "[[version]]": ctx.attr.version,
             "[[helm]]": ctx.executable._helm.path,
             "[[output_tgz]]": output_tgz.path,
         },
@@ -38,6 +39,10 @@ _package = rule(
         "tars": attr.label_list(),
         "package_dir": attr.string(
             mandatory = True,
+        ),
+        "version": attr.string(
+            mandatory = False,
+            default = "",
         ),
         "_helm": attr.label(
             allow_single_file = True,

--- a/rules/helm/package.tmpl.rb
+++ b/rules/helm/package.tmpl.rb
@@ -7,12 +7,12 @@ package_dir = "[[package_dir]]"
 multipath_sep = "[[multipath_sep]]"
 tarsStr = "[[tars]]"
 generatedStr = "[[generated]]"
+version = "[[version]]"
 helm = "[[helm]]"
 output_tgz = "[[output_tgz]]"
 
 # Variables expanded by gomplate.
 git_commit_short = '{{ (ds "workspace_status").STABLE_GIT_COMMIT_SHORT }}'
-git_branch = '{{ (ds "workspace_status").STABLE_GIT_BRANCH }}'
 
 # Create the temporary build directory for joining all the pieces required for packaging.
 tmp_build_dir = Dir.mktmpdir("build-", Dir.getwd)
@@ -47,15 +47,12 @@ begin
     FileUtils.cp(file, build_dir)
   end
 
-  # Handle chart versioning based on git state.
-  version = "v0.0.0-#{git_commit_short}"
-
   # A semver that matches what Helm uses.
   # https://github.com/Masterminds/semver/blob/910aa146bd66780c2815d652b92a7fc5331e533c/version.go#L41-L43
   semver_regex = /^v?([0-9]+)(\.[0-9]+)?(\.[0-9]+)?(-([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?(\+([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?$/
-  if git_branch.match(semver_regex)
-    version = git_branch
-  end
+
+  # Handle chart versioning based on git state if version doesn't match semver.
+  version = "v0.0.0-#{git_commit_short}" unless version.match(semver_regex)
 
   # Package and return the output path.
   package_cmd = <<-EOS


### PR DESCRIPTION
Using the branch name for automatic release versioning doesn't work well
with all CIs. It showed true for Concourse during release 1.0.0.

This new approach allows specifying a version to the packaging target.
If the version is not provided, the chart is versioned as it was before.
