### PR TITLE
Consume Eirini & Bits service as subcharts

### DIFF
--- a/deploy/helm/kubecf/requirements.lock
+++ b/deploy/helm/kubecf/requirements.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: eirini
+  repository: https://cloudfoundry-incubator.github.io/eirini-release
+  version: 1.4.0
+- name: bits
+  repository: https://cloudfoundry-incubator.github.io/bits-service-release/helm
+  version: 2.36.0
+digest: sha256:9f535241dbcb0c0f90b6c7f1d4c40cdaca408c3726cf1f79fb44915d1cfe9897
+generated: "2020-03-12T10:16:58.725936+02:00"

--- a/deploy/helm/kubecf/requirements.yaml
+++ b/deploy/helm/kubecf/requirements.yaml
@@ -1,0 +1,9 @@
+dependencies:
+  - name: eirini
+    version: 1.4.0
+    repository: https://cloudfoundry-incubator.github.io/eirini-release
+    condition: features.eirini.use_helm_release
+  - name: bits
+    version: 2.36.0
+    repository: https://cloudfoundry-incubator.github.io/bits-service-release/helm
+    condition: features.eirini.use_helm_release

--- a/deploy/helm/kubecf/values.yaml
+++ b/deploy/helm/kubecf/values.yaml
@@ -237,6 +237,7 @@ settings:
 features:
   eirini:
     enabled: false
+    use_helm_release: false
     registry:
       service:
         nodePort: 32123
@@ -328,3 +329,124 @@ k8s-host-url: ""
 k8s-service-token: ""
 k8s-service-username: ""
 k8s-node-ca: ""
+
+eirini:
+  opi:
+    use_registry_ingress: false
+    ingress_endpoint: ~
+    kube:
+      external_ips: []
+    services:
+      loadbalanced: false
+
+    deny_app_ingress: false
+
+    cc_api:
+      serviceName: "kubecf-api"
+
+    staging:
+      enable: true
+      tls:
+        client:
+          secretName: "kubecf.var-eirini-tls-client-cert"
+          certPath: "certificate"
+          keyPath: "private_key"
+        cc_uploader:
+          secretName: "kubecf.var-cc-bridge-cc-uploader"
+          certPath: "certificate"
+          keyPath: "private_key"
+        ca:
+          secretName: "kubecf.var-eirini-tls-client-cert"
+          path: "ca"
+        stagingReporter:
+          secretName: "kubecf.var-eirini-tls-client-cert"
+          certPath: "certificate"
+          keyPath: "private_key"
+          caPath: "ca"
+
+    tls:
+      opiCapiClient:
+        secretName: "kubecf.var-eirini-tls-client-cert"
+        keyPath: "private_key"
+        certPath: "certificate"
+      opiServer:
+        secretName: "kubecf.var-eirini-tls-server-cert"
+        certPath: "certificate"
+        keyPath: "private_key"
+      capi:
+        secretName: "kubecf.var-eirini-tls-server-cert"
+        caPath: "ca"
+      eirini:
+        secretName: "kubecf.var-eirini-tls-server-cert"
+        caPath: "ca"
+
+    events:
+      enable: true
+      tls:
+        capiClient:
+          secretName: "kubecf.var-cc-tls"
+          keyPath: "private_key"
+          certPath: "certificate"
+        capi:
+          secretName: "kubecf.var-cc-tls"
+          caPath: "ca"
+
+    logs:
+      enable: true
+      serviceName: "kubecf-doppler"
+      tls:
+        client:
+          secretName: "kubecf.var-loggregator-tls-agent"
+          keyPath: "private_key"
+          certPath: "certificate"
+        server:
+          secretName: "kubecf.var-loggregator-tls-agent"
+          caPath: "ca"
+
+    metrics:
+      enable: true
+      tls:
+        client:
+          secretName: "kubecf.var-loggregator-tls-doppler"
+          keyPath: "private_key"
+          certPath: "certificate"
+        server:
+          secretName: "kubecf.var-loggregator-tls-doppler"
+          caPath: "ca"
+
+    rootfsPatcher:
+      enable: true
+      timeout: 2m
+
+    routing:
+      enable: true
+      nats:
+        secretName: "kubecf.var-nats-password"
+        passwordPath: "password"
+        serviceName: "kubecf-nats"
+
+    secretSmuggler:
+      enable: false
+
+bits:
+  env:
+    DOMAIN: ~
+  ingress:
+    endpoint: ~
+    use: false
+  kube:
+    external_ips: []
+  services:
+    loadbalanced: false
+
+  blobstore:
+    serviceName: "kubecf-singleton-blobstore"
+    userName: "blobstore-user"
+    secret:
+      name: "kubecf.var-blobstore-admin-users-password"
+      passwordPath: "password"
+  
+  secrets:
+    BITS_SERVICE_SECRET: ~
+    BITS_SERVICE_SIGNING_USER_PASSWORD: ~
+


### PR DESCRIPTION
## Description
This PR adds Eirini and Bits service as conditional sub-charts to kubecf. These sub-charts will only be installed if the property `features.eirini_native.enabled` is set to `true`.

This PR should be merged after #465

## Motivation and Context
See #465 

## How Has This Been Tested?
We deployed a patched kubecf that includes these changes (based on version `0.2.0`) and cf-operator version `2.0.0` on IKS.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.


/cc @herrjulz