### PR TITLE
Use pxc image from the cfcontainerization org

### DIFF
--- a/deploy/helm/kubecf/values.yaml
+++ b/deploy/helm/kubecf/values.yaml
@@ -56,7 +56,7 @@ releases:
   # pxc is not a BOSH release.
   pxc:
     image:
-      repository: "splatform/pxc"
+      repository: "cfcontainerization/pxc"
       tag: 0.9.4
   eirini:
     version: 0.0.25


### PR DESCRIPTION
The pxc image lives in the cfcontainerization org like all the other images now.