### PR TITLE
CI: Bump catapult version to latest

### DIFF
--- a/.concourse/pipeline.yaml
+++ b/.concourse/pipeline.yaml
@@ -52,7 +52,7 @@ resources:
   source:
     uri: https://github.com/SUSE/catapult
   version:
-    ref: 7eea74f5cab3386b65c08938b25811e99bb829ef
+    ref: 543bc71abc8bd22e5ef81fdf94a7afeb2f99066d
 
 - name: s3.kubecf-ci
   type: s3

--- a/testing/ccdb_key_rotation/rotate-ccdb-keys-test.sh
+++ b/testing/ccdb_key_rotation/rotate-ccdb-keys-test.sh
@@ -218,7 +218,7 @@ echo Trigger rotation ...
 echo
 
 # Trigger the actual rotation of the keys
-kubectl patch qjob kubecf-rotate-cc-database-key \
+kubectl patch qjob "${KUBECF_INSTALL_NAME}-rotate-cc-database-key" \
   --namespace "${KUBECF_NAMESPACE}" \
   --type merge \
   --patch '{"spec":{"trigger":{"strategy":"now"}}}'


### PR DESCRIPTION
- Bump Catapult version to latest to include brain tests fixes https://github.com/SUSE/catapult/commit/543bc71abc8bd22e5ef81fdf94a7afeb2f99066d
- Fixes a leftover from the rotation test that hardcodes the deployment name, while there is a variable for it to consume