### PR TITLE
fix: auto-delete database-seeder pod

### DIFF
--- a/deploy/helm/kubecf/templates/database.yaml
+++ b/deploy/helm/kubecf/templates/database.yaml
@@ -355,6 +355,9 @@ spec:
   template:
     spec:
       template:
+        metadata:
+          labels:
+            delete: pod
         spec:
           containers:
           - name: seeder


### PR DESCRIPTION
## Description

Fixes https://github.com/cloudfoundry-incubator/kubecf/issues/439.

Reference: https://github.com/cloudfoundry-incubator/cf-operator/pull/173.

## Motivation and Context

Upon completion and success, the database-seeder job pod was left behind even after KubeCF helm installation was removed. This PR fixes this.

## How Has This Been Tested?

Deployed KubeCF and asserted that the QuarksJob controller deleted the pod upon completion.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
