### PR TITLE
fix: cf-operator bundled with KubeCF

### DIFF
--- a/deploy/bundle/BUILD.bazel
+++ b/deploy/bundle/BUILD.bazel
@@ -1,11 +1,10 @@
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
-load("//:def.bzl", "project")
 
 copy_file(
     name = "cf_operator_chart",
     src = "@cf_operator//file",
-    out = project.external_files['cf_operator'].urls[0].rpartition("/")[-1],
+    out = "cf-operator.tgz",
 )
 
 pkg_tar(


### PR DESCRIPTION
## Description

The cf-operator file in the bundle had the wrong naming pattern after
the refactoring of how the external files are handled. Now, the
cf-operator and KubeCF chart files in the bundle have predictable names.

The files in the bundle:
- cf-operator.tgz
- kubecf.tgz

## How Has This Been Tested?

Built the bundle and verified the cf-operator and kubecf charts with `helm inspect`.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
