### PR TITLE
fix: disable brain tests on CI

### DIFF
--- a/.concourse/pipeline.yaml
+++ b/.concourse/pipeline.yaml
@@ -1262,7 +1262,7 @@ jobs:
   - get: commit-to-test
     passed:
     # - smoke-tests-post-rotate-eirini
-    - brain-tests-eirini
+    - smoke-tests-eirini
     trigger: true
     version: "every"
   - task: cleanup-cluster


### PR DESCRIPTION
The updates to `cleanup-eirini-cluster` were left behind. This PR fixes it.
This is a follow-up on https://github.com/cloudfoundry-incubator/kubecf/pull/497.