### PR TITLE
Extend cipher suite for gorouter

### DIFF
--- a/deploy/helm/kubecf/assets/operations/instance_groups/router.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/router.yaml
@@ -45,6 +45,19 @@
   path: /instance_groups/name=router/env?/bosh/agent/settings/labels/app.kubernetes.io~1version
   value: {{ default .Chart.Version .Chart.AppVersion | quote }}
 
+# Update cipher suites based on https://wiki.mozilla.org/Security/Server_Side_TLS#Recommended_configurations
+- type: replace
+  path: /instance_groups/name=router/jobs/name=gorouter/properties/router/cipher_suites?
+  value: "\
+    ECDHE-ECDSA-CHACHA20-POLY1305:\
+    ECDHE-RSA-CHACHA20-POLY1305:\
+    ECDHE-ECDSA-AES128-GCM-SHA256:\
+    ECDHE-RSA-AES128-GCM-SHA256:\
+    ECDHE-ECDSA-AES256-GCM-SHA384:\
+    ECDHE-RSA-AES256-GCM-SHA384:\
+    AES128-GCM-SHA256:\
+    AES256-GCM-SHA384"
+
 # Trust the diego_instance_identity_ca certificate - trusting its CA
 # is insufficient with the cf-operator
 # Also add the CredHub CA


### PR DESCRIPTION
This is required for certain load balancers on public cloud to work correctly (e.g. ELB on EKS). See also https://github.com/SUSE/scf/pull/3179

Ciphers were selected based on recommendation from https://wiki.mozilla.org/Security/Server_Side_TLS#Recommended_configurations

## How Has This Been Tested?

I've tested the change with both `sslscan` and directly via `openssl`, and see (some of) the new ciphers. Output from an alpha version of sslscan 2.0 (to use openssl 1.1 instead of 1.0.2 in the release version) shows:

```
  Supported Server Cipher(s):
Preferred TLSv1.2  256 bits  ECDHE-RSA-AES256-GCM-SHA384   Curve 25519 DHE 253
Accepted  TLSv1.2  256 bits  ECDHE-RSA-CHACHA20-POLY1305   Curve 25519 DHE 253
Accepted  TLSv1.2  128 bits  ECDHE-RSA-AES128-GCM-SHA256   Curve 25519 DHE 253
Accepted  TLSv1.2  256 bits  AES256-GCM-SHA384
Accepted  TLSv1.2  128 bits  AES128-GCM-SHA256
```

None of the `ECDHE_ECDSA_*` ciphers are reported as being supported. Checking manually via `openssl` shows an error:

```
$ echo -n | openssl s_client -cipher ECDHE-ECDSA-CHACHA20-POLY1305 -connect api.192.168.99.121.xip.io:443
CONNECTED(00000005)
4349615552:error:14094410:SSL routines:ssl3_read_bytes:sslv3 alert handshake failure:ssl/record/rec_layer_s3.c:1544:SSL alert number 40
...
```

I don't know why this happens, but I have verified that all specified ciphers are spelled correctly (unknown cipher names throw an error), so any potential issue with them would be in the gorouter implementation, and not in the property specification, so outside the scope of this PR.