### PR TITLE
Downgrade java buildpack

### DIFF
--- a/deploy/helm/kubecf/values.yaml
+++ b/deploy/helm/kubecf/values.yaml
@@ -83,7 +83,7 @@ releases:
     version: "4.27.0.1"
     stemcell:
       os: SLE_15_SP1
-      version: 23.15-7.0.0_374.gb8e8e6af
+      version: 23.7-7.0.0_374.gb8e8e6af
     file: suse-java-buildpack/packages/java-buildpack-sle15/java-buildpack-v4.28.0.1-b417824c.zip
   suse-ruby-buildpack:
     url: registry.suse.com/cap-staging


### PR DESCRIPTION
The docker image release is not yet published, and this blocks
KubeCF deployments.

## Description
` spec-copier-suse-java-buildpack         registry.suse.com/cap-staging/suse-java-buildpack:SLE_15_SP1-23.15-7.0.0_374.gb8e8e6af-4.27.0.1       false  ImagePullBackOff   0 off:off     n/a `


## Motivation and Context
Can't deploy anymore KubeCF, It's blocking me to work on other issues. Not meant to merge if there is a proper fix, but feel free to merge to get master back to green

## How Has This Been Tested?
Wait for CI runs

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
