### PR TITLE
Print image list script for kubecf manifest

### DIFF
--- a/dev/kubecf/fetchImageList.sh
+++ b/dev/kubecf/fetchImageList.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+set -eu
+
+if [ "$#" -ne 2 ]; then
+  echo "Usage: $0 <HELM_TEMPLATE_FILE> <VALUES_FILE>"
+  echo ""
+  echo "Example: $0 output.yaml values.yaml"
+  exit 1
+fi
+
+manifestIdentifyString="# Source: kubecf/templates/cf_deployment.yaml"
+variableIdentifyString="# Source: kubecf/templates/implicit_vars.yaml"
+qjobName="QuarksJob"
+
+# Count the number of yaml blocks
+yamlFileCount=$(grep -c "# Source: kubecf/templates/" "$1")
+yamlFileCount=$((yamlFileCount - 1))
+
+# Fetch manifest file
+for fileIndex in $(seq 0 "$yamlFileCount")
+do
+    yamlOutput=$(yq r -d"$fileIndex" "$1")
+    if [[ $yamlOutput =~ $manifestIdentifyString ]]
+    then
+        yq r -d"$fileIndex" "$1" data.manifest > manifest.yaml
+    fi
+done
+
+## Interpolate ops files
+for fileIndex in $(seq 0 "$yamlFileCount")
+do
+	yamlOutput=$(yq r -d"$fileIndex" "$1" data.ops)
+    if [ -n "$yamlOutput" ]
+    then
+        yq r -d"$fileIndex" "$1" data.ops > ops"$fileIndex".yaml
+        bosh interpolate manifest.yaml --ops-file ops"$fileIndex".yaml > manifest"$fileIndex".yaml
+        cp manifest"$fileIndex".yaml manifest.yaml
+        
+        rm ops"$fileIndex".yaml
+        rm manifest"$fileIndex".yaml
+    fi
+done
+
+## Interpolate implicit variables
+for fileIndex in $(seq 0 "$yamlFileCount")
+do
+	yamlOutput=$(yq r -d"$fileIndex" "$1")
+    if [[ $yamlOutput =~ $variableIdentifyString ]]
+    then
+        key=$(yq r -d"$fileIndex" "$1" metadata.name)
+        key=$(cut -d '-' -f2- <<< "$key")
+        key=${key//-/_}
+        value=$(yq r -d"$fileIndex" "$1" stringData.value)
+        if [ -n "$value" ]
+        then
+            bosh interpolate manifest.yaml -v "$key"="$value" > manifest"$fileIndex".yaml
+            cp manifest"$fileIndex".yaml manifest.yaml
+            
+            rm manifest"$fileIndex".yaml
+        fi
+    fi
+done
+
+# Print image info from kube manifest
+imageCount=$(yq r manifest.yaml --length releases)
+for imageIndex in $(seq 0 "$imageCount")
+do
+    value=$(yq r manifest.yaml releases["$imageIndex"].stemcell)
+    if [ -n "$value" ]
+    then 
+        imageName=$(yq r manifest.yaml releases["$imageIndex"].name)
+        imageUrl=$(yq r manifest.yaml releases["$imageIndex"].url)
+        imageOS=$(yq r manifest.yaml releases["$imageIndex"].stemcell.os)
+        imageStemcellVersion=$(yq r manifest.yaml releases["$imageIndex"].stemcell.version)
+        imageVersion=$(yq r manifest.yaml releases["$imageIndex"].version)
+    
+        imageElement="${imageUrl}/${imageName}:${imageOS}-${imageStemcellVersion}-${imageVersion}"
+        echo "$imageElement"
+    fi
+done
+
+# Print image info from QuarksJob
+for fileIndex in $(seq 0 "$yamlFileCount")
+do
+    data=$(yq r -d"$fileIndex" "$1" kind)
+    if [[ $data == "$qjobName" ]]
+    then
+        containersCount=$(yq r -d"$fileIndex" "$1" --length spec.template.spec.template.spec.containers)
+        containersCount=$((containersCount - 1))
+        for containerIndex in $(seq 0 "$containersCount")
+        do 
+            imageName=$(yq r -d"$fileIndex" "$1" spec.template.spec.template.spec.containers["$containerIndex"].image)
+            echo "$imageName"
+        done
+    fi
+done


### PR DESCRIPTION
This bash script prints the list of images used in the kubecf manifest after interpolation of ops files and implicit variables.

## How Has This Been Tested?
locally.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
