### PR TITLE
CI: Use pool system for the pipeline

### DIFF
--- a/.concourse/README.md
+++ b/.concourse/README.md
@@ -54,6 +54,24 @@ command and use the `fly` script that you can find in this directory:
 ./fly -t target set-pipeline -p kubecf
 ```
 
+## Pool for the pipeline
+
+The kubecf pipeline is using the [concourse pool
+resource](https://github.com/concourse/pool-resource) to obtain k8s clusters
+for running the jobs. Once used, the clusters are destroyed from EKCP and
+removed from the pool by the kubecf pipeline itself as needed.
+
+There is an additional pipeline "kubecf-pool-reconciler" that automatically
+creates k8s clusters and adds them to the pool, up to the specificied maximum
+number of clusters.
+
+To deployed the kubecf-pool-reconciler pipeline do:
+
+```
+fly -t suse.dev set-pipeline -p kubecf-pool-reconciler --config <(gomplate -V -f kubecf-pool-reconciler.yaml.gomplate)
+```
+
+
 ## Pipeline development
 
 If you wish to deploy a copy of this pipeline without publishing artifacts to

--- a/.concourse/fly
+++ b/.concourse/fly
@@ -5,14 +5,16 @@
 #
 # E.g. ./fly -t target set-pipeline -p kubecf
 
+set -Eeuo pipefail
+
 if ! hash gomplate 2>/dev/null;then
   echo "gomplate missing. Follow the instructions in https://docs.gomplate.ca/installing/ and install it first."
   exit 1
 fi
 
 if [[ -f config.yaml ]]; then
-    exec fly ${@} --config <(gomplate -V -c .=config.yaml -f pipeline.yaml.gomplate)
+    fly ${@} --config <(gomplate -V -c .=config.yaml -f pipeline.yaml.gomplate)
 else
-    exec fly ${@} --config <(gomplate -V -f pipeline.yaml.gomplate)
+    fly ${@} --config <(gomplate -V -f pipeline.yaml.gomplate)
 fi
 

--- a/.concourse/kubecf-pool-reconciler.yaml.gomplate
+++ b/.concourse/kubecf-pool-reconciler.yaml.gomplate
@@ -1,4 +1,4 @@
-{{ $kind_pool_size := 2 }}
+{{ $kind_pool_size := 5 }}
 
 resources:
 - name: kind-environments
@@ -66,4 +66,3 @@ jobs:
         args: *deploy_args
   - put: kind-environments
     params: {add: output}
-

--- a/.concourse/kubecf-pool-reconciler.yaml.gomplate
+++ b/.concourse/kubecf-pool-reconciler.yaml.gomplate
@@ -1,3 +1,5 @@
+{{ $kind_pool_size := 2 }}
+
 resources:
 - name: kind-environments
   type: pool
@@ -16,14 +18,14 @@ resources:
 
 
 deploy_args: &deploy_args
-- -xce
+- -ce
 - |
   export FORCE_DELETE=true
   export BACKEND=ekcp
   export QUIET_OUTPUT=true
   export CLUSTER_NAME="$CLUSTER_PREFIX-$(date +%s | sha256sum | base64 | head -c 32 ; echo)"
   CURRENT_CLUSTERS=$(ls kind-environments/kind/**/* | grep -v .keep | wc -l)
-  if [ $CURRENT_CLUSTERS -lt 2 ]; then
+  if [ $CURRENT_CLUSTERS -lt {{ $kind_pool_size }} ]; then
 
   pushd catapult
   make k8s

--- a/.concourse/kubecf-pool-reconciler.yaml.gomplate
+++ b/.concourse/kubecf-pool-reconciler.yaml.gomplate
@@ -25,10 +25,10 @@ deploy_args: &deploy_args
   export QUIET_OUTPUT=true
   export CLUSTER_NAME="$CLUSTER_PREFIX-$(date +%s | sha256sum | base64 | head -c 32 ; echo)"
   CURRENT_CLUSTERS=$(ls kind-environments/kind/**/* | grep -v .keep | wc -l)
-  if [ $CURRENT_CLUSTERS -lt {{ $kind_pool_size }} ]; then
 
-  pushd catapult
-  make k8s
+  if [ $CURRENT_CLUSTERS -lt {{ $kind_pool_size }} ]; then
+    pushd catapult
+    make k8s
   else
     echo "No resources to add"
     exit 0

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -29,7 +29,7 @@ resources:
   type: concourse-git-queue
   source:
     bucket: {{ if has . "s3_bucket" }}{{ .s3_bucket }}{{ else }}kubecf-ci{{ end }}
-    bucket_subfolder: build-queue
+    bucket_subfolder: {{ if has . "s3_bucket_folder" }}{{ .s3_bucket_folder }}{{ else }}build-queue{{ end }}
     aws_access_key_id: ((aws-access-key))
     aws_secret_access_key: ((aws-secret-key))
     access_token: ((github-access-token))
@@ -175,7 +175,7 @@ jobs:
       - name: output
       params:
         GITHUB_ACCESS_TOKEN: ((github-access-token))
-        REPO: "cloudfoundry-incubator/kubecf"
+        REPO: {{ if has . "kubecf_repository" }}{{ .kubecf_repository }}{{ else }}{{ "cloudfoundry-incubator/kubecf" }}{{ end }}
       run:
         path: "/bin/bash"
         args:
@@ -195,6 +195,7 @@ jobs:
         smoke-rotated-eirini,acceptance-eirini,sync-integration-tests-diego,brain-tests-diego
       trigger: "PR"
       metadata_path: "kubecf-pr/.git/resource/url"
+      github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
 - name: queue-fork-pr
   public: true
   plan:
@@ -217,7 +218,7 @@ jobs:
       - name: output
       params:
         GITHUB_ACCESS_TOKEN: ((github-access-token))
-        REPO: "cloudfoundry-incubator/kubecf"
+        REPO: {{ if has . "kubecf_repository" }}{{ .kubecf_repository }}{{ else }}{{ "cloudfoundry-incubator/kubecf" }}{{ end }}
       run:
         path: "/bin/bash"
         args:
@@ -235,6 +236,7 @@ jobs:
       state: "pending"
       trigger: "PR"
       metadata_path: "kubecf-fork-pr/.git/resource/url"
+      github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
 - name: queue-master
   public: true
   plan:
@@ -246,12 +248,13 @@ jobs:
     params:
       <<: *commit-status
       commit_path: "kubecf-master/.git/ref"
-      remote: "cloudfoundry-incubator/kubecf"
+      remote: {{ if has . "kubecf_repository" }}{{ .kubecf_repository }}{{ else }}{{ "cloudfoundry-incubator/kubecf" }}{{ end }}
       remote_path: ""
       description: "Queued"
       state: "pending"
       trigger: "master"
       metadata_path: ""
+      github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
 - name: lint
   public: true
   plan:
@@ -285,6 +288,7 @@ jobs:
         version_path: "commit-to-test/.git/resource/version"
         state: "success"
         contexts: "lint"
+        github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
     on_failure:
       put: commit-to-test
       params:
@@ -293,6 +297,7 @@ jobs:
         version_path: "commit-to-test/.git/resource/version"
         state: "failure"
         contexts: "lint"
+        github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
 - name: build
   public: false # TODO: public or not?
   plan:
@@ -328,6 +333,7 @@ jobs:
         version_path: "commit-to-test/.git/resource/version"
         state: "success"
         contexts: "build"
+        github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
     on_failure:
       do:
       - put: commit-to-test
@@ -337,6 +343,7 @@ jobs:
           contexts: "build"
           commit_path: "commit-to-test/.git/resource/ref"
           version_path: "commit-to-test/.git/resource/version"
+          github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
   - put: s3.kubecf-ci
     params:
       file: output/kubecf-v*.tgz

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -116,7 +116,7 @@ deploy_args: &deploy_args
   export FORCE_DELETE=true
   export HELM_VERSION="v3.1.1"
   export SCF_TESTGROUP=true
-  export BACKEND=kind
+  export BACKEND=imported
   export DOCKER_ORG=cap-staging
   export QUIET_OUTPUT=true
   export CLUSTER_NAME="$(cat kind-environments/name)"
@@ -124,13 +124,12 @@ deploy_args: &deploy_args
   pushd catapult
   # Bring up a k8s cluster and builds+deploy kubecf
   # https://github.com/SUSE/catapult/wiki/Build-and-run-SCF#build-and-run-kubecf
-  export KUBECFG=../kind-environments/metadata
   make kubeconfig scf
 
 test_args: &test_args
 - -xce
 - |
-  export BACKEND=kind
+  export BACKEND=imported
   export KUBECF_TEST_SUITE="${TEST_SUITE:-smokes}"
   export SCF_LOCAL="${PWD}/commit-to-test"
   export KUBECF_NAMESPACE="scf"
@@ -146,7 +145,7 @@ test_args: &test_args
 rotate_args: &rotate_args
 - -xce
 - |
-  export BACKEND=kind
+  export BACKEND=imported
   export KUBECF_NAMESPACE="scf"
   export CLUSTER_NAME="$(cat kind-environments/name)"
   export KUBECFG="$(readlink -f kind-environments/metadata)"
@@ -407,56 +406,61 @@ jobs:
       run:
         path: "/bin/bash"
         args: *deploy_args
-    on_success:
-      put: commit-to-test
+  on_success:
+    put: commit-to-test
+    params:
+      description: "Deploying with {{ $cfScheduler }} was successful"
+      state: "success"
+      commit_path: "commit-to-test/.git/resource/ref"
+      version_path: "commit-to-test/.git/resource/version"
+      contexts: "deploy-{{ $cfScheduler }}"
+      github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
+  on_failure:
+    do:
+    - put: commit-to-test
       params:
-        description: "Deploying with {{ $cfScheduler }} was successful"
-        state: "success"
+        description: "Deploying with {{ $cfScheduler }} failed"
         commit_path: "commit-to-test/.git/resource/ref"
         version_path: "commit-to-test/.git/resource/version"
+        state: "failure"
         contexts: "deploy-{{ $cfScheduler }}"
         github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
-    on_failure:
-      do:
-      - put: commit-to-test
+    - task: cleanup-cluster
+      config: &cleanup-cluster
+        platform: linux
+        image_resource:
+          type: registry-image
+          source:
+            repository: splatform/catapult
+        inputs:
+        - name: commit-to-test
+        - name: kind-environments
         params:
-          description: "Deploying with {{ $cfScheduler }} failed"
-          commit_path: "commit-to-test/.git/resource/ref"
-          version_path: "commit-to-test/.git/resource/version"
-          state: "failure"
-          contexts: "deploy-{{ $cfScheduler }}"
-          github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
-      - task: cleanup-cluster
-        config: &cleanup-cluster
-          platform: linux
-          image_resource:
-            type: registry-image
-            source:
-              repository: splatform/catapult
-          inputs:
-          - name: commit-to-test
-          - name: kind-environments
-          params:
-            CLUSTER_NAME_PREFIX: "kubecf-{{ $cfScheduler }}"
-            EKCP_HOST: ((ekcp-host))
-          run:
-            path: "/bin/bash"
-            args:
-            - -ce
-            - |
-              export CLUSTER_NAME="$(cat kind-environments/name)"
-              curl -X DELETE -s "http://${EKCP_HOST}/${CLUSTER_NAME}" | jq -r .Output
-      - put: kind-environments
-        params: { remove : kind-environments}
-    on_abort:
-      do:
-      - task: cleanup-cluster
-        config:
-          <<: *cleanup-cluster
-          params:
-            CLUSTER_NAME_PREFIX: "kubecf-{{ $cfScheduler }}"
-      - put: kind-environments
-        params: { remove : kind-environments}
+          CLUSTER_NAME_PREFIX: "kubecf-{{ $cfScheduler }}"
+          EKCP_HOST: ((ekcp-host))
+        run:
+          path: "/bin/bash"
+          args:
+          - -ce
+          - |
+            export CLUSTER_NAME="$(cat kind-environments/name)"
+            curl -X DELETE -s "http://${EKCP_HOST}/${CLUSTER_NAME}" | jq -r .Output
+    - put: kind-environments
+      params: { remove : kind-environments}
+  on_abort:
+    do:
+    - task: cleanup-cluster
+      config:
+        <<: *cleanup-cluster
+    - put: kind-environments
+      params: { remove : kind-environments}
+  on_error:
+    do:
+    - task: cleanup-cluster
+      config:
+        <<: *cleanup-cluster
+    - put: kind-environments
+      params: { remove : kind-environments}
 
 - name: smoke-tests-{{ $cfScheduler }}
   public: true
@@ -494,37 +498,44 @@ jobs:
       run:
         path: "/bin/bash"
         args: *test_args
-    on_success:
-      put: commit-to-test
+  on_success:
+    put: commit-to-test
+    params:
+      description: "Smoke tests on {{ $cfScheduler }} were successful"
+      state: "success"
+      commit_path: "commit-to-test/.git/resource/ref"
+      version_path: "commit-to-test/.git/resource/version"
+      contexts: "smoke-{{ $cfScheduler }}"
+      github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
+  on_failure:
+    do:
+    - put: commit-to-test
       params:
-        description: "Smoke tests on {{ $cfScheduler }} were successful"
-        state: "success"
+        description: "Smoke tests on {{ $cfScheduler }} failed"
         commit_path: "commit-to-test/.git/resource/ref"
         version_path: "commit-to-test/.git/resource/version"
+        state: "failure"
         contexts: "smoke-{{ $cfScheduler }}"
         github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
-    on_failure:
-      do:
-      - put: commit-to-test
-        params:
-          description: "Smoke tests on {{ $cfScheduler }} failed"
-          commit_path: "commit-to-test/.git/resource/ref"
-          version_path: "commit-to-test/.git/resource/version"
-          state: "failure"
-          contexts: "smoke-{{ $cfScheduler }}"
-          github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
-      - task: cleanup-cluster
-        config:
-          <<: *cleanup-cluster
-      - put: kind-environments
-        params: { remove : kind-environments}
-    on_abort:
-      do:
-      - task: cleanup-cluster
-        config:
-          <<: *cleanup-cluster
-      - put: kind-environments
-        params: { remove : kind-environments}
+    - task: cleanup-cluster
+      config:
+        <<: *cleanup-cluster
+    - put: kind-environments
+      params: { remove : kind-environments}
+  on_abort:
+    do:
+    - task: cleanup-cluster
+      config:
+        <<: *cleanup-cluster
+    - put: kind-environments
+      params: { remove : kind-environments}
+  on_error:
+    do:
+    - task: cleanup-cluster
+      config:
+        <<: *cleanup-cluster
+    - put: kind-environments
+      params: { remove : kind-environments}
 
 - name: ccdb-rotate-{{ $cfScheduler }}
   public: true
@@ -561,40 +572,47 @@ jobs:
       run:
         path: "/bin/bash"
         args: *rotate_args
-    on_success:
-      put: commit-to-test
+  on_success:
+    put: commit-to-test
+    params:
+      description: "Rotating secrets on {{ $cfScheduler }} was successful"
+      state: "success"
+      commit_path: "commit-to-test/.git/resource/ref"
+      version_path: "commit-to-test/.git/resource/version"
+      contexts: "rotate-{{ $cfScheduler }}"
+      github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
+  on_failure:
+    do:
+    - put: commit-to-test
       params:
-        description: "Rotating secrets on {{ $cfScheduler }} was successful"
-        state: "success"
+        description: "Rotating secrets on {{ $cfScheduler }} failed"
         commit_path: "commit-to-test/.git/resource/ref"
         version_path: "commit-to-test/.git/resource/version"
+        state: "failure"
         contexts: "rotate-{{ $cfScheduler }}"
         github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
-    on_failure:
-      do:
-      - put: commit-to-test
+    - task: cleanup-cluster
+      config:
+        <<: *cleanup-cluster
         params:
-          description: "Rotating secrets on {{ $cfScheduler }} failed"
-          commit_path: "commit-to-test/.git/resource/ref"
-          version_path: "commit-to-test/.git/resource/version"
-          state: "failure"
-          contexts: "rotate-{{ $cfScheduler }}"
-          github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
-      - task: cleanup-cluster
-        config:
-          <<: *cleanup-cluster
-          params:
-            CLUSTER_NAME_PREFIX: "kubecf-{{ $cfScheduler }}"
-            EKCP_HOST: ((ekcp-host))
-      - put: kind-environments
-        params: { remove : kind-environments}
-    on_abort:
-      do:
-      - task: cleanup-cluster
-        config:
-          <<: *cleanup-cluster
-      - put: kind-environments
-        params: { remove : kind-environments}
+          CLUSTER_NAME_PREFIX: "kubecf-{{ $cfScheduler }}"
+          EKCP_HOST: ((ekcp-host))
+    - put: kind-environments
+      params: { remove : kind-environments}
+  on_abort:
+    do:
+    - task: cleanup-cluster
+      config:
+        <<: *cleanup-cluster
+    - put: kind-environments
+      params: { remove : kind-environments}
+  on_error:
+    do:
+    - task: cleanup-cluster
+      config:
+        <<: *cleanup-cluster
+    - put: kind-environments
+      params: { remove : kind-environments}
 
 - name: smoke-tests-post-rotate-{{ $cfScheduler }}
   public: true
@@ -632,37 +650,44 @@ jobs:
       run:
         path: "/bin/bash"
         args: *test_args
-    on_success:
-      put: commit-to-test
+  on_success:
+    put: commit-to-test
+    params:
+      description: "Smoke tests on {{ $cfScheduler }} after rotating secrets was successful"
+      state: "success"
+      commit_path: "commit-to-test/.git/resource/ref"
+      version_path: "commit-to-test/.git/resource/version"
+      contexts: "smoke-rotated-{{ $cfScheduler }}"
+      github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
+  on_failure:
+    do:
+    - put: commit-to-test
       params:
-        description: "Smoke tests on {{ $cfScheduler }} after rotating secrets was successful"
-        state: "success"
+        description: "Smoke tests on {{ $cfScheduler }} after rotating secrets failed"
         commit_path: "commit-to-test/.git/resource/ref"
         version_path: "commit-to-test/.git/resource/version"
+        state: "failure"
         contexts: "smoke-rotated-{{ $cfScheduler }}"
         github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
-    on_failure:
-      do:
-      - put: commit-to-test
-        params:
-          description: "Smoke tests on {{ $cfScheduler }} after rotating secrets failed"
-          commit_path: "commit-to-test/.git/resource/ref"
-          version_path: "commit-to-test/.git/resource/version"
-          state: "failure"
-          contexts: "smoke-rotated-{{ $cfScheduler }}"
-          github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
-      - task: cleanup-cluster
-        config:
-          <<: *cleanup-cluster
-      - put: kind-environments
-        params: { remove : kind-environments}
-    on_abort:
-      do:
-      - task: cleanup-cluster
-        config:
-          <<: *cleanup-cluster
-      - put: kind-environments
-        params: { remove : kind-environments}
+    - task: cleanup-cluster
+      config:
+        <<: *cleanup-cluster
+    - put: kind-environments
+      params: { remove : kind-environments}
+  on_abort:
+    do:
+    - task: cleanup-cluster
+      config:
+        <<: *cleanup-cluster
+    - put: kind-environments
+      params: { remove : kind-environments}
+  on_error:
+    do:
+    - task: cleanup-cluster
+      config:
+        <<: *cleanup-cluster
+    - put: kind-environments
+      params: { remove : kind-environments}
 
 - name: sync-integration-tests-{{ $cfScheduler }}
   public: true
@@ -700,37 +725,44 @@ jobs:
       run:
         path: "/bin/bash"
         args: *test_args
-    on_success:
-      put: commit-to-test
+  on_success:
+    put: commit-to-test
+    params:
+      description: "Sync Integration tests on {{ $cfScheduler }} succeeded"
+      state: "success"
+      contexts: "sync-integration-tests-{{ $cfScheduler }}"
+      commit_path: "commit-to-test/.git/resource/ref"
+      version_path: "commit-to-test/.git/resource/version"
+      github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
+  on_failure:
+    do:
+    - put: commit-to-test
       params:
-        description: "Sync Integration tests on {{ $cfScheduler }} succeeded"
-        state: "success"
-        contexts: "sync-integration-tests-{{ $cfScheduler }}"
+        description: "Sync Integration tests on {{ $cfScheduler }} failed"
+        state: "failure"
         commit_path: "commit-to-test/.git/resource/ref"
         version_path: "commit-to-test/.git/resource/version"
+        contexts: "sync-integration-tests-{{ $cfScheduler }}"
         github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
-    on_failure:
-      do:
-      - put: commit-to-test
-        params:
-          description: "Sync Integration tests on {{ $cfScheduler }} failed"
-          state: "failure"
-          commit_path: "commit-to-test/.git/resource/ref"
-          version_path: "commit-to-test/.git/resource/version"
-          contexts: "sync-integration-tests-{{ $cfScheduler }}"
-          github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
-      - task: cleanup-cluster
-        config:
-          <<: *cleanup-cluster
-      - put: kind-environments
-        params: { remove : kind-environments}
-    on_abort:
-      do:
-      - task: cleanup-cluster
-        config:
-          <<: *cleanup-cluster
-      - put: kind-environments
-        params: { remove : kind-environments}
+    - task: cleanup-cluster
+      config:
+        <<: *cleanup-cluster
+    - put: kind-environments
+      params: { remove : kind-environments}
+  on_abort:
+    do:
+    - task: cleanup-cluster
+      config:
+        <<: *cleanup-cluster
+    - put: kind-environments
+      params: { remove : kind-environments}
+  on_error:
+    do:
+    - task: cleanup-cluster
+      config:
+        <<: *cleanup-cluster
+    - put: kind-environments
+      params: { remove : kind-environments}
 
 # TODO: re-enable once BRAIN tests are fixed.
 # - name: brain-tests-{{ $cfScheduler }}
@@ -837,37 +869,44 @@ jobs:
       run:
         path: "/bin/bash"
         args: *test_args
-    on_success:
-      put: commit-to-test
+  on_success:
+    put: commit-to-test
+    params:
+      description: "Acceptance tests on {{ $cfScheduler }} succeeded"
+      state: "success"
+      contexts: "acceptance-{{ $cfScheduler }}"
+      commit_path: "commit-to-test/.git/resource/ref"
+      version_path: "commit-to-test/.git/resource/version"
+      github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
+  on_failure:
+    do:
+    - put: commit-to-test
       params:
-        description: "Acceptance tests on {{ $cfScheduler }} succeeded"
-        state: "success"
-        contexts: "acceptance-{{ $cfScheduler }}"
+        description: "Acceptance tests on {{ $cfScheduler }} failed"
+        state: "failure"
         commit_path: "commit-to-test/.git/resource/ref"
         version_path: "commit-to-test/.git/resource/version"
+        contexts: "acceptance-{{ $cfScheduler }}"
         github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
-    on_failure:
-      do:
-      - put: commit-to-test
-        params:
-          description: "Acceptance tests on {{ $cfScheduler }} failed"
-          state: "failure"
-          commit_path: "commit-to-test/.git/resource/ref"
-          version_path: "commit-to-test/.git/resource/version"
-          contexts: "acceptance-{{ $cfScheduler }}"
-          github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
-      - task: cleanup-cluster
-        config:
-          <<: *cleanup-cluster
-      - put: kind-environments
-        params: { remove : kind-environments}
-    on_abort:
-      do:
-      - task: cleanup-cluster
-        config:
-          <<: *cleanup-cluster
-      - put: kind-environments
-        params: { remove : kind-environments}
+    - task: cleanup-cluster
+      config:
+        <<: *cleanup-cluster
+    - put: kind-environments
+      params: { remove : kind-environments}
+  on_abort:
+    do:
+    - task: cleanup-cluster
+      config:
+        <<: *cleanup-cluster
+    - put: kind-environments
+      params: { remove : kind-environments}
+  on_error:
+    do:
+    - task: cleanup-cluster
+      config:
+        <<: *cleanup-cluster
+    - put: kind-environments
+      params: { remove : kind-environments}
 
 - name: cleanup-{{ $cfScheduler }}-cluster
   public: true
@@ -877,13 +916,13 @@ jobs:
     - smoke-tests-post-rotate-{{ $cfScheduler }}
     trigger: true
     version: "every"
-  - task: cleanup-cluster
-    config:
-      <<: *cleanup-cluster
-      params:
-        CLUSTER_NAME_PREFIX: "kubecf-{{ $cfScheduler }}"
-  - put: kind-environments
-    params: { remove : kind-environments}
+  ensure:
+   do:
+   - task: cleanup-cluster
+     config:
+       <<: *cleanup-cluster
+   - put: kind-environments
+     params: { remove : kind-environments}
 
 {{ end }} # of range cfscheduler
 

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -353,7 +353,9 @@ jobs:
       file: output/kubecf-bundle-v*.tgz
       acl: public-read
 
-- name: deploy-diego
+{{- range $_, $cfScheduler := slice "diego" "eirini" }}
+
+- name: deploy-{{ $cfScheduler }}
   max_in_flight: 2
   public: true
   plan:
@@ -389,27 +391,29 @@ jobs:
         EKCP_HOST: ((ekcp-host))
         QUIET_OUTPUT: true
         ENABLE_EIRINI: false
-        CLUSTER_NAME_PREFIX: kubecf-diego
+        CLUSTER_NAME_PREFIX: kubecf-{{ $cfScheduler }}
       run:
         path: "/bin/bash"
         args: *deploy_args
     on_success:
       put: commit-to-test
       params:
-        description: "Deploying with Diego was successful"
+        description: "Deploying with {{ $cfScheduler }} was successful"
         state: "success"
         commit_path: "commit-to-test/.git/resource/ref"
         version_path: "commit-to-test/.git/resource/version"
-        contexts: "deploy-diego"
+        contexts: "deploy-{{ $cfScheduler }}"
+        github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
     on_failure:
       do:
       - put: commit-to-test
         params:
-          description: "Deploying with Diego failed"
+          description: "Deploying with {{ $cfScheduler }} failed"
           commit_path: "commit-to-test/.git/resource/ref"
           version_path: "commit-to-test/.git/resource/version"
           state: "failure"
-          contexts: "deploy-diego"
+          contexts: "deploy-{{ $cfScheduler }}"
+          github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
       - task: cleanup-cluster
         config: &cleanup-cluster
           platform: linux
@@ -421,7 +425,7 @@ jobs:
           - name: commit-to-test
           params:
             EKCP_HOST: ((ekcp-host))
-            CLUSTER_NAME_PREFIX: "kubecf-diego"
+            CLUSTER_NAME_PREFIX: "kubecf-{{ $cfScheduler }}"
           run:
             path: "/bin/bash"
             args:
@@ -435,25 +439,24 @@ jobs:
       config:
         <<: *cleanup-cluster
         params:
-          CLUSTER_NAME_PREFIX: "kubecf-diego"
-          EKCP_HOST: ((ekcp-host))
+          CLUSTER_NAME_PREFIX: "kubecf-{{ $cfScheduler }}"
 
-- name: smoke-tests-diego
+- name: smoke-tests-{{ $cfScheduler }}
   public: true
   plan:
   - get: commit-to-test
     passed:
-    - deploy-diego
+    - deploy-{{ $cfScheduler }}
     trigger: true
     version: "every"
   - get: s3.kubecf-ci
     passed:
-    - deploy-diego
+    - deploy-{{ $cfScheduler }}
   - get: s3.kubecf-ci-bundle
     passed:
-    - deploy-diego
+    - deploy-{{ $cfScheduler }}
   - get: catapult
-  - task: test-diego
+  - task: test-{{ $cfScheduler }}
     privileged: true
     timeout: 1h30m
     config:
@@ -471,57 +474,59 @@ jobs:
         DEFAULT_STACK: cflinuxfs3
         EKCP_HOST: ((ekcp-host))
         TEST_SUITE: smokes
-        CLUSTER_NAME_PREFIX: kubecf-diego
+        CLUSTER_NAME_PREFIX: kubecf-{{ $cfScheduler }}
       run:
         path: "/bin/bash"
         args: *test_args
     on_success:
       put: commit-to-test
       params:
-        description: "Smoke tests on Diego were successful"
+        description: "Smoke tests on {{ $cfScheduler }} were successful"
         state: "success"
         commit_path: "commit-to-test/.git/resource/ref"
         version_path: "commit-to-test/.git/resource/version"
-        contexts: "smoke-diego"
+        contexts: "smoke-{{ $cfScheduler }}"
+        github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
     on_failure:
       do:
       - put: commit-to-test
         params:
-          description: "Smoke tests on Diego failed"
+          description: "Smoke tests on {{ $cfScheduler }} failed"
           commit_path: "commit-to-test/.git/resource/ref"
           version_path: "commit-to-test/.git/resource/version"
           state: "failure"
-          contexts: "smoke-diego"
+          contexts: "smoke-{{ $cfScheduler }}"
+          github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
       - task: cleanup-cluster
         config:
           <<: *cleanup-cluster
           params:
-            CLUSTER_NAME_PREFIX: "kubecf-diego"
+            CLUSTER_NAME_PREFIX: "kubecf-{{ $cfScheduler }}"
             EKCP_HOST: ((ekcp-host))
     on_abort:
       task: cleanup-cluster
       config:
         <<: *cleanup-cluster
         params:
-          CLUSTER_NAME_PREFIX: "kubecf-diego"
+          CLUSTER_NAME_PREFIX: "kubecf-{{ $cfScheduler }}"
           EKCP_HOST: ((ekcp-host))
 
-- name: ccdb-rotate-diego
+- name: ccdb-rotate-{{ $cfScheduler }}
   public: true
   plan:
   - get: commit-to-test
     passed:
-    - cf-acceptance-tests-diego
+    - cf-acceptance-tests-{{ $cfScheduler }}
     trigger: true
     version: "every"
   - get: s3.kubecf-ci
     passed:
-    - cf-acceptance-tests-diego
+    - cf-acceptance-tests-{{ $cfScheduler }}
   - get: s3.kubecf-ci-bundle
     passed:
-    - cf-acceptance-tests-diego
+    - cf-acceptance-tests-{{ $cfScheduler }}
   - get: catapult
-  - task: rotate-diego
+  - task: rotate-{{ $cfScheduler }}
     privileged: true
     timeout: 1h30m
     config:
@@ -537,58 +542,58 @@ jobs:
       - name: output
       params:
         DEFAULT_STACK: cflinuxfs3
-        EKCP_HOST: ((ekcp-host))
-        CLUSTER_NAME_PREFIX: kubecf-diego
+        CLUSTER_NAME_PREFIX: kubecf-{{ $cfScheduler }}
       run:
         path: "/bin/bash"
         args: *rotate_args
     on_success:
       put: commit-to-test
       params:
-        description: "Rotating secrets on Diego was successful"
+        description: "Rotating secrets on {{ $cfScheduler }} was successful"
         state: "success"
         commit_path: "commit-to-test/.git/resource/ref"
         version_path: "commit-to-test/.git/resource/version"
-        contexts: "rotate-diego"
+        contexts: "rotate-{{ $cfScheduler }}"
+        github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
     on_failure:
       do:
       - put: commit-to-test
         params:
-          description: "Rotating secrets on Diego failed"
+          description: "Rotating secrets on {{ $cfScheduler }} failed"
           commit_path: "commit-to-test/.git/resource/ref"
           version_path: "commit-to-test/.git/resource/version"
           state: "failure"
-          contexts: "rotate-diego"
+          contexts: "rotate-{{ $cfScheduler }}"
+          github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
       - task: cleanup-cluster
         config:
           <<: *cleanup-cluster
           params:
-            CLUSTER_NAME_PREFIX: "kubecf-diego"
+            CLUSTER_NAME_PREFIX: "kubecf-{{ $cfScheduler }}"
             EKCP_HOST: ((ekcp-host))
     on_abort:
       task: cleanup-cluster
       config:
         <<: *cleanup-cluster
         params:
-          CLUSTER_NAME_PREFIX: "kubecf-diego"
-          EKCP_HOST: ((ekcp-host))
+          CLUSTER_NAME_PREFIX: "kubecf-{{ $cfScheduler }}"
 
-- name: smoke-tests-post-rotate-diego
+- name: smoke-tests-post-rotate-{{ $cfScheduler }}
   public: true
   plan:
   - get: commit-to-test
     passed:
-    - ccdb-rotate-diego
+    - ccdb-rotate-{{ $cfScheduler }}
     trigger: true
     version: "every"
   - get: s3.kubecf-ci
     passed:
-    - ccdb-rotate-diego
+    - ccdb-rotate-{{ $cfScheduler }}
   - get: s3.kubecf-ci-bundle
     passed:
-    - ccdb-rotate-diego
+    - ccdb-rotate-{{ $cfScheduler }}
   - get: catapult
-  - task: test-diego
+  - task: test-{{ $cfScheduler }}
     privileged: true
     timeout: 1h30m
     config:
@@ -606,57 +611,59 @@ jobs:
         DEFAULT_STACK: cflinuxfs3
         EKCP_HOST: ((ekcp-host))
         TEST_SUITE: smokes
-        CLUSTER_NAME_PREFIX: kubecf-diego
+        CLUSTER_NAME_PREFIX: kubecf-{{ $cfScheduler }}
       run:
         path: "/bin/bash"
         args: *test_args
     on_success:
       put: commit-to-test
       params:
-        description: "Smoke tests on Diego after rotating secrets was successful"
+        description: "Smoke tests on {{ $cfScheduler }} after rotating secrets was successful"
         state: "success"
         commit_path: "commit-to-test/.git/resource/ref"
         version_path: "commit-to-test/.git/resource/version"
-        contexts: "smoke-rotated-diego"
+        contexts: "smoke-rotated-{{ $cfScheduler }}"
+        github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
     on_failure:
       do:
       - put: commit-to-test
         params:
-          description: "Smoke tests on Diego after rotating secrets failed"
+          description: "Smoke tests on {{ $cfScheduler }} after rotating secrets failed"
           commit_path: "commit-to-test/.git/resource/ref"
           version_path: "commit-to-test/.git/resource/version"
           state: "failure"
-          contexts: "smoke-rotated-diego"
+          contexts: "smoke-rotated-{{ $cfScheduler }}"
+          github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
       - task: cleanup-cluster
         config:
           <<: *cleanup-cluster
           params:
-            CLUSTER_NAME_PREFIX: "kubecf-diego"
+            CLUSTER_NAME_PREFIX: "kubecf-{{ $cfScheduler }}"
             EKCP_HOST: ((ekcp-host))
     on_abort:
       task: cleanup-cluster
       config:
         <<: *cleanup-cluster
         params:
-          CLUSTER_NAME_PREFIX: "kubecf-diego"
+          CLUSTER_NAME_PREFIX: "kubecf-{{ $cfScheduler }}"
           EKCP_HOST: ((ekcp-host))
 
-- name: sync-integration-tests-diego
+- name: sync-integration-tests-{{ $cfScheduler }}
   public: true
   plan:
   - get: commit-to-test
     passed:
-    - smoke-tests-diego
+    - smoke-tests-{{ $cfScheduler }}
     trigger: true
     version: "every"
   - get: s3.kubecf-ci
     passed:
-    - smoke-tests-diego
+    - smoke-tests-{{ $cfScheduler }}
   - get: s3.kubecf-ci-bundle
     passed:
-    - smoke-tests-diego
+    - smoke-tests-{{ $cfScheduler }}
   - get: catapult
-  - task: test-diego
+  - task: test-{{ $cfScheduler }}
     privileged: true
     timeout: 1h30m
     config:
@@ -674,58 +681,59 @@ jobs:
         DEFAULT_STACK: cflinuxfs3
         EKCP_HOST: ((ekcp-host))
         TEST_SUITE: sits
-        CLUSTER_NAME_PREFIX: kubecf-diego
+        CLUSTER_NAME_PREFIX: kubecf-{{ $cfScheduler }}
       run:
         path: "/bin/bash"
         args: *test_args
     on_success:
       put: commit-to-test
       params:
-        description: "Sync Integration tests on Diego succeeded"
+        description: "Sync Integration tests on {{ $cfScheduler }} succeeded"
         state: "success"
-        contexts: "sync-integration-tests-diego"
+        contexts: "sync-integration-tests-{{ $cfScheduler }}"
         commit_path: "commit-to-test/.git/resource/ref"
         version_path: "commit-to-test/.git/resource/version"
+        github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
     on_failure:
       do:
       - put: commit-to-test
         params:
-          description: "Sync Integration tests on Diego failed"
+          description: "Sync Integration tests on {{ $cfScheduler }} failed"
           state: "failure"
           commit_path: "commit-to-test/.git/resource/ref"
           version_path: "commit-to-test/.git/resource/version"
-          contexts: "sync-integration-tests-diego"
+          contexts: "sync-integration-tests-{{ $cfScheduler }}"
+          github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
       - task: cleanup-cluster
         config:
           <<: *cleanup-cluster
           params:
-            CLUSTER_NAME_PREFIX: "kubecf-diego"
+            CLUSTER_NAME_PREFIX: "kubecf-{{ $cfScheduler }}"
             EKCP_HOST: ((ekcp-host))
     on_abort:
       task: cleanup-cluster
       config:
         <<: *cleanup-cluster
         params:
-          CLUSTER_NAME_PREFIX: "kubecf-diego"
-          EKCP_HOST: ((ekcp-host))
+          CLUSTER_NAME_PREFIX: "kubecf-{{ $cfScheduler }}"
 
 # TODO: re-enable once BRAIN tests are fixed.
-# - name: brain-tests-diego
+# - name: brain-tests-{{ $cfScheduler }}
 #   public: true
 #   plan:
 #   - get: commit-to-test
 #     passed:
-#     - sync-integration-tests-diego
+#     - sync-integration-tests-{{ $cfScheduler }}
 #     trigger: true
 #     version: "every"
 #   - get: s3.kubecf-ci
 #     passed:
-#     - sync-integration-tests-diego
+#     - sync-integration-tests-{{ $cfScheduler }}
 #   - get: s3.kubecf-ci-bundle
 #     passed:
-#     - sync-integration-tests-diego
+#     - sync-integration-tests-{{ $cfScheduler }}
 #   - get: catapult
-#   - task: test-diego
+#   - task: test-{{ $cfScheduler }}
 #     privileged: true
 #     timeout: 1h30m
 #     config:
@@ -743,57 +751,57 @@ jobs:
 #         DEFAULT_STACK: cflinuxfs3
 #         EKCP_HOST: ((ekcp-host))
 #         TEST_SUITE: brain
-#         CLUSTER_NAME_PREFIX: kubecf-diego
+#         CLUSTER_NAME_PREFIX: kubecf-{{ $cfScheduler }}
 #       run:
 #         path: "/bin/bash"
 #         args: *test_args
 #     on_success:
 #       put: commit-to-test
 #       params:
-#         description: "Brain tests on Diego succeeded"
+#         description: "Brain tests on {{ $cfScheduler }} succeeded"
 #         state: "success"
-#         contexts: "brain-tests-diego"
+#         contexts: "brain-tests-{{ $cfScheduler }}"
 #         commit_path: "commit-to-test/.git/resource/ref"
 #         version_path: "commit-to-test/.git/resource/version"
 #     on_failure:
 #       do:
 #       - put: commit-to-test
 #         params:
-#           description: "Brain tests on Diego failed"
+#           description: "Brain tests on {{ $cfScheduler }} failed"
 #           state: "failure"
 #           commit_path: "commit-to-test/.git/resource/ref"
 #           version_path: "commit-to-test/.git/resource/version"
-#           contexts: "brain-tests-diego"
+#           contexts: "brain-tests-{{ $cfScheduler }}"
 #       - task: cleanup-cluster
 #         config:
 #           <<: *cleanup-cluster
 #           params:
-#             CLUSTER_NAME_PREFIX: "kubecf-diego"
+#             CLUSTER_NAME_PREFIX: "kubecf-{{ $cfScheduler }}"
 #             EKCP_HOST: ((ekcp-host))
 #     on_abort:
 #       task: cleanup-cluster
 #       config:
 #         <<: *cleanup-cluster
 #         params:
-#           CLUSTER_NAME_PREFIX: "kubecf-diego"
+#           CLUSTER_NAME_PREFIX: "kubecf-{{ $cfScheduler }}"
 #           EKCP_HOST: ((ekcp-host))
 
-- name: cf-acceptance-tests-diego
+- name: cf-acceptance-tests-{{ $cfScheduler }}
   public: true
   plan:
   - get: commit-to-test
     passed:
-    - sync-integration-tests-diego
+    - sync-integration-tests-{{ $cfScheduler }}
     trigger: true
     version: "every"
   - get: s3.kubecf-ci
     passed:
-    - sync-integration-tests-diego
+    - sync-integration-tests-{{ $cfScheduler }}
   - get: s3.kubecf-ci-bundle
     passed:
-    - sync-integration-tests-diego
+    - sync-integration-tests-{{ $cfScheduler }}
   - get: catapult
-  - task: test-diego
+  - task: test-{{ $cfScheduler }}
     privileged: true
     timeout: 5h30m
     config:
@@ -809,484 +817,57 @@ jobs:
       - name: output
       params:
         DEFAULT_STACK: cflinuxfs3
-        EKCP_HOST: ((ekcp-host))
         TEST_SUITE: cats
-        CLUSTER_NAME_PREFIX: kubecf-diego
+        CLUSTER_NAME_PREFIX: kubecf-{{ $cfScheduler }}
       run:
         path: "/bin/bash"
         args: *test_args
     on_success:
       put: commit-to-test
       params:
-        description: "Acceptance tests on Diego succeeded"
+        description: "Acceptance tests on {{ $cfScheduler }} succeeded"
         state: "success"
-        contexts: "acceptance-diego"
+        contexts: "acceptance-{{ $cfScheduler }}"
         commit_path: "commit-to-test/.git/resource/ref"
         version_path: "commit-to-test/.git/resource/version"
+        github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
     on_failure:
       do:
       - put: commit-to-test
         params:
-          description: "Acceptance tests on Diego failed"
+          description: "Acceptance tests on {{ $cfScheduler }} failed"
           state: "failure"
           commit_path: "commit-to-test/.git/resource/ref"
           version_path: "commit-to-test/.git/resource/version"
-          contexts: "acceptance-diego"
+          contexts: "acceptance-{{ $cfScheduler }}"
+          github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
       - task: cleanup-cluster
         config:
           <<: *cleanup-cluster
           params:
-            CLUSTER_NAME_PREFIX: "kubecf-diego"
-            EKCP_HOST: ((ekcp-host))
+            CLUSTER_NAME_PREFIX: "kubecf-{{ $cfScheduler }}"
     on_abort:
       task: cleanup-cluster
       config:
         <<: *cleanup-cluster
         params:
-          CLUSTER_NAME_PREFIX: "kubecf-diego"
-          EKCP_HOST: ((ekcp-host))
+          CLUSTER_NAME_PREFIX: "kubecf-{{ $cfScheduler }}"
 
-- name: cleanup-diego-cluster
+- name: cleanup-{{ $cfScheduler }}-cluster
   public: true
   plan:
   - get: commit-to-test
     passed:
-    - smoke-tests-post-rotate-diego
+    - smoke-tests-post-rotate-{{ $cfScheduler }}
     trigger: true
     version: "every"
   - task: cleanup-cluster
     config:
       <<: *cleanup-cluster
       params:
-        CLUSTER_NAME_PREFIX: "kubecf-diego"
-        EKCP_HOST: ((ekcp-host))
+        CLUSTER_NAME_PREFIX: "kubecf-{{ $cfScheduler }}"
 
-# Eirini
-- name: deploy-eirini
-  max_in_flight: 2
-  public: true
-  plan:
-  - get: commit-to-test
-    trigger: true
-    version: "every"
-    passed:
-    - build
-  - get: s3.kubecf-ci
-    passed:
-    - build
-  - get: s3.kubecf-ci-bundle
-    passed:
-    - build
-  - get: catapult
-  - task: deploy
-    timeout: 2h30m
-    privileged: true
-    config:
-      platform: linux
-      image_resource:
-        type: registry-image
-        source:
-          repository: splatform/catapult
-      inputs:
-      - name: commit-to-test
-      - name: catapult
-      - name: s3.kubecf-ci
-      outputs:
-      - name: output
-      params:
-        DEFAULT_STACK: cflinuxfs3
-        EKCP_HOST: ((ekcp-host))
-        ENABLE_EIRINI: true
-        CLUSTER_NAME_PREFIX: kubecf-eirini
-      run:
-        path: "/bin/bash"
-        args: *deploy_args
-    on_success:
-      put: commit-to-test
-      params:
-        description: "Deploying Eirini succeeded"
-        state: "success"
-        contexts: "deploy-eirini"
-        commit_path: "commit-to-test/.git/resource/ref"
-        version_path: "commit-to-test/.git/resource/version"
-    on_failure:
-      do:
-      - put: commit-to-test
-        params:
-          description: "Deploying Eirini failed"
-          commit_path: "commit-to-test/.git/resource/ref"
-          version_path: "commit-to-test/.git/resource/version"
-          state: "failure"
-          contexts: "deploy-eirini"
-      - task: cleanup-cluster
-        config:
-          <<: *cleanup-cluster
-          params:
-            CLUSTER_NAME_PREFIX: "kubecf-eirini"
-            EKCP_HOST: ((ekcp-host))
-    on_abort:
-      task: cleanup-cluster
-      config:
-        <<: *cleanup-cluster
-        params:
-          CLUSTER_NAME_PREFIX: "kubecf-eirini"
-          EKCP_HOST: ((ekcp-host))
-
-- name: smoke-tests-eirini
-  public: true
-  plan:
-  - get: commit-to-test
-    passed:
-    - deploy-eirini
-    trigger: true
-    version: "every"
-  - get: s3.kubecf-ci
-    passed:
-    - deploy-eirini
-  - get: s3.kubecf-ci-bundle
-    passed:
-    - deploy-eirini
-  - get: catapult
-  - task: test
-    privileged: true
-    timeout: 1h30m
-    config:
-      platform: linux
-      image_resource:
-        type: registry-image
-        source:
-          repository: splatform/catapult
-      inputs:
-      - name: catapult
-      - name: commit-to-test
-      outputs:
-      - name: mail-output
-      params:
-        DEFAULT_STACK: cflinuxfs3
-        EKCP_HOST: ((ekcp-host))
-        TEST_SUITE: smokes
-        CLUSTER_NAME_PREFIX: kubecf-eirini
-      run:
-        path: "/bin/bash"
-        args: *test_args
-    on_success:
-      put: commit-to-test
-      params:
-        description: "Smoke tests on Eirini succeeded"
-        state: "success"
-        contexts: "smoke-eirini"
-        commit_path: "commit-to-test/.git/resource/ref"
-        version_path: "commit-to-test/.git/resource/version"
-    on_failure:
-      do:
-      - put: commit-to-test
-        params:
-          description: "Smoke tests on Eirini failed"
-          state: "failure"
-          contexts: "smoke-eirini"
-          commit_path: "commit-to-test/.git/resource/ref"
-          version_path: "commit-to-test/.git/resource/version"
-      - task: cleanup-cluster
-        config:
-          <<: *cleanup-cluster
-          params:
-            CLUSTER_NAME_PREFIX: "kubecf-eirini"
-            EKCP_HOST: ((ekcp-host))
-    on_abort:
-      task: cleanup-cluster
-      config:
-        <<: *cleanup-cluster
-        params:
-          CLUSTER_NAME_PREFIX: "kubecf-eirini"
-          EKCP_HOST: ((ekcp-host))
-
-# TODO: re-enable once BRAIN tests are fixed.
-# - name: brain-tests-eirini
-#   public: true
-#   plan:
-#   - get: commit-to-test
-#     passed:
-#     - smoke-tests-eirini
-#     trigger: true
-#     version: "every"
-#   - get: s3.kubecf-ci
-#     passed:
-#     - smoke-tests-eirini
-#   - get: s3.kubecf-ci-bundle
-#     passed:
-#     - smoke-tests-eirini
-#   - get: catapult
-#   - task: test
-#     privileged: true
-#     timeout: 1h30m
-#     config:
-#       platform: linux
-#       image_resource:
-#         type: registry-image
-#         source:
-#           repository: splatform/catapult
-#       inputs:
-#       - name: catapult
-#       - name: commit-to-test
-#       outputs:
-#       - name: mail-output
-#       params:
-#         DEFAULT_STACK: cflinuxfs3
-#         EKCP_HOST: ((ekcp-host))
-#         TEST_SUITE: brain
-#         CLUSTER_NAME_PREFIX: kubecf-eirini
-#       run:
-#         path: "/bin/bash"
-#         args: *test_args
-#     on_success:
-#       put: commit-to-test
-#       params:
-#         description: "Brain tests on Eirini succeeded"
-#         state: "success"
-#         contexts: "brain-eirini"
-#         commit_path: "commit-to-test/.git/resource/ref"
-#         version_path: "commit-to-test/.git/resource/version"
-#     on_failure:
-#       do:
-#       - put: commit-to-test
-#         params:
-#           description: "Brain tests on Eirini failed"
-#           state: "failure"
-#           contexts: "brain-eirini"
-#           commit_path: "commit-to-test/.git/resource/ref"
-#           version_path: "commit-to-test/.git/resource/version"
-#       - task: cleanup-cluster
-#         config:
-#           <<: *cleanup-cluster
-#           params:
-#             CLUSTER_NAME_PREFIX: "kubecf-eirini"
-#             EKCP_HOST: ((ekcp-host))
-#     on_abort:
-#       task: cleanup-cluster
-#       config:
-#         <<: *cleanup-cluster
-#         params:
-#           CLUSTER_NAME_PREFIX: "kubecf-eirini"
-#           EKCP_HOST: ((ekcp-host))
-
-- name: ccdb-rotate-eirini
-  public: true
-  plan:
-  - get: commit-to-test
-    passed:
-    - cf-acceptance-tests-eirini
-    trigger: true
-    version: "every"
-  - get: s3.kubecf-ci
-    passed:
-    - cf-acceptance-tests-eirini
-  - get: s3.kubecf-ci-bundle
-    passed:
-    - cf-acceptance-tests-eirini
-  - get: catapult
-  - task: rotate-eirini
-    privileged: true
-    timeout: 1h30m
-    config:
-      platform: linux
-      image_resource:
-        type: registry-image
-        source:
-          repository: splatform/catapult
-      inputs:
-      - name: catapult
-      - name: commit-to-test
-      outputs:
-      - name: output
-      params:
-        DEFAULT_STACK: cflinuxfs3
-        EKCP_HOST: ((ekcp-host))
-        CLUSTER_NAME_PREFIX: kubecf-eirini
-      run:
-        path: "/bin/bash"
-        args: *rotate_args
-    on_success:
-      put: commit-to-test
-      params:
-        description: "Rotating secrets on Eirini succeeded"
-        state: "success"
-        contexts: "rotate-eirini"
-        commit_path: "commit-to-test/.git/resource/ref"
-        version_path: "commit-to-test/.git/resource/version"
-    on_failure:
-      do:
-      - put: commit-to-test
-        params:
-          description: "Rotating secrets on Eirini failed"
-          state: "failure"
-          commit_path: "commit-to-test/.git/resource/ref"
-          version_path: "commit-to-test/.git/resource/version"
-          contexts: "rotate-eirini"
-      - task: cleanup-cluster
-        config:
-          <<: *cleanup-cluster
-          params:
-            CLUSTER_NAME_PREFIX: "kubecf-eirini"
-            EKCP_HOST: ((ekcp-host))
-    on_abort:
-      task: cleanup-cluster
-      config:
-        <<: *cleanup-cluster
-        params:
-          CLUSTER_NAME_PREFIX: "kubecf-eirini"
-          EKCP_HOST: ((ekcp-host))
-
-- name: smoke-tests-post-rotate-eirini
-  public: true
-  plan:
-  - get: commit-to-test
-    passed:
-    - ccdb-rotate-eirini
-    trigger: true
-    version: "every"
-  - get: s3.kubecf-ci
-    passed:
-    - ccdb-rotate-eirini
-  - get: s3.kubecf-ci-bundle
-    passed:
-    - ccdb-rotate-eirini
-  - get: catapult
-  - task: test
-    privileged: true
-    timeout: 1h30m
-    config:
-      platform: linux
-      image_resource:
-        type: registry-image
-        source:
-          repository: splatform/catapult
-      inputs:
-      - name: catapult
-      - name: commit-to-test
-      outputs:
-      - name: mail-output
-      params:
-        DEFAULT_STACK: cflinuxfs3
-        EKCP_HOST: ((ekcp-host))
-        TEST_SUITE: smokes
-        CLUSTER_NAME_PREFIX: kubecf-eirini
-      run:
-        path: "/bin/bash"
-        args: *test_args
-    on_success:
-      put: commit-to-test
-      params:
-        description: "Smoke tests after rotating secrets on Eirini succeeded"
-        state: "success"
-        contexts: "smoke-rotated-eirini"
-        commit_path: "commit-to-test/.git/resource/ref"
-        version_path: "commit-to-test/.git/resource/version"
-    on_failure:
-      do:
-      - put: commit-to-test
-        params:
-          description: "Smoke tests after rotating secrets on Eirini failed"
-          state: "failure"
-          commit_path: "commit-to-test/.git/resource/ref"
-          version_path: "commit-to-test/.git/resource/version"
-          contexts: "smoke-rotated-eirini"
-      - task: cleanup-cluster
-        config:
-          <<: *cleanup-cluster
-          params:
-            CLUSTER_NAME_PREFIX: "kubecf-eirini"
-            EKCP_HOST: ((ekcp-host))
-    on_abort:
-      task: cleanup-cluster
-      config:
-        <<: *cleanup-cluster
-        params:
-          CLUSTER_NAME_PREFIX: "kubecf-eirini"
-          EKCP_HOST: ((ekcp-host))
-
-- name: cf-acceptance-tests-eirini
-  public: true
-  plan:
-  - get: commit-to-test
-    passed:
-    - smoke-tests-eirini
-    # trigger: true
-    version: "every"
-  - get: s3.kubecf-ci
-    passed:
-    - smoke-tests-eirini
-  - get: s3.kubecf-ci-bundle
-    passed:
-    - smoke-tests-eirini
-  - get: catapult
-  - task: test
-    timeout: 5h30m
-    privileged: true
-    config:
-      platform: linux
-      image_resource:
-        type: registry-image
-        source:
-          repository: splatform/catapult
-      inputs:
-      - name: catapult
-      - name: commit-to-test
-      outputs:
-      - name: mail-output
-      params:
-        DEFAULT_STACK: cflinuxfs3
-        EKCP_HOST: ((ekcp-host))
-        TEST_SUITE: cats
-        CLUSTER_NAME_PREFIX: kubecf-eirini
-      run:
-        path: "/bin/bash"
-        args: *test_args
-    on_success:
-      put: commit-to-test
-      params:
-        description: "Acceptance tests on Eirini succeeded"
-        state: "success"
-        contexts: "acceptance-eirini"
-        commit_path: "commit-to-test/.git/resource/ref"
-        version_path: "commit-to-test/.git/resource/version"
-    on_failure:
-      do:
-      - put: commit-to-test
-        params:
-          description: "Acceptance tests on Eirini failed"
-          state: "failure"
-          commit_path: "commit-to-test/.git/resource/ref"
-          version_path: "commit-to-test/.git/resource/version"
-          contexts: "acceptance-eirini"
-      - task: cleanup-cluster
-        config:
-          <<: *cleanup-cluster
-          params:
-            CLUSTER_NAME_PREFIX: "kubecf-eirini"
-            EKCP_HOST: ((ekcp-host))
-    on_abort:
-      task: cleanup-cluster
-      config:
-        <<: *cleanup-cluster
-        params:
-          CLUSTER_NAME_PREFIX: "kubecf-eirini"
-          EKCP_HOST: ((ekcp-host))
-
-- name: cleanup-eirini-cluster
-  public: true
-  plan:
-  - get: commit-to-test
-    passed:
-    # - smoke-tests-post-rotate-eirini
-    - smoke-tests-eirini
-    trigger: true
-    version: "every"
-  - task: cleanup-cluster
-    config:
-      <<: *cleanup-cluster
-      params:
-        CLUSTER_NAME_PREFIX: "kubecf-eirini"
-        EKCP_HOST: ((ekcp-host))
+{{ end }} # of range cfscheduler
 
 - name: publish
   public: true

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -364,12 +364,12 @@ jobs:
 {{- range $_, $cfScheduler := slice "diego" "eirini" }}
 
 - name: deploy-{{ $cfScheduler }}
-  max_in_flight: 2
+  max_in_flight: 1 # Use concourse queue which doesn't timeout
   public: true
   plan:
   - put: kind-environments
     params: {acquire: true}
-    timeout: 2h
+    timeout: 4h
   - get: commit-to-test
     trigger: true
     version: "every"

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -366,10 +366,12 @@ jobs:
 - name: deploy-{{ $cfScheduler }}
   max_in_flight: 1 # Use concourse queue which doesn't timeout
   public: true
+  # Consider adding a serial_group between the two $cfScheduler
+  # if jobs starts to starve
   plan:
   - put: kind-environments
     params: {acquire: true}
-    timeout: 4h
+    timeout: 4h # Timeout should be long at least for the full pipeline to complete
   - get: commit-to-test
     trigger: true
     version: "every"

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -465,6 +465,9 @@ jobs:
 - name: smoke-tests-{{ $cfScheduler }}
   public: true
   plan:
+  - get: kind-environments
+    passed:
+    - deploy-{{ $cfScheduler }}
   - get: commit-to-test
     passed:
     - deploy-{{ $cfScheduler }}
@@ -488,6 +491,7 @@ jobs:
           repository: splatform/catapult
       inputs:
       - name: catapult
+      - name: kind-environments
       - name: commit-to-test
       outputs:
       - name: output
@@ -540,6 +544,9 @@ jobs:
 - name: ccdb-rotate-{{ $cfScheduler }}
   public: true
   plan:
+  - get: kind-environments
+    passed:
+    - cf-acceptance-tests-{{ $cfScheduler }}
   - get: commit-to-test
     passed:
     - cf-acceptance-tests-{{ $cfScheduler }}
@@ -564,6 +571,7 @@ jobs:
       inputs:
       - name: catapult
       - name: commit-to-test
+      - name: kind-environments
       outputs:
       - name: output
       params:
@@ -617,6 +625,9 @@ jobs:
 - name: smoke-tests-post-rotate-{{ $cfScheduler }}
   public: true
   plan:
+  - get: kind-environments
+    passed:
+    - ccdb-rotate-{{ $cfScheduler }}
   - get: commit-to-test
     passed:
     - ccdb-rotate-{{ $cfScheduler }}
@@ -641,6 +652,7 @@ jobs:
       inputs:
       - name: catapult
       - name: commit-to-test
+      - name: kind-environments
       outputs:
       - name: output
       params:
@@ -692,6 +704,9 @@ jobs:
 - name: sync-integration-tests-{{ $cfScheduler }}
   public: true
   plan:
+  - get: kind-environments
+    passed:
+    - smoke-tests-{{ $cfScheduler }}
   - get: commit-to-test
     passed:
     - smoke-tests-{{ $cfScheduler }}
@@ -716,6 +731,7 @@ jobs:
       inputs:
       - name: catapult
       - name: commit-to-test
+      - name: kind-environments
       outputs:
       - name: output
       params:
@@ -836,6 +852,9 @@ jobs:
 - name: cf-acceptance-tests-{{ $cfScheduler }}
   public: true
   plan:
+  - get: kind-environments
+    passed:
+    - sync-integration-tests-{{ $cfScheduler }}
   - get: commit-to-test
     passed:
     - sync-integration-tests-{{ $cfScheduler }}
@@ -859,6 +878,7 @@ jobs:
           repository: splatform/catapult
       inputs:
       - name: catapult
+      - name: kind-environments
       - name: commit-to-test
       outputs:
       - name: output
@@ -911,6 +931,9 @@ jobs:
 - name: cleanup-{{ $cfScheduler }}-cluster
   public: true
   plan:
+  - get: kind-environments
+    passed:
+    - smoke-tests-post-rotate-{{ $cfScheduler }}
   - get: commit-to-test
     passed:
     - smoke-tests-post-rotate-{{ $cfScheduler }}

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -119,12 +119,12 @@ deploy_args: &deploy_args
   export BACKEND=kind
   export DOCKER_ORG=cap-staging
   export QUIET_OUTPUT=true
-  export CLUSTER_NAME="${CLUSTER_NAME_PREFIX}-$(ls commit-to-test/*.json | \
-                       xargs basename | sed 's/.json$//g' | cut -c1-18)"
+  export CLUSTER_NAME="$(cat kind-environments/name)"
+  export KUBECFG="$(readlink -f kind-environments/metadata)"
   pushd catapult
   # Bring up a k8s cluster and builds+deploy kubecf
   # https://github.com/SUSE/catapult/wiki/Build-and-run-SCF#build-and-run-kubecf
-  export KUBECFG=../?
+  export KUBECFG=../kind-environments/metadata
   make kubeconfig scf
 
 test_args: &test_args
@@ -135,11 +135,10 @@ test_args: &test_args
   export SCF_LOCAL="${PWD}/commit-to-test"
   export KUBECF_NAMESPACE="scf"
   export QUIET_OUTPUT=true
-  export CLUSTER_NAME="${CLUSTER_NAME_PREFIX}-$(ls commit-to-test/*.json | \
-                       xargs basename | sed 's/.json$//g' | cut -c1-18)"
+  export CLUSTER_NAME="$(cat kind-environments/name)"
+  export KUBECFG="$(readlink -f kind-environments/metadata)"
   export KUBECF_CHECKOUT="${PWD}/commit-to-test"
   pushd catapult
-  export KUBECFG=../?
   # Grabs back a deployed cluster and runs test suites on it
   # See: https://github.com/SUSE/catapult/wiki/Running-SCF-tests#kubecf
   make kubeconfig tests-kubecf
@@ -149,13 +148,12 @@ rotate_args: &rotate_args
 - |
   export BACKEND=kind
   export KUBECF_NAMESPACE="scf"
-  export CLUSTER_NAME="${CLUSTER_NAME_PREFIX}-$(ls commit-to-test/*.json | \
-                       xargs basename | sed 's/.json$//g' | cut -c1-18)"
+  export CLUSTER_NAME="$(cat kind-environments/name)"
+  export KUBECFG="$(readlink -f kind-environments/metadata)"
   export KUBECF_CHECKOUT="${PWD}/commit-to-test"
   export KUBECF_INSTALL_NAME="susecf-scf"
 
   pushd catapult
-  export KUBECFG=../?
   make kubeconfig
   source build*/.envrc
 
@@ -437,22 +435,28 @@ jobs:
               repository: splatform/catapult
           inputs:
           - name: commit-to-test
+          - name: kind-environments
           params:
             CLUSTER_NAME_PREFIX: "kubecf-{{ $cfScheduler }}"
+            EKCP_HOST: ((ekcp-host))
           run:
             path: "/bin/bash"
             args:
             - -ce
             - |
-              export CLUSTER_NAME="${CLUSTER_NAME_PREFIX}-$(ls commit-to-test/*.json | \
-                                   xargs basename | sed 's/.json$//g' | cut -c1-18)"
+              export CLUSTER_NAME="$(cat kind-environments/name)"
               curl -X DELETE -s "http://${EKCP_HOST}/${CLUSTER_NAME}" | jq -r .Output
+      - put: kind-environments
+        params: { remove : kind-environments}
     on_abort:
-      task: cleanup-cluster
-      config:
-        <<: *cleanup-cluster
-        params:
-          CLUSTER_NAME_PREFIX: "kubecf-{{ $cfScheduler }}"
+      do:
+      - task: cleanup-cluster
+        config:
+          <<: *cleanup-cluster
+          params:
+            CLUSTER_NAME_PREFIX: "kubecf-{{ $cfScheduler }}"
+      - put: kind-environments
+        params: { remove : kind-environments}
 
 - name: smoke-tests-{{ $cfScheduler }}
   public: true
@@ -512,14 +516,15 @@ jobs:
       - task: cleanup-cluster
         config:
           <<: *cleanup-cluster
-          params:
-            CLUSTER_NAME_PREFIX: "kubecf-{{ $cfScheduler }}"
+      - put: kind-environments
+        params: { remove : kind-environments}
     on_abort:
-      task: cleanup-cluster
-      config:
-        <<: *cleanup-cluster
-        params:
-          CLUSTER_NAME_PREFIX: "kubecf-{{ $cfScheduler }}"
+      do:
+      - task: cleanup-cluster
+        config:
+          <<: *cleanup-cluster
+      - put: kind-environments
+        params: { remove : kind-environments}
 
 - name: ccdb-rotate-{{ $cfScheduler }}
   public: true
@@ -581,12 +586,15 @@ jobs:
           params:
             CLUSTER_NAME_PREFIX: "kubecf-{{ $cfScheduler }}"
             EKCP_HOST: ((ekcp-host))
+      - put: kind-environments
+        params: { remove : kind-environments}
     on_abort:
-      task: cleanup-cluster
-      config:
-        <<: *cleanup-cluster
-        params:
-          CLUSTER_NAME_PREFIX: "kubecf-{{ $cfScheduler }}"
+      do:
+      - task: cleanup-cluster
+        config:
+          <<: *cleanup-cluster
+      - put: kind-environments
+        params: { remove : kind-environments}
 
 - name: smoke-tests-post-rotate-{{ $cfScheduler }}
   public: true
@@ -646,14 +654,15 @@ jobs:
       - task: cleanup-cluster
         config:
           <<: *cleanup-cluster
-          params:
-            CLUSTER_NAME_PREFIX: "kubecf-{{ $cfScheduler }}"
+      - put: kind-environments
+        params: { remove : kind-environments}
     on_abort:
-      task: cleanup-cluster
-      config:
-        <<: *cleanup-cluster
-        params:
-          CLUSTER_NAME_PREFIX: "kubecf-{{ $cfScheduler }}"
+      do:
+      - task: cleanup-cluster
+        config:
+          <<: *cleanup-cluster
+      - put: kind-environments
+        params: { remove : kind-environments}
 
 - name: sync-integration-tests-{{ $cfScheduler }}
   public: true
@@ -713,14 +722,15 @@ jobs:
       - task: cleanup-cluster
         config:
           <<: *cleanup-cluster
-          params:
-            CLUSTER_NAME_PREFIX: "kubecf-{{ $cfScheduler }}"
+      - put: kind-environments
+        params: { remove : kind-environments}
     on_abort:
-      task: cleanup-cluster
-      config:
-        <<: *cleanup-cluster
-        params:
-          CLUSTER_NAME_PREFIX: "kubecf-{{ $cfScheduler }}"
+      do:
+      - task: cleanup-cluster
+        config:
+          <<: *cleanup-cluster
+      - put: kind-environments
+        params: { remove : kind-environments}
 
 # TODO: re-enable once BRAIN tests are fixed.
 # - name: brain-tests-{{ $cfScheduler }}
@@ -849,14 +859,15 @@ jobs:
       - task: cleanup-cluster
         config:
           <<: *cleanup-cluster
-          params:
-            CLUSTER_NAME_PREFIX: "kubecf-{{ $cfScheduler }}"
+      - put: kind-environments
+        params: { remove : kind-environments}
     on_abort:
-      task: cleanup-cluster
-      config:
-        <<: *cleanup-cluster
-        params:
-          CLUSTER_NAME_PREFIX: "kubecf-{{ $cfScheduler }}"
+      do:
+      - task: cleanup-cluster
+        config:
+          <<: *cleanup-cluster
+      - put: kind-environments
+        params: { remove : kind-environments}
 
 - name: cleanup-{{ $cfScheduler }}-cluster
   public: true
@@ -871,6 +882,8 @@ jobs:
       <<: *cleanup-cluster
       params:
         CLUSTER_NAME_PREFIX: "kubecf-{{ $cfScheduler }}"
+  - put: kind-environments
+    params: { remove : kind-environments}
 
 {{ end }} # of range cfscheduler
 

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -25,6 +25,14 @@ resource_types:
     repository: splatform/concourse-git-queue
 
 resources:
+- name: kind-environments
+  type: pool
+  source:
+    uri: git@github.com:SUSE/cf-ci-pools.git
+    branch: kubecf-kind-pools
+    pool: kind
+    private_key: ((github-private-key))
+
 - name: commit-to-test
   type: concourse-git-queue
   source:
@@ -108,7 +116,7 @@ deploy_args: &deploy_args
   export FORCE_DELETE=true
   export HELM_VERSION="v3.1.1"
   export SCF_TESTGROUP=true
-  export BACKEND=ekcp
+  export BACKEND=kind
   export DOCKER_ORG=cap-staging
   export QUIET_OUTPUT=true
   export CLUSTER_NAME="${CLUSTER_NAME_PREFIX}-$(ls commit-to-test/*.json | \
@@ -116,12 +124,13 @@ deploy_args: &deploy_args
   pushd catapult
   # Bring up a k8s cluster and builds+deploy kubecf
   # https://github.com/SUSE/catapult/wiki/Build-and-run-SCF#build-and-run-kubecf
-  make k8s scf
+  export KUBECFG=../?
+  make kubeconfig scf
 
 test_args: &test_args
 - -xce
 - |
-  export BACKEND=ekcp
+  export BACKEND=kind
   export KUBECF_TEST_SUITE="${TEST_SUITE:-smokes}"
   export SCF_LOCAL="${PWD}/commit-to-test"
   export KUBECF_NAMESPACE="scf"
@@ -130,14 +139,15 @@ test_args: &test_args
                        xargs basename | sed 's/.json$//g' | cut -c1-18)"
   export KUBECF_CHECKOUT="${PWD}/commit-to-test"
   pushd catapult
+  export KUBECFG=../?
   # Grabs back a deployed cluster and runs test suites on it
   # See: https://github.com/SUSE/catapult/wiki/Running-SCF-tests#kubecf
-  make recover tests-kubecf
+  make kubeconfig tests-kubecf
 
 rotate_args: &rotate_args
 - -xce
 - |
-  export BACKEND=ekcp
+  export BACKEND=kind
   export KUBECF_NAMESPACE="scf"
   export CLUSTER_NAME="${CLUSTER_NAME_PREFIX}-$(ls commit-to-test/*.json | \
                        xargs basename | sed 's/.json$//g' | cut -c1-18)"
@@ -145,7 +155,8 @@ rotate_args: &rotate_args
   export KUBECF_INSTALL_NAME="susecf-scf"
 
   pushd catapult
-  make recover
+  export KUBECFG=../?
+  make kubeconfig
   source build*/.envrc
 
   pushd "${KUBECF_CHECKOUT}"
@@ -359,6 +370,9 @@ jobs:
   max_in_flight: 2
   public: true
   plan:
+  - put: kind-environments
+    params: {acquire: true}
+    timeout: 2h
   - get: commit-to-test
     trigger: true
     version: "every"
@@ -382,13 +396,13 @@ jobs:
           repository: splatform/catapult
       inputs:
       - name: commit-to-test
+      - name: kind-environments
       - name: catapult
       - name: s3.kubecf-ci
       outputs:
       - name: output
       params:
         DEFAULT_STACK: cflinuxfs3
-        EKCP_HOST: ((ekcp-host))
         QUIET_OUTPUT: true
         ENABLE_EIRINI: false
         CLUSTER_NAME_PREFIX: kubecf-{{ $cfScheduler }}
@@ -424,7 +438,6 @@ jobs:
           inputs:
           - name: commit-to-test
           params:
-            EKCP_HOST: ((ekcp-host))
             CLUSTER_NAME_PREFIX: "kubecf-{{ $cfScheduler }}"
           run:
             path: "/bin/bash"
@@ -472,7 +485,6 @@ jobs:
       - name: output
       params:
         DEFAULT_STACK: cflinuxfs3
-        EKCP_HOST: ((ekcp-host))
         TEST_SUITE: smokes
         CLUSTER_NAME_PREFIX: kubecf-{{ $cfScheduler }}
       run:
@@ -502,14 +514,12 @@ jobs:
           <<: *cleanup-cluster
           params:
             CLUSTER_NAME_PREFIX: "kubecf-{{ $cfScheduler }}"
-            EKCP_HOST: ((ekcp-host))
     on_abort:
       task: cleanup-cluster
       config:
         <<: *cleanup-cluster
         params:
           CLUSTER_NAME_PREFIX: "kubecf-{{ $cfScheduler }}"
-          EKCP_HOST: ((ekcp-host))
 
 - name: ccdb-rotate-{{ $cfScheduler }}
   public: true
@@ -609,7 +619,6 @@ jobs:
       - name: output
       params:
         DEFAULT_STACK: cflinuxfs3
-        EKCP_HOST: ((ekcp-host))
         TEST_SUITE: smokes
         CLUSTER_NAME_PREFIX: kubecf-{{ $cfScheduler }}
       run:
@@ -639,14 +648,12 @@ jobs:
           <<: *cleanup-cluster
           params:
             CLUSTER_NAME_PREFIX: "kubecf-{{ $cfScheduler }}"
-            EKCP_HOST: ((ekcp-host))
     on_abort:
       task: cleanup-cluster
       config:
         <<: *cleanup-cluster
         params:
           CLUSTER_NAME_PREFIX: "kubecf-{{ $cfScheduler }}"
-          EKCP_HOST: ((ekcp-host))
 
 - name: sync-integration-tests-{{ $cfScheduler }}
   public: true
@@ -679,7 +686,6 @@ jobs:
       - name: output
       params:
         DEFAULT_STACK: cflinuxfs3
-        EKCP_HOST: ((ekcp-host))
         TEST_SUITE: sits
         CLUSTER_NAME_PREFIX: kubecf-{{ $cfScheduler }}
       run:
@@ -709,7 +715,6 @@ jobs:
           <<: *cleanup-cluster
           params:
             CLUSTER_NAME_PREFIX: "kubecf-{{ $cfScheduler }}"
-            EKCP_HOST: ((ekcp-host))
     on_abort:
       task: cleanup-cluster
       config:

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -403,7 +403,7 @@ jobs:
       params:
         DEFAULT_STACK: cflinuxfs3
         QUIET_OUTPUT: true
-        ENABLE_EIRINI: false
+        ENABLE_EIRINI: {{ eq $cfScheduler "eirini" }}
         CLUSTER_NAME_PREFIX: kubecf-{{ $cfScheduler }}
       run:
         path: "/bin/bash"

--- a/.concourse/pool.yaml.gomplate
+++ b/.concourse/pool.yaml.gomplate
@@ -22,14 +22,25 @@ deploy_args: &deploy_args
   export BACKEND=ekcp
   export QUIET_OUTPUT=true
   export CLUSTER_NAME="$CLUSTER_PREFIX-$(date +%s | sha256sum | base64 | head -c 32 ; echo)"
+  CURRENT_CLUSTERS=$(ls kind-environments/kind/**/* | grep -v .keep | wc -l)
+  if [ $CURRENT_CLUSTERS -lt 2 ]; then
+
   pushd catapult
   make k8s
+  else
+    echo "No resources to add"
+    exit 0
+  fi
+
   cp -rfv build*/kubeconfig ../output/metadata
   echo "$CLUSTER_NAME" > ../output/name
 
 jobs:
 - name: create-cluster
+  serial: true
   plan:
+  - get: kind-environments
+    trigger: true
   - get: catapult
   - task: deploy
     privileged: true
@@ -41,6 +52,7 @@ jobs:
         source:
           repository: splatform/catapult
       inputs:
+      - name: kind-environments
       - name: catapult
       outputs:
       - name: output

--- a/.concourse/pool.yaml.gomplate
+++ b/.concourse/pool.yaml.gomplate
@@ -1,0 +1,55 @@
+resources:
+- name: kind-environments
+  type: pool
+  source:
+    uri: git@github.com:SUSE/cf-ci-pools.git
+    branch: kubecf-kind-pools
+    pool: kind
+    private_key: ((github-private-key))
+
+- name: catapult
+  type: git
+  source:
+    uri: https://github.com/SUSE/catapult
+  version:
+    ref: 543bc71abc8bd22e5ef81fdf94a7afeb2f99066d
+
+
+deploy_args: &deploy_args
+- -xce
+- |
+  export FORCE_DELETE=true
+  export BACKEND=ekcp
+  export QUIET_OUTPUT=true
+  export CLUSTER_NAME="$CLUSTER_PREFIX-$(date +%s | sha256sum | base64 | head -c 32 ; echo)"
+  pushd catapult
+  make k8s
+  cp -rfv build*/kubeconfig ../output/metadata
+  echo "$CLUSTER_NAME" > ../output/name
+
+jobs:
+- name: create-cluster
+  plan:
+  - get: catapult
+  - task: deploy
+    privileged: true
+    timeout: 30m
+    config:
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: splatform/catapult
+      inputs:
+      - name: catapult
+      outputs:
+      - name: output
+      params:
+        EKCP_HOST: ((ekcp-host))
+        CLUSTER_PREFIX: "kind"
+      run:
+        path: "/bin/bash"
+        args: *deploy_args
+  - put: kind-environments
+    params: {add: output}
+


### PR DESCRIPTION
## Description
Fixes: https://github.com/cloudfoundry-incubator/kubecf/issues/501 . Introduce a pool mechanism to the KubeCF pipeline, and templates Eirini and Diego job definitions.

Kind clusters are now created by a separate pipeline, kubecf-pool-reconciler. This pipeline reconciles a "max pool size" by creating clusters and adding their kubeconfigs to the pool repository until the number of clusters in circulation match the "max pool size".

The KubeCF pipeline then consumes them, making jobs that have no resources to run, and wait for a lock that eventually will be created by the reconciler pipeline. The KubeCF pipeline will destroy the cluster and remove the kubeconfig from the pool when it finishes successfully, or in any job that has failed.


## Motivation and Context
See: https://github.com/cloudfoundry-incubator/kubecf/issues/501 .

## How Has This Been Tested?
https://concourse.suse.dev/teams/main/pipelines/kubecf-test
https://concourse.suse.dev/teams/main/pipelines/pool-create-test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
