### PR TITLE
CAP CI: implement pools

### DIFF
--- a/.concourse/cap-release/README.md
+++ b/.concourse/cap-release/README.md
@@ -25,21 +25,8 @@ The pipeline strives to have the minimum concourse yaml to do the job, and put
 the logic somewhere so one can run and iterate on the pipeline locally.
 It's still in flux.
 
-# Current status
+# K8s cluster management
 
-For now, the pipeline consumes clusters hardcoded by name: eg
-`cap-release-diego-caasp4-ha`.
+The pipeline consumes clusters by putting a lock on unclaimed kubeconfigs from git@github.com:SUSE/cf-ci-pools.git
 
-The kubeconfigs for these clusters are stored in EKCP hosts, and are created
-either manually or in an automated way by performing `BACKEND=foo make k8s` with
-Catapult.
-
-This hardcoding of kubeconfigs is needed until we have a fully-fledged Concourse
-Pool system that can pass the correct kubeconfig from 1 horizontal job to the
-next one (eg: deploy-diego-caasp4-ha -> smoke-tests-diego-casp4-ha). Until that
-moment, we perform `BACKEND=ekcp make recover` as first step to obtain the kubeconfig.
-
-Templating engine is not set in stone, either.
-
-## Manually adding a cluster to catapult-web/EKCP
-https://github.com/SUSE/catapult/wiki/Catapult-web#add-a-cluster-to-catapult-web
+Add your kubeconfigs to cf-ci-pools in ${Backend}-kube-hosts branch in unacliamed folder for CI to pick it up.

--- a/.concourse/cap-release/README.md
+++ b/.concourse/cap-release/README.md
@@ -29,4 +29,4 @@ It's still in flux.
 
 The pipeline consumes clusters by putting a lock on unclaimed kubeconfigs from git@github.com:SUSE/cf-ci-pools.git
 
-Add your kubeconfigs to cf-ci-pools in ${Backend}-kube-hosts branch in unacliamed folder for CI to pick it up.
+Add your kubeconfigs to cf-ci-pools.git in ${Backend}-kube-hosts branch in the unclaimed folder for CI to pick it up.

--- a/.concourse/cap-release/create_cap-release_pipeline.sh
+++ b/.concourse/cap-release/create_cap-release_pipeline.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
+set -x
 
-# NOTE for now, to insert clusters by kubeconfig into EKCP (change name of cluster):
-# curl -d "name=cap-release-diego-caasp4&kubeconfig=$(base64 ./kubeconfig)" -X POST http://ain.arch.suse.de:8030/api/v1/cluster/insert
+# NOTE for now, add your cluster's kubeconfig in git@github.com:SUSE/cf-ci-pools.git on branch ${BACKEND}-kube-hosts in unclaimed folder
+# Usage example: PIPELINE=name-demo-release BACKEND='backend: [ caasp4, eks ]' OPTIONS='options: [ sa ]' EIRINI='eirini: [ diego ]' ./create_cap-release_pipeline.sh
 
 export PIPELINE="${PIPELINE-cap-release}"
 
@@ -15,5 +16,4 @@ gomplate -d 'BACKEND=env:///BACKEND?type=application/yaml' \
          -d 'EIRINI=env:///EIRINI?type=application/yaml' \
          -f pipeline.template > "$PIPELINE".yaml
 
-fly -t concourse.suse.dev dp "$PIPELINE".yaml -p "$PIPELINE"
 fly -t concourse.suse.dev sp -c "$PIPELINE".yaml -p "$PIPELINE"

--- a/.concourse/cap-release/pipeline.template
+++ b/.concourse/cap-release/pipeline.template
@@ -338,6 +338,68 @@ jobs:
             {{- end }}
             {{- print $test }}
 
+- name: sync-integration-tests-{{$EiriniFlag}}-{{$Backend}}-{{$OptionsFlag}}
+  serial_groups: [{{$EiriniFlag}}-{{$Backend}}-{{$OptionsFlag}}]
+  public: false
+  plan:
+  - get: kubecf-master
+    passed:
+    - cf-acceptance-tests-{{$EiriniFlag}}-{{$Backend}}-{{$OptionsFlag}}
+    trigger: true
+  - get: catapult
+  - task: test-{{$EiriniFlag}}
+    privileged: true
+    timeout: 5h30m
+    input_mapping:
+      kubecf: kubecf-master
+    config:
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: splatform/catapult
+      inputs:
+      - name: catapult
+      - name: kubecf
+      outputs:
+      - name: output
+      params:
+        QUIET_OUTPUT: true
+        DEFAULT_STACK: cflinuxfs3
+        EKCP_HOST: ((ekcp-host))
+{{- if eq $EiriniFlag "eirini" }}
+        ENABLE_EIRINI: true
+{{ else }}
+        ENABLE_EIRINI: false
+{{- end }}
+{{- if eq $OptionsFlag "ha" }}
+        HA: true
+{{- end }}
+{{- if eq $OptionsFlag "all" }}
+{{- print $allbells }}
+{{- end }}
+        TEST_SUITE: sits
+        CLUSTER_NAME: {{$pipelineName}}-{{$EiriniFlag}}-{{$Backend}}-{{$OptionsFlag}}
+      run:
+        path: "/bin/bash"
+        args:
+          - -c
+          - |
+            {{- print $obtain_ekcp }}
+            {{- if eq $Backend "caasp4" }}
+            {{- print $import_caasp4 }}
+            {{- end }}
+            {{- if eq $Backend "eks" }}
+            {{- print $import_eks }}
+            {{- end }}
+            {{- if eq $Backend "gke" }}
+            {{- print $import_gke }}
+            {{- end }}
+            {{- if eq $Backend "aks" }}
+            {{- print $import_aks }}
+            {{- end }}
+            {{- print $test }}
+
 - name: upgrade-{{$EiriniFlag}}-{{$Backend}}-{{$OptionsFlag}}
   serial_groups: [{{$EiriniFlag}}-{{$Backend}}-{{$OptionsFlag}}]
   public: false
@@ -346,7 +408,7 @@ jobs:
     trigger: false
   - get: kubecf-master
     passed:
-    - cf-acceptance-tests-{{$EiriniFlag}}-{{$Backend}}-{{$OptionsFlag}}
+    - sync-integration-tests-{{$EiriniFlag}}-{{$Backend}}-{{$OptionsFlag}}
     trigger: true
   - get: catapult
   - task: upgrade-{{$EiriniFlag}}

--- a/.concourse/cap-release/pipeline.template
+++ b/.concourse/cap-release/pipeline.template
@@ -70,6 +70,7 @@ resources:
 {{- $obtain_kubeconfig := `
             # obtain kubeconfig from pool
             pool_file=${pool_file:-pool.kube-hosts/metadata}
+            export CLUSTER_NAME=$(cat pool.kube-hosts/name)
             cp ${pool_file} catapult/kubeconfig_$CLUSTER_NAME
             pushd catapult
 ` }}
@@ -198,7 +199,6 @@ jobs:
 {{- if eq $OptionsFlag "all" }}
 {{- print $allbells }}
 {{- end }}
-        CLUSTER_NAME: {{$pipelineName}}-{{$EiriniFlag}}-{{$Backend}}-{{$OptionsFlag}}
       run:
         path: "/bin/bash"
         args:
@@ -257,7 +257,6 @@ jobs:
 {{- print $allbells }}
 {{- end }}
         TEST_SUITE: smokes
-        CLUSTER_NAME: {{$pipelineName}}-{{$EiriniFlag}}-{{$Backend}}-{{$OptionsFlag}}
       run:
         path: "/bin/bash"
         args:
@@ -316,7 +315,6 @@ jobs:
 {{- print $allbells }}
 {{- end }}
         TEST_SUITE: cats
-        CLUSTER_NAME: {{$pipelineName}}-{{$EiriniFlag}}-{{$Backend}}-{{$OptionsFlag}}
       run:
         path: "/bin/bash"
         args:
@@ -375,7 +373,6 @@ jobs:
 {{- print $allbells }}
 {{- end }}
         TEST_SUITE: sits
-        CLUSTER_NAME: {{$pipelineName}}-{{$EiriniFlag}}-{{$Backend}}-{{$OptionsFlag}}
       run:
         path: "/bin/bash"
         args:
@@ -439,7 +436,6 @@ jobs:
         TEST_SUITE: cats
         TEST_SUITE: cats
         BACKEND: {{$Backend}}
-        CLUSTER_NAME: {{$pipelineName}}-{{$EiriniFlag}}-{{$Backend}}-{{$OptionsFlag}}
       run:
         path: "/bin/bash"
         args:
@@ -498,7 +494,6 @@ jobs:
 {{- print $allbells }}
 {{- end }}
         TEST_SUITE: cats
-        CLUSTER_NAME: {{$pipelineName}}-{{$EiriniFlag}}-{{$Backend}}-{{$OptionsFlag}}
       run:
         path: "/bin/bash"
         args:

--- a/.concourse/cap-release/pipeline.template
+++ b/.concourse/cap-release/pipeline.template
@@ -59,13 +59,25 @@ resources:
     region_name: us-west-2
     regexp: kubecf-bundle-v(.*).tgz
 
+
+# Pool resource with kube cluster information
+{{ range $_, $Backend := (ds "BACKEND").backend -}} # for all backends
+- name: {{$Backend}}-pool.kube-hosts
+  type: pool
+  source:
+    uri: git@github.com:SUSE/cf-ci-pools.git
+    private_key: ((github-private-key))
+    branch: {{$Backend}}-kube-hosts
+    pool: {{$Backend}}-kube-hosts
+{{end}}
+
 {{ $pipelineName := .Env.PIPELINE }}
 
-{{- $obtain_ekcp := `
-            # obtain kubeconfig from ekcp
+{{- $obtain_kubeconfig := `
+            # obtain kubeconfig from pool
+            pool_file=${pool_file:-pool.kube-hosts/metadata}
+            cp ${pool_file} catapult/kubeconfig_$CLUSTER_NAME
             pushd catapult
-            BACKEND=ekcp make recover
-            cp build$CLUSTER_NAME/kubeconfig kubeconfig_$CLUSTER_NAME
 ` }}
 
 {{- $import_gke := `
@@ -96,7 +108,7 @@ resources:
 ` }}
 
 {{- $import_caasp4 := `
-            # create builfolder prepared for caasp4os
+            # create buildfolder prepared for caasp4os
             export BACKEND=caasp4os
             export KUBECFG=$PWD/kubeconfig_$CLUSTER_NAME
             make kubeconfig
@@ -161,11 +173,15 @@ jobs:
     trigger: true
   - get: kubecf-master
   - get: catapult
+  - put: {{$Backend}}-pool.kube-hosts
+    params: {acquire: true}
+    timeout: 2m
   - task: deploy
     privileged: true
     timeout: 2h30m
     input_mapping:
       kubecf: kubecf-master
+      pool.kube-hosts: {{$Backend}}-pool.kube-hosts
     config:
       platform: linux
       image_resource:
@@ -176,12 +192,10 @@ jobs:
       - name: kubecf
       - name: catapult
       - name: s3.kubecf-bundle
-      outputs:
-      - name: output
+      - name: pool.kube-hosts
       params:
         QUIET_OUTPUT: true
         DEFAULT_STACK: cflinuxfs3
-        EKCP_HOST: ((ekcp-host))
 {{- if eq $EiriniFlag "eirini" }}
         ENABLE_EIRINI: true
 {{ else }}
@@ -199,7 +213,7 @@ jobs:
         args:
           - -c
           - |
-            {{- print $obtain_ekcp }}
+            {{- print $obtain_kubeconfig }}
             {{- if eq $Backend "caasp4" }}
             {{- print $import_caasp4 }}
             {{- end }}
@@ -221,13 +235,17 @@ jobs:
   - get: kubecf-master
     passed:
     - deploy-{{$EiriniFlag}}-{{$Backend}}-{{$OptionsFlag}}
-    trigger: true
   - get: catapult
+  - get: {{$Backend}}-pool.kube-hosts
+    passed:
+    - deploy-{{ $EiriniFlag }}-{{ $Backend }}-{{ $OptionsFlag }}
+    trigger: true
   - task: test-{{$EiriniFlag}}
     privileged: true
     timeout: 1h30m
     input_mapping:
       kubecf: kubecf-master
+      pool.kube-hosts: {{$Backend}}-pool.kube-hosts
     config:
       platform: linux
       image_resource:
@@ -237,12 +255,10 @@ jobs:
       inputs:
       - name: catapult
       - name: kubecf
-      outputs:
-      - name: output
+      - name: pool.kube-hosts
       params:
         QUIET_OUTPUT: true
         DEFAULT_STACK: cflinuxfs3
-        EKCP_HOST: ((ekcp-host))
 {{- if eq $EiriniFlag "eirini" }}
         ENABLE_EIRINI: true
 {{ else }}
@@ -261,7 +277,7 @@ jobs:
         args:
           - -c
           - |
-            {{- print $obtain_ekcp }}
+            {{- print $obtain_kubeconfig }}
             {{- if eq $Backend "caasp4" }}
             {{- print $import_caasp4 }}
             {{- end }}
@@ -283,13 +299,17 @@ jobs:
   - get: kubecf-master
     passed:
     - smoke-tests-{{$EiriniFlag}}-{{$Backend}}-{{$OptionsFlag}}
-    trigger: true
   - get: catapult
+  - get: {{$Backend}}-pool.kube-hosts
+    passed:
+    - smoke-tests-{{$EiriniFlag}}-{{$Backend}}-{{$OptionsFlag}}
+    trigger: true
   - task: test-{{$EiriniFlag}}
     privileged: true
     timeout: 5h30m
     input_mapping:
       kubecf: kubecf-master
+      pool.kube-hosts: {{$Backend}}-pool.kube-hosts
     config:
       platform: linux
       image_resource:
@@ -299,12 +319,10 @@ jobs:
       inputs:
       - name: catapult
       - name: kubecf
-      outputs:
-      - name: output
+      - name: pool.kube-hosts
       params:
         QUIET_OUTPUT: true
         DEFAULT_STACK: cflinuxfs3
-        EKCP_HOST: ((ekcp-host))
 {{- if eq $EiriniFlag "eirini" }}
         ENABLE_EIRINI: true
 {{ else }}
@@ -323,7 +341,7 @@ jobs:
         args:
           - -c
           - |
-            {{- print $obtain_ekcp }}
+            {{- print $obtain_kubeconfig}}
             {{- if eq $Backend "caasp4" }}
             {{- print $import_caasp4 }}
             {{- end }}
@@ -345,13 +363,17 @@ jobs:
   - get: kubecf-master
     passed:
     - cf-acceptance-tests-{{$EiriniFlag}}-{{$Backend}}-{{$OptionsFlag}}
-    trigger: true
   - get: catapult
+  - get: {{$Backend}}-pool.kube-hosts
+    passed:
+    - cf-acceptance-tests-{{$EiriniFlag}}-{{$Backend}}-{{$OptionsFlag}}
+    trigger: true
   - task: test-{{$EiriniFlag}}
     privileged: true
     timeout: 5h30m
     input_mapping:
       kubecf: kubecf-master
+      pool.kube-hosts: {{$Backend}}-pool.kube-hosts
     config:
       platform: linux
       image_resource:
@@ -361,12 +383,10 @@ jobs:
       inputs:
       - name: catapult
       - name: kubecf
-      outputs:
-      - name: output
+      - name: pool.kube-hosts
       params:
         QUIET_OUTPUT: true
         DEFAULT_STACK: cflinuxfs3
-        EKCP_HOST: ((ekcp-host))
 {{- if eq $EiriniFlag "eirini" }}
         ENABLE_EIRINI: true
 {{ else }}
@@ -409,13 +429,17 @@ jobs:
   - get: kubecf-master
     passed:
     - sync-integration-tests-{{$EiriniFlag}}-{{$Backend}}-{{$OptionsFlag}}
-    trigger: true
   - get: catapult
+  - get: {{$Backend}}-pool.kube-hosts
+    passed:
+    - sync-integration-tests-{{$EiriniFlag}}-{{$Backend}}-{{$OptionsFlag}}
+    trigger: true
   - task: upgrade-{{$EiriniFlag}}
     privileged: true
     timeout: 5h30m
     input_mapping:
       kubecf: kubecf-master
+      pool.kube-hosts: {{$Backend}}-pool.kube-hosts
     config:
       platform: linux
       image_resource:
@@ -426,12 +450,10 @@ jobs:
       - name: catapult
       - name: kubecf
       - name: s3.kubecf-bundle
-      outputs:
-      - name: output
+      - name: pool.kube-hosts
       params:
         QUIET_OUTPUT: true
         DEFAULT_STACK: cflinuxfs3
-        EKCP_HOST: ((ekcp-host))
 {{- if eq $EiriniFlag "eirini" }}
         ENABLE_EIRINI: true
 {{ else }}
@@ -452,7 +474,7 @@ jobs:
         args:
           - -c
           - |
-            {{- print $obtain_ekcp }}
+            {{- print $obtain_kubeconfig }}
             {{- if eq $Backend "caasp4" }}
             {{- print $import_caasp4 }}
             {{- end }}
@@ -474,13 +496,17 @@ jobs:
   - get: kubecf-master
     passed:
     - upgrade-{{$EiriniFlag}}-{{$Backend}}-{{$OptionsFlag}}
-    trigger: true
   - get: catapult
+  - get: {{$Backend}}-pool.kube-hosts
+    passed:
+    - upgrade-{{$EiriniFlag}}-{{$Backend}}-{{$OptionsFlag}}
+    trigger: true
   - task: stratos-{{$EiriniFlag}}
     privileged: true
     timeout: 5h30m
     input_mapping:
       kubecf: kubecf-master
+      pool.kube-hosts: {{$Backend}}-pool.kube-hosts
     config:
       platform: linux
       image_resource:
@@ -490,12 +516,10 @@ jobs:
       inputs:
       - name: catapult
       - name: kubecf
-      outputs:
-      - name: output
+      - name: pool.kube-hosts
       params:
         QUIET_OUTPUT: true
         DEFAULT_STACK: cflinuxfs3
-        EKCP_HOST: ((ekcp-host))
 {{- if eq $EiriniFlag "eirini" }}
         ENABLE_EIRINI: true
 {{ else }}
@@ -514,7 +538,7 @@ jobs:
         args:
           - -c
           - |
-            {{- print $obtain_ekcp }}
+            {{- print $obtain_kubeconfig }}
             {{- if eq $Backend "caasp4" }}
             {{- print $import_caasp4 }}
             {{- end }}

--- a/.concourse/cap-release/pipeline.template
+++ b/.concourse/cap-release/pipeline.template
@@ -38,12 +38,6 @@ resource_types:
     tag: release
 
 resources:
-- name: kubecf-master
-  type: git
-  source:
-    branch: master
-    uri: https://github.com/SUSE/kubecf
-
 - name: catapult
   type: git
   source:
@@ -171,7 +165,6 @@ jobs:
   plan:
   - get: s3.kubecf-bundle
     trigger: true
-  - get: kubecf-master
   - get: catapult
   - put: {{$Backend}}-pool.kube-hosts
     params: {acquire: true}
@@ -180,7 +173,6 @@ jobs:
     privileged: true
     timeout: 2h30m
     input_mapping:
-      kubecf: kubecf-master
       pool.kube-hosts: {{$Backend}}-pool.kube-hosts
     config:
       platform: linux
@@ -189,7 +181,6 @@ jobs:
         source:
           repository: splatform/catapult
       inputs:
-      - name: kubecf
       - name: catapult
       - name: s3.kubecf-bundle
       - name: pool.kube-hosts
@@ -232,9 +223,6 @@ jobs:
   serial_groups: [{{$EiriniFlag}}-{{$Backend}}-{{$OptionsFlag}}]
   public: false
   plan:
-  - get: kubecf-master
-    passed:
-    - deploy-{{$EiriniFlag}}-{{$Backend}}-{{$OptionsFlag}}
   - get: catapult
   - get: {{$Backend}}-pool.kube-hosts
     passed:
@@ -244,7 +232,6 @@ jobs:
     privileged: true
     timeout: 1h30m
     input_mapping:
-      kubecf: kubecf-master
       pool.kube-hosts: {{$Backend}}-pool.kube-hosts
     config:
       platform: linux
@@ -254,7 +241,6 @@ jobs:
           repository: splatform/catapult
       inputs:
       - name: catapult
-      - name: kubecf
       - name: pool.kube-hosts
       params:
         QUIET_OUTPUT: true
@@ -296,9 +282,6 @@ jobs:
   serial_groups: [{{$EiriniFlag}}-{{$Backend}}-{{$OptionsFlag}}]
   public: false
   plan:
-  - get: kubecf-master
-    passed:
-    - smoke-tests-{{$EiriniFlag}}-{{$Backend}}-{{$OptionsFlag}}
   - get: catapult
   - get: {{$Backend}}-pool.kube-hosts
     passed:
@@ -308,7 +291,6 @@ jobs:
     privileged: true
     timeout: 5h30m
     input_mapping:
-      kubecf: kubecf-master
       pool.kube-hosts: {{$Backend}}-pool.kube-hosts
     config:
       platform: linux
@@ -318,7 +300,6 @@ jobs:
           repository: splatform/catapult
       inputs:
       - name: catapult
-      - name: kubecf
       - name: pool.kube-hosts
       params:
         QUIET_OUTPUT: true
@@ -360,9 +341,6 @@ jobs:
   serial_groups: [{{$EiriniFlag}}-{{$Backend}}-{{$OptionsFlag}}]
   public: false
   plan:
-  - get: kubecf-master
-    passed:
-    - cf-acceptance-tests-{{$EiriniFlag}}-{{$Backend}}-{{$OptionsFlag}}
   - get: catapult
   - get: {{$Backend}}-pool.kube-hosts
     passed:
@@ -372,7 +350,6 @@ jobs:
     privileged: true
     timeout: 5h30m
     input_mapping:
-      kubecf: kubecf-master
       pool.kube-hosts: {{$Backend}}-pool.kube-hosts
     config:
       platform: linux
@@ -382,7 +359,6 @@ jobs:
           repository: splatform/catapult
       inputs:
       - name: catapult
-      - name: kubecf
       - name: pool.kube-hosts
       params:
         QUIET_OUTPUT: true
@@ -426,9 +402,6 @@ jobs:
   plan:
   - get: s3.kubecf-bundle
     trigger: false
-  - get: kubecf-master
-    passed:
-    - sync-integration-tests-{{$EiriniFlag}}-{{$Backend}}-{{$OptionsFlag}}
   - get: catapult
   - get: {{$Backend}}-pool.kube-hosts
     passed:
@@ -438,7 +411,6 @@ jobs:
     privileged: true
     timeout: 5h30m
     input_mapping:
-      kubecf: kubecf-master
       pool.kube-hosts: {{$Backend}}-pool.kube-hosts
     config:
       platform: linux
@@ -448,7 +420,6 @@ jobs:
           repository: splatform/catapult
       inputs:
       - name: catapult
-      - name: kubecf
       - name: s3.kubecf-bundle
       - name: pool.kube-hosts
       params:
@@ -493,9 +464,6 @@ jobs:
   serial_groups: [{{$EiriniFlag}}-{{$Backend}}-{{$OptionsFlag}}]
   public: false
   plan:
-  - get: kubecf-master
-    passed:
-    - upgrade-{{$EiriniFlag}}-{{$Backend}}-{{$OptionsFlag}}
   - get: catapult
   - get: {{$Backend}}-pool.kube-hosts
     passed:
@@ -505,7 +473,6 @@ jobs:
     privileged: true
     timeout: 5h30m
     input_mapping:
-      kubecf: kubecf-master
       pool.kube-hosts: {{$Backend}}-pool.kube-hosts
     config:
       platform: linux
@@ -515,7 +482,6 @@ jobs:
           repository: splatform/catapult
       inputs:
       - name: catapult
-      - name: kubecf
       - name: pool.kube-hosts
       params:
         QUIET_OUTPUT: true

--- a/.concourse/cap-release/pipeline.template
+++ b/.concourse/cap-release/pipeline.template
@@ -1,10 +1,10 @@
 ---
 
 groups:
-- name: ALL
-  jobs:
 {{ range $_, $Backend := (ds "BACKEND").backend -}} # for all backends
-{{ range $_, $Jobs := slice "deploy" "smoke-tests" "cf-acceptance-tests" "upgrade" "stratos" -}} # for jobs
+- name: {{$Backend}}
+  jobs:
+{{ range $_, $Jobs := slice "deploy" "smoke-tests" "cf-acceptance-tests" "sync-integration-tests" "upgrade" "stratos" -}} # for jobs
 {{ range $_, $EiriniFlag := (ds "EIRINI").eirini -}} # for eirini
 {{ range $_, $OptionsFlag := (ds "OPTIONS").options -}} # for options
     - {{$Jobs}}-{{$EiriniFlag}}-{{$Backend}}-{{$OptionsFlag}}
@@ -12,9 +12,9 @@ groups:
 {{ end }} # end eirini
 {{ end }} # end options
 {{ end }} # end backend
-{{ range $_, $Backend := (ds "BACKEND").backend -}} # for all backends
-- name: {{$Backend}}
+- name: ALL
   jobs:
+{{ range $_, $Backend := (ds "BACKEND").backend -}} # for all backends
 {{ range $_, $Jobs := slice "deploy" "smoke-tests" "cf-acceptance-tests" "upgrade" "stratos" -}} # for jobs
 {{ range $_, $EiriniFlag := (ds "EIRINI").eirini -}} # for eirini
 {{ range $_, $OptionsFlag := (ds "OPTIONS").options -}} # for options
@@ -47,7 +47,7 @@ resources:
 - name: catapult
   type: git
   source:
-    branch: master
+    branch: fix-test-jobs-removal
     uri: https://github.com/SUSE/catapult
 
 - name: s3.kubecf-bundle


### PR DESCRIPTION
## Description

- Implement pools and remove ekcp
CI now uses concourse pool resource. Inorder to test you cluster you will have to place you kubeconfig in ${backend}-kube-hosts branch of git@github.com:SUSE/cf-ci-pools.git in unclaimed folder.

- Fix triggers
This is a bug fix. Post deploy, CI's consequent jobs  were getting triggered by kubecf git resource. Now all jobs gets triggered via kubeconfig / pool resource

- Remove kubecf resource
kubecf github repo is not required in this CI as a resource.

- remove kubecf CI to avoid any confusion

## Motivation and Context
Pool implementation  is required to manage locks on kubeconfigs while testing.

## How Has This Been Tested?
https://concourse.suse.dev/teams/main/pipelines/prabal-demo-release?group=eks

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
