### PR TITLE
Fix. Modified the database initialization sequence.

### DIFF
--- a/deploy/helm/kubecf/assets/scripts/jobs/pxc/functions.sh
+++ b/deploy/helm/kubecf/assets/scripts/jobs/pxc/functions.sh
@@ -33,6 +33,8 @@ init_mysql() {
     # if we have CLUSTER_JOIN - then we do not need to perform datadir initialize
     # the data will be copied from another node
     if [ ! -e "$DATADIR/$SENTINEL" ]; then
+        echo "Removing pending files in $DATADIR, because sentinel was not reached"
+        rm -rf "$DATADIR"/*
         if [ -z "$MYSQL_ROOT_PASSWORD" ] && [ -z "$MYSQL_ALLOW_EMPTY_PASSWORD" ] && [ -z "$MYSQL_RANDOM_ROOT_PASSWORD" ] && [ -z "$MYSQL_ROOT_PASSWORD_FILE" ]; then
             echo >&2 'error: database is uninitialized and password option is not specified '
             echo >&2 '  You need to specify one of MYSQL_ROOT_PASSWORD, MYSQL_ROOT_PASSWORD_FILE,  MYSQL_ALLOW_EMPTY_PASSWORD or MYSQL_RANDOM_ROOT_PASSWORD'

--- a/deploy/helm/kubecf/assets/scripts/jobs/pxc/functions.sh
+++ b/deploy/helm/kubecf/assets/scripts/jobs/pxc/functions.sh
@@ -28,10 +28,11 @@ EOF
 }
 
 init_mysql() {
+    SENTINEL=INIT_MYSQL_DONE
     DATADIR=/var/lib/mysql
     # if we have CLUSTER_JOIN - then we do not need to perform datadir initialize
     # the data will be copied from another node
-    if [ ! -e "$DATADIR/mysql" ]; then
+    if [ ! -e "$DATADIR/$SENTINEL" ]; then
         if [ -z "$MYSQL_ROOT_PASSWORD" ] && [ -z "$MYSQL_ALLOW_EMPTY_PASSWORD" ] && [ -z "$MYSQL_RANDOM_ROOT_PASSWORD" ] && [ -z "$MYSQL_ROOT_PASSWORD_FILE" ]; then
             echo >&2 'error: database is uninitialized and password option is not specified '
             echo >&2 '  You need to specify one of MYSQL_ROOT_PASSWORD, MYSQL_ROOT_PASSWORD_FILE,  MYSQL_ALLOW_EMPTY_PASSWORD or MYSQL_RANDOM_ROOT_PASSWORD'
@@ -130,5 +131,6 @@ EOSQL
         echo
         echo 'MySQL init process done. Ready for start up.'
         echo
+        touch "$DATADIR/$SENTINEL"
     fi
 }

--- a/deploy/helm/kubecf/assets/scripts/jobs/pxc/functions.sh
+++ b/deploy/helm/kubecf/assets/scripts/jobs/pxc/functions.sh
@@ -34,7 +34,7 @@ init_mysql() {
     # the data will be copied from another node
     if [ ! -e "$DATADIR/$SENTINEL" ]; then
         echo "Removing pending files in $DATADIR, because sentinel was not reached"
-        rm -rf "$DATADIR"/*
+        rm -rf "${DATADIR:?}"/*
         if [ -z "$MYSQL_ROOT_PASSWORD" ] && [ -z "$MYSQL_ALLOW_EMPTY_PASSWORD" ] && [ -z "$MYSQL_RANDOM_ROOT_PASSWORD" ] && [ -z "$MYSQL_ROOT_PASSWORD_FILE" ]; then
             echo >&2 'error: database is uninitialized and password option is not specified '
             echo >&2 '  You need to specify one of MYSQL_ROOT_PASSWORD, MYSQL_ROOT_PASSWORD_FILE,  MYSQL_ALLOW_EMPTY_PASSWORD or MYSQL_RANDOM_ROOT_PASSWORD'


### PR DESCRIPTION
# Description

Use a sentinel file not touched by mysql itself and getting explicitly set when initialization has completed. This prevents slows systems from leaving a partial initialization behind where the old sentinel was already set, causing regular activation of the server on this and breaking.

## Motivation and Context
See https://github.com/cloudfoundry-incubator/kubecf/issues/566

## How Has This Been Tested?

Stood up a cluster on the system where the issue occurred. Before the change the database pod gets stuck, never becomes running, and the remainder of the system is then stuck also.

With the change the cluster is standing up ok, the database pod takes longer to start completely, but start it does.

In a system where the issue does not (SSD backed) a cluster with the change also stands up ok, IOW the change is not breaking thing in general.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
