### PR TITLE
Extract log-cache jobs from the doppler into a separate instance group

### DIFF
--- a/deploy/helm/kubecf/BUILD.bazel
+++ b/deploy/helm/kubecf/BUILD.bazel
@@ -47,12 +47,19 @@ yaml_extractor(
     filter = """.instance_groups[] | select(.name == "api") | .jobs[] | select(.name == "routing-api")""",
 )
 
+yaml_extractor(
+    name = "log_cache_jobs",
+    src = "@cf_deployment//:cf-deployment.yml",
+    filter = """[.instance_groups[] | select(.name == "doppler") | .jobs[] | select(.name | contains("log-cache"))]""",
+)
+
 pkg_tar(
     name = "extracted_jobs",
     package_dir = "assets/jobs",
     srcs = [
         ":auctioneer_job",
         ":routing_api_job",
+        ":log_cache_jobs",
     ],
 )
 

--- a/deploy/helm/kubecf/assets/operations/instance_groups/doppler.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/doppler.yaml
@@ -30,84 +30,9 @@
             exec:
               command: [curl, --fail, --head, --silent, http://localhost:14825/health]
 
-# Add quarks properties for log-cache.
-- type: replace
-  path: /instance_groups/name=doppler/jobs/name=log-cache/properties/health_addr?
-  value: "::6060"
-- type: replace
-  path: /instance_groups/name=doppler/jobs/name=log-cache/properties/quarks?
-  value:
-    ports:
-    - name: log-cache
-      protocol: TCP
-      internal: 8080
-    run:
-      healthcheck:
-        log-cache:
-          readiness:
-            exec:
-              command:
-              - curl
-              - --insecure
-              - --fail
-              - --head
-              - --silent
-              - --cert
-              - /var/vcap/jobs/log-cache/config/certs/metrics.crt
-              - --key
-              - /var/vcap/jobs/log-cache/config/certs/metrics.key
-              - https://localhost:6060/debug/pprof/cmdline
-
-- type: replace
-  path: /instance_groups/name=doppler/jobs/name=log-cache-gateway/properties/quarks?/run/healthcheck/log-cache-gateway
-  value:
-    readiness:
-      # Unfortunately, by default the health port listens on localhost only
-      # and isn't easily configurable
-      exec:
-        command:
-        - curl
-        - --insecure
-        - --fail
-        - --head
-        - --silent
-        - --cert
-        - /var/vcap/jobs/log-cache/config/certs/metrics.crt
-        - --key
-        - /var/vcap/jobs/log-cache/config/certs/metrics.key
-        - https://localhost:6063/debug/pprof/cmdline
-
-- type: replace
-  path: /instance_groups/name=doppler/jobs/name=log-cache-nozzle/properties/quarks?/run/healthcheck/log-cache-nozzle
-  value:
-    readiness:
-      # Unfortunately, by default the health port listens on localhost only
-      # and isn't easily configurable
-      exec:
-        command: [curl, --fail, --head, --silent, http://localhost:6061/debug/pprof/cmdline]
-
 - type: replace
   path: /instance_groups/name=doppler/jobs/name=route_registrar/properties/quarks?/run/healthcheck/route_registrar
   value:
     readiness: ~
       # The route registrar doesn't expose anything to indicate if the
       # routes are healthy
-
-- type: replace
-  path: /instance_groups/name=doppler/jobs/name=log-cache-cf-auth-proxy/properties/quarks?/run/healthcheck/log-cache-cf-auth-proxy
-  value:
-    readiness:
-      # Unfortunately, by default the health port listens on localhost only
-      # and isn't easily configurable
-      exec:
-        command:
-        - curl
-        - --insecure
-        - --fail
-        - --head
-        - --silent
-        - --cert
-        - /var/vcap/jobs/log-cache/config/certs/metrics.crt
-        - --key
-        - /var/vcap/jobs/log-cache/config/certs/metrics.key
-        - https://localhost:6065/debug/pprof/cmdline

--- a/deploy/helm/kubecf/assets/operations/instance_groups/log-cache.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/log-cache.yaml
@@ -1,0 +1,75 @@
+
+# Add quarks properties for log-cache.
+- type: replace
+  path: /instance_groups/name=log-cache/jobs/name=log-cache/properties/health_addr?
+  value: "::6060"
+- type: replace
+  path: /instance_groups/name=log-cache/jobs/name=log-cache/properties/quarks?
+  value:
+    ports:
+    - name: log-cache
+      protocol: TCP
+      internal: 8080
+    run:
+      healthcheck:
+        log-cache:
+          readiness:
+            exec:
+              command:
+              - curl
+              - --insecure
+              - --fail
+              - --head
+              - --silent
+              - --cert
+              - /var/vcap/jobs/log-cache/config/certs/metrics.crt
+              - --key
+              - /var/vcap/jobs/log-cache/config/certs/metrics.key
+              - https://localhost:6060/debug/pprof/cmdline
+
+- type: replace
+  path: /instance_groups/name=log-cache/jobs/name=log-cache-gateway/properties/quarks?/run/healthcheck/log-cache-gateway
+  value:
+    readiness:
+      # Unfortunately, by default the health port listens on localhost only
+      # and isn't easily configurable
+      exec:
+        command:
+        - curl
+        - --insecure
+        - --fail
+        - --head
+        - --silent
+        - --cert
+        - /var/vcap/jobs/log-cache/config/certs/metrics.crt
+        - --key
+        - /var/vcap/jobs/log-cache/config/certs/metrics.key
+        - https://localhost:6063/debug/pprof/cmdline
+
+- type: replace
+  path: /instance_groups/name=log-cache/jobs/name=log-cache-nozzle/properties/quarks?/run/healthcheck/log-cache-nozzle
+  value:
+    readiness:
+      # Unfortunately, by default the health port listens on localhost only
+      # and isn't easily configurable
+      exec:
+        command: [curl, --fail, --head, --silent, http://localhost:6061/debug/pprof/cmdline]
+
+- type: replace
+  path: /instance_groups/name=log-cache/jobs/name=log-cache-cf-auth-proxy/properties/quarks?/run/healthcheck/log-cache-cf-auth-proxy
+  value:
+    readiness:
+      # Unfortunately, by default the health port listens on localhost only
+      # and isn't easily configurable
+      exec:
+        command:
+        - curl
+        - --insecure
+        - --fail
+        - --head
+        - --silent
+        - --cert
+        - /var/vcap/jobs/log-cache/config/certs/metrics.crt
+        - --key
+        - /var/vcap/jobs/log-cache/config/certs/metrics.key
+        - https://localhost:6065/debug/pprof/cmdline

--- a/deploy/helm/kubecf/assets/operations/unordered/move_log_cache.yaml
+++ b/deploy/helm/kubecf/assets/operations/unordered/move_log_cache.yaml
@@ -1,0 +1,19 @@
+# Move log-cache jobs to a separate instance group
+# log-cache can not be scaled in a robust manner as of now. Extracting it
+# into a separate ig allows for scaling doppler again.
+- type: remove
+  path: /instance_groups/name=doppler/jobs/name=log-cache
+- type: remove
+  path: /instance_groups/name=doppler/jobs/name=log-cache-gateway
+- type: remove
+  path: /instance_groups/name=doppler/jobs/name=log-cache-nozzle
+- type: remove
+  path: /instance_groups/name=doppler/jobs/name=log-cache-cf-auth-proxy
+- type: replace
+  path: /instance_groups/name=doppler:after
+  value:
+    name: log-cache
+    instances: 1
+    stemcell: default
+    jobs:
+    {{- .Files.Get "assets/jobs/log_cache_jobs.yaml" | nindent 4 }}

--- a/deploy/helm/kubecf/templates/bosh_deployment.yaml
+++ b/deploy/helm/kubecf/templates/bosh_deployment.yaml
@@ -20,6 +20,8 @@ spec:
     type: configmap
   - name: {{ include "kubecf.ops-name" (dict "ReleaseName" $root.Release.Name "Path" "assets/operations/unordered/move_routing_api.yaml") }}
     type: configmap
+  - name: {{ include "kubecf.ops-name" (dict "ReleaseName" $root.Release.Name "Path" "assets/operations/unordered/move_log_cache.yaml") }}
+    type: configmap
 {{- if .Values.features.suse_buildpacks.enabled }}
   - name: {{ include "kubecf.ops-name" (dict "ReleaseName" $root.Release.Name "Path" "assets/operations/buildpacks/set_suse_buildpacks.yaml") }}
     type: configmap

--- a/deploy/helm/kubecf/templates/ops.yaml
+++ b/deploy/helm/kubecf/templates/ops.yaml
@@ -22,6 +22,7 @@ data:
 
 {{ include "kubecf.ops" (dict "Root" $root "Path" "assets/operations/unordered/move_auctioneer.yaml") }}
 {{ include "kubecf.ops" (dict "Root" $root "Path" "assets/operations/unordered/move_routing_api.yaml") }}
+{{ include "kubecf.ops" (dict "Root" $root "Path" "assets/operations/unordered/move_log_cache.yaml") }}
 
 {{- if .Values.features.suse_buildpacks.enabled }}
 {{ include "kubecf.ops" (dict "Root" $root "Path" "assets/operations/buildpacks/set_suse_buildpacks.yaml") }}


### PR DESCRIPTION
That way doppler can be scaled and log-cache kept as a singleton.
Scaling log-cache doesn't work as of now.

*Note*: There's still one failing smoke test and pushing apps fails with some stats server error. The app does run fine and logs can be streamed, though.