### PR TITLE
Bump brain test release to v0.0.10.

### DIFF
--- a/deploy/helm/kubecf/values.yaml
+++ b/deploy/helm/kubecf/values.yaml
@@ -47,10 +47,10 @@ releases:
   bits-service:
     version: 2.28.0
   brain-tests:
-    version: v0.0.9
+    version: v0.0.10
     stemcell:
       os: SLE_15_SP1
-      version: 23.11-7.0.0_374.gb8e8e6af
+      version: 23.16-7.0.0_374.gb8e8e6af
   cf-acceptance-tests:
     version: 0.0.11
     stemcell:


### PR DESCRIPTION
## Description

Bumps the brain test release to `v0.0.10`.

## Motivation and Context

Ref: https://jira.suse.com/browse/CAP-526

## How Has This Been Tested?

Local invokation of the brain tests in a minikube based cluster.

__Note__: I have seen case `010` both passing and failing for the same commit, the bumped BTR version. Currently more suspecting glitchiness in my environment, hence why I decided to go forward with making a PR.

The failure hit the 10 minute limit. And according to the log I have the case actually succeeded. It just did not terminate. This seems to be what @mook-as has seen before in his local environment. More notes in the referenced ticket.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
