### PR TITLE
Split KubeCF pipeline in prod and no-prod jobs

### DIFF
--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -7,6 +7,9 @@
 # don't have to know what kind of values were used when it was deployed last
 # time.
 
+{{ $prod := slice "queue-pr" "queue-master" "queue-fork-pr" "lint" "build" "publish"}}
+{{ $noprod := slice }}
+
 resource_types:
 - name: pull-request
   type: docker-image
@@ -361,10 +364,17 @@ jobs:
       file: output/kubecf-bundle-v*.tgz
       acl: public-read
 
+
+# Special case, as Eirini is not ready, we don't want CATs to end up in prod job view:
+{{ $noprod = $noprod | append "cf-acceptance-tests-eirini" }}
+{{ $prod = $prod | append "cf-acceptance-tests-diego" }}
+# TODO: Delete the special case here as soon as we get Eirini CATS green
+
 {{- range $_, $cfScheduler := slice "diego" "eirini" }}
 
 # prod-jobs
-
+# Generate the prod slice in the range, so we have the full list for the tab view group
+{{ $prod = $prod | append ( printf "deploy-%s" $cfScheduler ) }}
 - name: deploy-{{ $cfScheduler }}
   #max_in_flight: 1 # Re-enable to when we want to set a limit on concurrent deployments
   public: true
@@ -466,6 +476,7 @@ jobs:
     - put: kind-environments
       params: { remove : kind-environments}
 
+{{ $prod = $prod | append ( printf "smoke-tests-%s" $cfScheduler ) }}
 - name: smoke-tests-{{ $cfScheduler }}
   public: true
   plan:
@@ -545,6 +556,8 @@ jobs:
     - put: kind-environments
       params: { remove : kind-environments}
 
+# TODO: Add the append here as soon as we get Eirini CATS green, and remove the special case at the top of the range
+# It should have been: {{/*  $prod = $prod | append ( printf "cf-acceptance-tests-%s" $cfScheduler )  */}}
 - name: cf-acceptance-tests-{{ $cfScheduler }}
   public: true
   plan:
@@ -625,6 +638,8 @@ jobs:
       params: { remove : kind-environments}
 
 # no-prod jobs
+
+{{ $noprod = $noprod | append ( printf "sync-integration-tests-%s" $cfScheduler ) }}
 - name: sync-integration-tests-{{ $cfScheduler }}
   public: true
   plan:
@@ -704,6 +719,7 @@ jobs:
     - put: kind-environments
       params: { remove : kind-environments}
 
+{{ $noprod = $noprod | append ( printf "ccdb-rotate-%s" $cfScheduler ) }}
 - name: ccdb-rotate-{{ $cfScheduler }}
   public: true
   plan:
@@ -785,6 +801,7 @@ jobs:
     - put: kind-environments
       params: { remove : kind-environments}
 
+{{ $noprod = $noprod | append ( printf "smoke-tests-post-rotate-%s" $cfScheduler ) }}
 - name: smoke-tests-post-rotate-{{ $cfScheduler }}
   public: true
   plan:
@@ -933,6 +950,8 @@ jobs:
 #           CLUSTER_NAME_PREFIX: "kubecf-{{ $cfScheduler }}"
 #           EKCP_HOST: ((ekcp-host))
 
+# Cleanup gets executed only at the end, make it into noprod as we need to keep it at the end
+{{ $noprod = $noprod | append ( printf "cleanup-%s-cluster" $cfScheduler ) }}
 - name: cleanup-{{ $cfScheduler }}-cluster
   public: true
   plan:
@@ -1000,3 +1019,14 @@ jobs:
       - put: s3.kubecf-bundle
         params:
           file: s3.kubecf-ci-bundle/kubecf-bundle-v*.tgz
+
+groups:
+- name: prod
+  jobs: [ {{ join $prod "," }} ]
+
+- name: no-prod
+  jobs: [ {{ join $noprod "," }} ]
+
+- name: all
+  # Joins prod and noprod with a "," while filtering elements making them uniques.
+  jobs: [ {{ join (flatten (slice $prod $noprod) | uniq ) "," }} ]

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -329,6 +329,8 @@ jobs:
           ./dev/linters/shellcheck.sh
           ./dev/linters/yamllint.sh
           ./dev/linters/helmlint.sh
+
+{{- if has $prod "lint" }}
     on_success:
       put: commit-to-test
       params:
@@ -347,6 +349,8 @@ jobs:
         state: "failure"
         contexts: "lint"
         github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
+{{- end }}
+
 - name: build
   public: false # TODO: public or not?
   plan:
@@ -374,6 +378,7 @@ jobs:
         - |
           cd commit-to-test
           ./dev/build.sh ../output
+{{- if has $prod "build" }}
     on_success:
       put: commit-to-test
       params:
@@ -393,6 +398,7 @@ jobs:
           commit_path: "commit-to-test/.git/resource/ref"
           version_path: "commit-to-test/.git/resource/version"
           github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
+{{- end }}
   - put: s3.kubecf-ci
     params:
       file: output/kubecf-v*.tgz

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -363,6 +363,8 @@ jobs:
 
 {{- range $_, $cfScheduler := slice "diego" "eirini" }}
 
+# prod-jobs
+
 - name: deploy-{{ $cfScheduler }}
   #max_in_flight: 1 # Re-enable to when we want to set a limit on concurrent deployments
   public: true
@@ -543,7 +545,87 @@ jobs:
     - put: kind-environments
       params: { remove : kind-environments}
 
-- name: ccdb-rotate-{{ $cfScheduler }}
+- name: cf-acceptance-tests-{{ $cfScheduler }}
+  public: true
+  plan:
+  - get: kind-environments
+    passed:
+    - smoke-tests-{{ $cfScheduler }}
+  - get: commit-to-test
+    passed:
+    - smoke-tests-{{ $cfScheduler }}
+    trigger: true
+    version: "every"
+  - get: s3.kubecf-ci
+    passed:
+    - smoke-tests-{{ $cfScheduler }}
+  - get: s3.kubecf-ci-bundle
+    passed:
+    - smoke-tests-{{ $cfScheduler }}
+  - get: catapult
+  - task: test-{{ $cfScheduler }}
+    privileged: true
+    timeout: 5h30m
+    config:
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: splatform/catapult
+      inputs:
+      - name: catapult
+      - name: kind-environments
+      - name: commit-to-test
+      outputs:
+      - name: output
+      params:
+        DEFAULT_STACK: cflinuxfs3
+        TEST_SUITE: cats
+        CLUSTER_NAME_PREFIX: kubecf-{{ $cfScheduler }}
+      run:
+        path: "/bin/bash"
+        args: *test_args
+  on_success:
+    put: commit-to-test
+    params:
+      description: "Acceptance tests on {{ $cfScheduler }} succeeded"
+      state: "success"
+      contexts: "acceptance-{{ $cfScheduler }}"
+      commit_path: "commit-to-test/.git/resource/ref"
+      version_path: "commit-to-test/.git/resource/version"
+      github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
+  on_failure:
+    do:
+    - put: commit-to-test
+      params:
+        description: "Acceptance tests on {{ $cfScheduler }} failed"
+        state: "failure"
+        commit_path: "commit-to-test/.git/resource/ref"
+        version_path: "commit-to-test/.git/resource/version"
+        contexts: "acceptance-{{ $cfScheduler }}"
+        github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
+    - task: cleanup-cluster
+      config:
+        <<: *cleanup-cluster
+    - put: kind-environments
+      params: { remove : kind-environments}
+  on_abort:
+    do:
+    - task: cleanup-cluster
+      config:
+        <<: *cleanup-cluster
+    - put: kind-environments
+      params: { remove : kind-environments}
+  on_error:
+    do:
+    - task: cleanup-cluster
+      config:
+        <<: *cleanup-cluster
+    - put: kind-environments
+      params: { remove : kind-environments}
+
+# no-prod jobs
+- name: sync-integration-tests-{{ $cfScheduler }}
   public: true
   plan:
   - get: kind-environments
@@ -560,6 +642,85 @@ jobs:
   - get: s3.kubecf-ci-bundle
     passed:
     - cf-acceptance-tests-{{ $cfScheduler }}
+  - get: catapult
+  - task: test-{{ $cfScheduler }}
+    privileged: true
+    timeout: 1h30m
+    config:
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: splatform/catapult
+      inputs:
+      - name: catapult
+      - name: commit-to-test
+      - name: kind-environments
+      outputs:
+      - name: output
+      params:
+        DEFAULT_STACK: cflinuxfs3
+        TEST_SUITE: sits
+        CLUSTER_NAME_PREFIX: kubecf-{{ $cfScheduler }}
+      run:
+        path: "/bin/bash"
+        args: *test_args
+  on_success:
+    put: commit-to-test
+    params:
+      description: "Sync Integration tests on {{ $cfScheduler }} succeeded"
+      state: "success"
+      contexts: "sync-integration-tests-{{ $cfScheduler }}"
+      commit_path: "commit-to-test/.git/resource/ref"
+      version_path: "commit-to-test/.git/resource/version"
+      github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
+  on_failure:
+    do:
+    - put: commit-to-test
+      params:
+        description: "Sync Integration tests on {{ $cfScheduler }} failed"
+        state: "failure"
+        commit_path: "commit-to-test/.git/resource/ref"
+        version_path: "commit-to-test/.git/resource/version"
+        contexts: "sync-integration-tests-{{ $cfScheduler }}"
+        github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
+    - task: cleanup-cluster
+      config:
+        <<: *cleanup-cluster
+    - put: kind-environments
+      params: { remove : kind-environments}
+  on_abort:
+    do:
+    - task: cleanup-cluster
+      config:
+        <<: *cleanup-cluster
+    - put: kind-environments
+      params: { remove : kind-environments}
+  on_error:
+    do:
+    - task: cleanup-cluster
+      config:
+        <<: *cleanup-cluster
+    - put: kind-environments
+      params: { remove : kind-environments}
+
+- name: ccdb-rotate-{{ $cfScheduler }}
+  public: true
+  plan:
+  - get: kind-environments
+    passed:
+    - sync-integration-tests-{{ $cfScheduler }}
+  - get: commit-to-test
+    passed:
+    - sync-integration-tests-{{ $cfScheduler }}
+    trigger: true
+    version: "every"
+  - get: s3.kubecf-ci
+    passed:
+    - sync-integration-tests-{{ $cfScheduler }}
+  - get: s3.kubecf-ci-bundle
+    passed:
+    - sync-integration-tests-{{ $cfScheduler }}
   - get: catapult
   - task: rotate-{{ $cfScheduler }}
     privileged: true
@@ -703,85 +864,6 @@ jobs:
     - put: kind-environments
       params: { remove : kind-environments}
 
-- name: sync-integration-tests-{{ $cfScheduler }}
-  public: true
-  plan:
-  - get: kind-environments
-    passed:
-    - smoke-tests-{{ $cfScheduler }}
-  - get: commit-to-test
-    passed:
-    - smoke-tests-{{ $cfScheduler }}
-    trigger: true
-    version: "every"
-  - get: s3.kubecf-ci
-    passed:
-    - smoke-tests-{{ $cfScheduler }}
-  - get: s3.kubecf-ci-bundle
-    passed:
-    - smoke-tests-{{ $cfScheduler }}
-  - get: catapult
-  - task: test-{{ $cfScheduler }}
-    privileged: true
-    timeout: 1h30m
-    config:
-      platform: linux
-      image_resource:
-        type: registry-image
-        source:
-          repository: splatform/catapult
-      inputs:
-      - name: catapult
-      - name: commit-to-test
-      - name: kind-environments
-      outputs:
-      - name: output
-      params:
-        DEFAULT_STACK: cflinuxfs3
-        TEST_SUITE: sits
-        CLUSTER_NAME_PREFIX: kubecf-{{ $cfScheduler }}
-      run:
-        path: "/bin/bash"
-        args: *test_args
-  on_success:
-    put: commit-to-test
-    params:
-      description: "Sync Integration tests on {{ $cfScheduler }} succeeded"
-      state: "success"
-      contexts: "sync-integration-tests-{{ $cfScheduler }}"
-      commit_path: "commit-to-test/.git/resource/ref"
-      version_path: "commit-to-test/.git/resource/version"
-      github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
-  on_failure:
-    do:
-    - put: commit-to-test
-      params:
-        description: "Sync Integration tests on {{ $cfScheduler }} failed"
-        state: "failure"
-        commit_path: "commit-to-test/.git/resource/ref"
-        version_path: "commit-to-test/.git/resource/version"
-        contexts: "sync-integration-tests-{{ $cfScheduler }}"
-        github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
-    - task: cleanup-cluster
-      config:
-        <<: *cleanup-cluster
-    - put: kind-environments
-      params: { remove : kind-environments}
-  on_abort:
-    do:
-    - task: cleanup-cluster
-      config:
-        <<: *cleanup-cluster
-    - put: kind-environments
-      params: { remove : kind-environments}
-  on_error:
-    do:
-    - task: cleanup-cluster
-      config:
-        <<: *cleanup-cluster
-    - put: kind-environments
-      params: { remove : kind-environments}
-
 # TODO: re-enable once BRAIN tests are fixed.
 # - name: brain-tests-{{ $cfScheduler }}
 #   public: true
@@ -850,85 +932,6 @@ jobs:
 #         params:
 #           CLUSTER_NAME_PREFIX: "kubecf-{{ $cfScheduler }}"
 #           EKCP_HOST: ((ekcp-host))
-
-- name: cf-acceptance-tests-{{ $cfScheduler }}
-  public: true
-  plan:
-  - get: kind-environments
-    passed:
-    - sync-integration-tests-{{ $cfScheduler }}
-  - get: commit-to-test
-    passed:
-    - sync-integration-tests-{{ $cfScheduler }}
-    trigger: true
-    version: "every"
-  - get: s3.kubecf-ci
-    passed:
-    - sync-integration-tests-{{ $cfScheduler }}
-  - get: s3.kubecf-ci-bundle
-    passed:
-    - sync-integration-tests-{{ $cfScheduler }}
-  - get: catapult
-  - task: test-{{ $cfScheduler }}
-    privileged: true
-    timeout: 5h30m
-    config:
-      platform: linux
-      image_resource:
-        type: registry-image
-        source:
-          repository: splatform/catapult
-      inputs:
-      - name: catapult
-      - name: kind-environments
-      - name: commit-to-test
-      outputs:
-      - name: output
-      params:
-        DEFAULT_STACK: cflinuxfs3
-        TEST_SUITE: cats
-        CLUSTER_NAME_PREFIX: kubecf-{{ $cfScheduler }}
-      run:
-        path: "/bin/bash"
-        args: *test_args
-  on_success:
-    put: commit-to-test
-    params:
-      description: "Acceptance tests on {{ $cfScheduler }} succeeded"
-      state: "success"
-      contexts: "acceptance-{{ $cfScheduler }}"
-      commit_path: "commit-to-test/.git/resource/ref"
-      version_path: "commit-to-test/.git/resource/version"
-      github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
-  on_failure:
-    do:
-    - put: commit-to-test
-      params:
-        description: "Acceptance tests on {{ $cfScheduler }} failed"
-        state: "failure"
-        commit_path: "commit-to-test/.git/resource/ref"
-        version_path: "commit-to-test/.git/resource/version"
-        contexts: "acceptance-{{ $cfScheduler }}"
-        github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
-    - task: cleanup-cluster
-      config:
-        <<: *cleanup-cluster
-    - put: kind-environments
-      params: { remove : kind-environments}
-  on_abort:
-    do:
-    - task: cleanup-cluster
-      config:
-        <<: *cleanup-cluster
-    - put: kind-environments
-      params: { remove : kind-environments}
-  on_error:
-    do:
-    - task: cleanup-cluster
-      config:
-        <<: *cleanup-cluster
-    - put: kind-environments
-      params: { remove : kind-environments}
 
 - name: cleanup-{{ $cfScheduler }}-cluster
   public: true

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -7,8 +7,37 @@
 # don't have to know what kind of values were used when it was deployed last
 # time.
 
-{{ $prod := slice "queue-pr" "queue-master" "queue-fork-pr" "lint" "build" "publish"}}
-{{ $noprod := slice }}
+# Variables
+{{ $availableCfSchedulers := slice "diego" "eirini" }} # Diego / Eirini
+
+# Prod and no-prod jobs
+# Jobs that are stable and ready should go into $prod.
+
+# Queue jobs don't end up in contexts. But they are showed in prod tab view
+{{ $queue := slice "queue-pr" "queue-master" "queue-fork-pr" "publish"}}
+
+
+# Production ready Jobs
+# cf-acceptance-tests-* and smoke-test-* are a Special case, as Eirini is not ready, we don't want smoke/CATs to end up in prod job view.
+# TODO: Delete the special case here as soon as we get Eirini CATS green and we stabilize Eirini smoke (e.g. with a more large timeout)
+{{ $prod := slice "lint" "build" "cf-acceptance-tests-diego" "smoke-tests-diego"}}
+
+# Jobs that aren't reliable yet, nor production ready
+{{ $noprod := slice "cf-acceptance-tests-eirini" "smoke-tests-eirini"}}
+
+# Add jobs for each scheduler in the correct category
+{{range $_, $cfScheduler := $availableCfSchedulers }}
+
+  # Generate the prod slice in the range, so we have the full list for the tab view group
+  {{ $prod = $prod | append ( printf "deploy-%s" $cfScheduler ) }}
+
+  {{ $noprod = $noprod | append ( printf "sync-integration-tests-%s" $cfScheduler ) }}
+  {{ $noprod = $noprod | append ( printf "ccdb-rotate-%s" $cfScheduler ) }}
+
+  # Cleanup gets executed only at the end, make it into noprod as we need to keep it at the end
+  {{ $noprod = $noprod | append ( printf "cleanup-%s-cluster" $cfScheduler ) }}
+  {{ $noprod = $noprod | append ( printf "smoke-tests-post-rotate-%s" $cfScheduler ) }}
+{{ end }}
 
 resource_types:
 - name: pull-request
@@ -365,16 +394,9 @@ jobs:
       acl: public-read
 
 
-# Special case, as Eirini is not ready, we don't want CATs to end up in prod job view:
-{{ $noprod = $noprod | append "cf-acceptance-tests-eirini" }}
-{{ $prod = $prod | append "cf-acceptance-tests-diego" }}
-# TODO: Delete the special case here as soon as we get Eirini CATS green
-
-{{- range $_, $cfScheduler := slice "diego" "eirini" }}
+{{- range $_, $cfScheduler := $availableCfSchedulers }}
 
 # prod-jobs
-# Generate the prod slice in the range, so we have the full list for the tab view group
-{{ $prod = $prod | append ( printf "deploy-%s" $cfScheduler ) }}
 - name: deploy-{{ $cfScheduler }}
   #max_in_flight: 1 # Re-enable to when we want to set a limit on concurrent deployments
   public: true
@@ -476,7 +498,6 @@ jobs:
     - put: kind-environments
       params: { remove : kind-environments}
 
-{{ $prod = $prod | append ( printf "smoke-tests-%s" $cfScheduler ) }}
 - name: smoke-tests-{{ $cfScheduler }}
   public: true
   plan:
@@ -556,8 +577,7 @@ jobs:
     - put: kind-environments
       params: { remove : kind-environments}
 
-# TODO: Add the append here as soon as we get Eirini CATS green, and remove the special case at the top of the range
-# It should have been: {{/*  $prod = $prod | append ( printf "cf-acceptance-tests-%s" $cfScheduler )  */}}
+
 - name: cf-acceptance-tests-{{ $cfScheduler }}
   public: true
   plan:
@@ -639,7 +659,6 @@ jobs:
 
 # no-prod jobs
 
-{{ $noprod = $noprod | append ( printf "sync-integration-tests-%s" $cfScheduler ) }}
 - name: sync-integration-tests-{{ $cfScheduler }}
   public: true
   plan:
@@ -719,7 +738,6 @@ jobs:
     - put: kind-environments
       params: { remove : kind-environments}
 
-{{ $noprod = $noprod | append ( printf "ccdb-rotate-%s" $cfScheduler ) }}
 - name: ccdb-rotate-{{ $cfScheduler }}
   public: true
   plan:
@@ -801,7 +819,6 @@ jobs:
     - put: kind-environments
       params: { remove : kind-environments}
 
-{{ $noprod = $noprod | append ( printf "smoke-tests-post-rotate-%s" $cfScheduler ) }}
 - name: smoke-tests-post-rotate-{{ $cfScheduler }}
   public: true
   plan:
@@ -950,8 +967,7 @@ jobs:
 #           CLUSTER_NAME_PREFIX: "kubecf-{{ $cfScheduler }}"
 #           EKCP_HOST: ((ekcp-host))
 
-# Cleanup gets executed only at the end, make it into noprod as we need to keep it at the end
-{{ $noprod = $noprod | append ( printf "cleanup-%s-cluster" $cfScheduler ) }}
+
 - name: cleanup-{{ $cfScheduler }}-cluster
   public: true
   plan:
@@ -1022,11 +1038,11 @@ jobs:
 
 groups:
 - name: prod
-  jobs: [ {{ join $prod "," }} ]
+  jobs: [ {{ join (flatten (slice $queue $prod) | uniq ) "," }} ]
 
 - name: no-prod
   jobs: [ {{ join $noprod "," }} ]
 
 - name: all
   # Joins prod and noprod with a "," while filtering elements making them uniques.
-  jobs: [ {{ join (flatten (slice $prod $noprod) | uniq ) "," }} ]
+  jobs: [ {{ join (flatten (slice $queue (slice $prod $noprod) ) | uniq ) "," }} ]

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -310,6 +310,16 @@ jobs:
   - get: commit-to-test
     trigger: true
     version: "every"
+{{- if has $prod "lint" }}
+  - put: commit-to-test
+    params:
+      description: "Lint started"
+      state: "pending"
+      contexts: "lint"
+      commit_path: "commit-to-test/.git/resource/ref"
+      version_path: "commit-to-test/.git/resource/version"
+      github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
+{{- end }}
   - task: lint
     config:
       platform: linux
@@ -359,6 +369,16 @@ jobs:
     version: "every"
     passed:
     - lint
+{{- if has $prod "build" }}
+  - put: commit-to-test
+    params:
+      description: "Build started"
+      state: "pending"
+      contexts: "build"
+      commit_path: "commit-to-test/.git/resource/ref"
+      version_path: "commit-to-test/.git/resource/version"
+      github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
+{{- end }}
   - task: build
     config:
       platform: linux
@@ -433,6 +453,16 @@ jobs:
     passed:
     - build
   - get: catapult
+{{- if has $prod (printf "deploy-%s" $cfScheduler) }}
+  - put: commit-to-test
+    params:
+      description: "Deploy on {{ $cfScheduler }} started"
+      state: "pending"
+      contexts: "deploy-{{ $cfScheduler }}"
+      commit_path: "commit-to-test/.git/resource/ref"
+      version_path: "commit-to-test/.git/resource/version"
+      github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
+{{- end }}
   - task: deploy
     privileged: true
     timeout: 3h30m
@@ -535,6 +565,16 @@ jobs:
     passed:
     - deploy-{{ $cfScheduler }}
   - get: catapult
+{{- if has $prod (printf "smoke-tests-%s" $cfScheduler) }}
+  - put: commit-to-test
+    params:
+      description: "Smoke tests on {{ $cfScheduler }} running"
+      state: "pending"
+      contexts: "smoke-tests-{{ $cfScheduler }}"
+      commit_path: "commit-to-test/.git/resource/ref"
+      version_path: "commit-to-test/.git/resource/version"
+      github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
+{{- end }}
   - task: test-{{ $cfScheduler }}
     privileged: true
     timeout: 1h30m
@@ -619,6 +659,16 @@ jobs:
     passed:
     - smoke-tests-{{ $cfScheduler }}
   - get: catapult
+{{- if has $prod (printf "cf-acceptance-tests-%s" $cfScheduler) }}
+  - put: commit-to-test
+    params:
+      description: "Acceptance tests on {{ $cfScheduler }} running"
+      state: "pending"
+      contexts: "cf-acceptance-tests-{{ $cfScheduler }}"
+      commit_path: "commit-to-test/.git/resource/ref"
+      version_path: "commit-to-test/.git/resource/version"
+      github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
+{{- end }}
   - task: test-{{ $cfScheduler }}
     privileged: true
     timeout: 5h30m
@@ -708,6 +758,16 @@ jobs:
     passed:
     - cf-acceptance-tests-{{ $cfScheduler }}
   - get: catapult
+{{- if has $prod (printf "sync-integration-tests-%s" $cfScheduler) }}
+  - put: commit-to-test
+    params:
+      description: "Sync Integration tests on {{ $cfScheduler }} running"
+      state: "pending"
+      contexts: "sync-integration-tests-{{ $cfScheduler }}"
+      commit_path: "commit-to-test/.git/resource/ref"
+      version_path: "commit-to-test/.git/resource/version"
+      github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
+{{- end }}
   - task: test-{{ $cfScheduler }}
     privileged: true
     timeout: 1h30m
@@ -793,6 +853,16 @@ jobs:
     passed:
     - sync-integration-tests-{{ $cfScheduler }}
   - get: catapult
+{{- if has $prod (printf "rotate-%s" $cfScheduler) }}
+  - put: commit-to-test
+    params:
+      description: "Rotating secrets on {{ $cfScheduler }} is running"
+      state: "pending"
+      contexts: "rotate-{{ $cfScheduler }}"
+      commit_path: "commit-to-test/.git/resource/ref"
+      version_path: "commit-to-test/.git/resource/version"
+      github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
+{{- end }}
   - task: rotate-{{ $cfScheduler }}
     privileged: true
     timeout: 1h30m
@@ -880,6 +950,16 @@ jobs:
     passed:
     - ccdb-rotate-{{ $cfScheduler }}
   - get: catapult
+{{- if has $prod (printf "smoke-rotated-{%s" $cfScheduler) }}
+  - put: commit-to-test
+    params:
+      description: "Smoke tests on {{ $cfScheduler }} after rotating secrets is running"
+      state: "pending"
+      contexts: "smoke-rotated-{{ $cfScheduler }}"
+      commit_path: "commit-to-test/.git/resource/ref"
+      version_path: "commit-to-test/.git/resource/version"
+      github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
+{{- end }}
   - task: test-{{ $cfScheduler }}
     privileged: true
     timeout: 1h30m

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -543,7 +543,7 @@ jobs:
       state: "success"
       commit_path: "commit-to-test/.git/resource/ref"
       version_path: "commit-to-test/.git/resource/version"
-      contexts: "smoke-{{ $cfScheduler }}"
+      contexts: "smoke-tests-{{ $cfScheduler }}"
       github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
   on_failure:
     do:
@@ -553,7 +553,7 @@ jobs:
         commit_path: "commit-to-test/.git/resource/ref"
         version_path: "commit-to-test/.git/resource/version"
         state: "failure"
-        contexts: "smoke-{{ $cfScheduler }}"
+        contexts: "smoke-tests-{{ $cfScheduler }}"
         github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
     - task: cleanup-cluster
       config:
@@ -623,7 +623,7 @@ jobs:
     params:
       description: "Acceptance tests on {{ $cfScheduler }} succeeded"
       state: "success"
-      contexts: "acceptance-{{ $cfScheduler }}"
+      contexts: "cf-acceptance-tests-{{ $cfScheduler }}"
       commit_path: "commit-to-test/.git/resource/ref"
       version_path: "commit-to-test/.git/resource/version"
       github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
@@ -639,7 +639,7 @@ jobs:
         state: "failure"
         commit_path: "commit-to-test/.git/resource/ref"
         version_path: "commit-to-test/.git/resource/version"
-        contexts: "acceptance-{{ $cfScheduler }}"
+        contexts: "cf-acceptance-tests-{{ $cfScheduler }}"
         github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
 {{- end }}
 

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -440,6 +440,7 @@ jobs:
       run:
         path: "/bin/bash"
         args: *deploy_args
+{{- if has $prod (printf "deploy-%s" $cfScheduler) }}
   on_success:
     put: commit-to-test
     params:
@@ -449,8 +450,10 @@ jobs:
       version_path: "commit-to-test/.git/resource/version"
       contexts: "deploy-{{ $cfScheduler }}"
       github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
+{{- end }}
   on_failure:
     do:
+{{- if has $prod (printf "deploy-%s" $cfScheduler) }}
     - put: commit-to-test
       params:
         description: "Deploying with {{ $cfScheduler }} failed"
@@ -459,6 +462,7 @@ jobs:
         state: "failure"
         contexts: "deploy-{{ $cfScheduler }}"
         github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
+{{- end }}
     - task: cleanup-cluster
       config: &cleanup-cluster
         platform: linux
@@ -536,6 +540,7 @@ jobs:
       run:
         path: "/bin/bash"
         args: *test_args
+{{- if has $prod (printf "smoke-tests-%s" $cfScheduler) }}
   on_success:
     put: commit-to-test
     params:
@@ -545,8 +550,10 @@ jobs:
       version_path: "commit-to-test/.git/resource/version"
       contexts: "smoke-tests-{{ $cfScheduler }}"
       github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
+{{- end }}
   on_failure:
     do:
+{{- if has $prod (printf "smoke-tests-%s" $cfScheduler) }}
     - put: commit-to-test
       params:
         description: "Smoke tests on {{ $cfScheduler }} failed"
@@ -555,6 +562,7 @@ jobs:
         state: "failure"
         contexts: "smoke-tests-{{ $cfScheduler }}"
         github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
+{{- end }}
     - task: cleanup-cluster
       config:
         <<: *cleanup-cluster
@@ -617,7 +625,7 @@ jobs:
         path: "/bin/bash"
         args: *test_args
 
-{{- if eq $cfScheduler "diego" }}
+{{- if has $prod (printf "cf-acceptance-tests-%s" $cfScheduler) }}
   on_success:
     put: commit-to-test
     params:
@@ -632,7 +640,7 @@ jobs:
   on_failure:
     do:
 
-{{- if eq $cfScheduler "diego" }}
+{{- if has $prod (printf "cf-acceptance-tests-%s" $cfScheduler) }}
     - put: commit-to-test
       params:
         description: "Acceptance tests on {{ $cfScheduler }} failed"
@@ -705,28 +713,31 @@ jobs:
       run:
         path: "/bin/bash"
         args: *test_args
-# Disable github status reporting for no-prod jobs
-#  on_success:
-#    put: commit-to-test
-#    params:
-#      description: "Sync Integration tests on {{ $cfScheduler }} succeeded"
-#      state: "success"
-#      contexts: "sync-integration-tests-{{ $cfScheduler }}"
-#      commit_path: "commit-to-test/.git/resource/ref"
-#      version_path: "commit-to-test/.git/resource/version"
-#      github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
+{{- if has $prod (printf "sync-integration-tests-%s" $cfScheduler) }}
+  on_success:
+    put: commit-to-test
+    params:
+      description: "Sync Integration tests on {{ $cfScheduler }} succeeded"
+      state: "success"
+      contexts: "sync-integration-tests-{{ $cfScheduler }}"
+      commit_path: "commit-to-test/.git/resource/ref"
+      version_path: "commit-to-test/.git/resource/version"
+      github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
+{{- end }}
   on_failure:
     do:
 
-# Disable github status reporting for no-prod jobs
-#    - put: commit-to-test
-#      params:
-#        description: "Sync Integration tests on {{ $cfScheduler }} failed"
-#        state: "failure"
-#        commit_path: "commit-to-test/.git/resource/ref"
-#        version_path: "commit-to-test/.git/resource/version"
-#        contexts: "sync-integration-tests-{{ $cfScheduler }}"
-#        github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
+{{- if has $prod (printf "sync-integration-tests-%s" $cfScheduler) }}
+    - put: commit-to-test
+      params:
+        description: "Sync Integration tests on {{ $cfScheduler }} failed"
+        state: "failure"
+        commit_path: "commit-to-test/.git/resource/ref"
+        version_path: "commit-to-test/.git/resource/version"
+        contexts: "sync-integration-tests-{{ $cfScheduler }}"
+        github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
+{{- end }}
+
     - task: cleanup-cluster
       config:
         <<: *cleanup-cluster
@@ -786,27 +797,31 @@ jobs:
       run:
         path: "/bin/bash"
         args: *rotate_args
-# Disable github status reporting for no-prod jobs
-#  on_success:
-#    put: commit-to-test
-#    params:
-#      description: "Rotating secrets on {{ $cfScheduler }} was successful"
-#      state: "success"
-#      commit_path: "commit-to-test/.git/resource/ref"
-#      version_path: "commit-to-test/.git/resource/version"
-#      contexts: "rotate-{{ $cfScheduler }}"
-#      github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
+
+{{- if has $prod (printf "rotate-%s" $cfScheduler) }}
+  on_success:
+    put: commit-to-test
+    params:
+      description: "Rotating secrets on {{ $cfScheduler }} was successful"
+      state: "success"
+      commit_path: "commit-to-test/.git/resource/ref"
+      version_path: "commit-to-test/.git/resource/version"
+      contexts: "rotate-{{ $cfScheduler }}"
+      github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
+{{- end }}
+
   on_failure:
     do:
-# Disable github status reporting for no-prod jobs
-#    - put: commit-to-test
-#      params:
-#        description: "Rotating secrets on {{ $cfScheduler }} failed"
-#        commit_path: "commit-to-test/.git/resource/ref"
-#        version_path: "commit-to-test/.git/resource/version"
-#        state: "failure"
-#        contexts: "rotate-{{ $cfScheduler }}"
-#        github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
+{{- if has $prod (printf "rotate-%s" $cfScheduler) }}
+    - put: commit-to-test
+      params:
+        description: "Rotating secrets on {{ $cfScheduler }} failed"
+        commit_path: "commit-to-test/.git/resource/ref"
+        version_path: "commit-to-test/.git/resource/version"
+        state: "failure"
+        contexts: "rotate-{{ $cfScheduler }}"
+        github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
+{{- end }}
     - task: cleanup-cluster
       config:
         <<: *cleanup-cluster
@@ -870,27 +885,33 @@ jobs:
       run:
         path: "/bin/bash"
         args: *test_args
-# Disable github status reporting for no-prod jobs
-#  on_success:
-#    put: commit-to-test
-#    params:
-#      description: "Smoke tests on {{ $cfScheduler }} after rotating secrets was successful"
-#      state: "success"
-#      commit_path: "commit-to-test/.git/resource/ref"
-#      version_path: "commit-to-test/.git/resource/version"
-#      contexts: "smoke-rotated-{{ $cfScheduler }}"
-#      github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
+
+{{- if has $prod (printf "smoke-rotated-{%s" $cfScheduler) }}
+  on_success:
+    put: commit-to-test
+    params:
+      description: "Smoke tests on {{ $cfScheduler }} after rotating secrets was successful"
+      state: "success"
+      commit_path: "commit-to-test/.git/resource/ref"
+      version_path: "commit-to-test/.git/resource/version"
+      contexts: "smoke-rotated-{{ $cfScheduler }}"
+      github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
+{{- end }}
+
   on_failure:
     do:
-# Disable github status reporting for no-prod jobs
-#    - put: commit-to-test
-#      params:
-#        description: "Smoke tests on {{ $cfScheduler }} after rotating secrets failed"
-#        commit_path: "commit-to-test/.git/resource/ref"
-#        version_path: "commit-to-test/.git/resource/version"
-#        state: "failure"
-#        contexts: "smoke-rotated-{{ $cfScheduler }}"
-#        github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
+
+{{- if has $prod (printf "smoke-rotated-{%s" $cfScheduler) }}
+    - put: commit-to-test
+      params:
+        description: "Smoke tests on {{ $cfScheduler }} after rotating secrets failed"
+        commit_path: "commit-to-test/.git/resource/ref"
+        version_path: "commit-to-test/.git/resource/version"
+        state: "failure"
+        contexts: "smoke-rotated-{{ $cfScheduler }}"
+        github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
+{{- end }}
+
     - task: cleanup-cluster
       config:
         <<: *cleanup-cluster

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -39,6 +39,17 @@
   {{ $noprod = $noprod | append ( printf "smoke-tests-post-rotate-%s" $cfScheduler ) }}
 {{ end }}
 
+groups:
+- name: prod
+  jobs: [ {{ join (flatten (slice $queue $prod) | uniq ) "," }} ]
+
+- name: no-prod
+  jobs: [ {{ join $noprod "," }} ]
+
+- name: all
+  # Joins prod and noprod with a "," while filtering elements making them uniques.
+  jobs: [ {{ join (flatten (slice $queue (slice $prod $noprod) ) | uniq ) "," }} ]
+
 resource_types:
 - name: pull-request
   type: docker-image
@@ -1069,14 +1080,3 @@ jobs:
       - put: s3.kubecf-bundle
         params:
           file: s3.kubecf-ci-bundle/kubecf-bundle-v*.tgz
-
-groups:
-- name: prod
-  jobs: [ {{ join (flatten (slice $queue $prod) | uniq ) "," }} ]
-
-- name: no-prod
-  jobs: [ {{ join $noprod "," }} ]
-
-- name: all
-  # Joins prod and noprod with a "," while filtering elements making them uniques.
-  jobs: [ {{ join (flatten (slice $queue (slice $prod $noprod) ) | uniq ) "," }} ]

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -230,9 +230,7 @@ jobs:
       description: "Queued"
       state: "pending"
       contexts: >
-        lint,build,deploy-diego,smoke-diego,rotate-diego,smoke-rotated-diego,
-        acceptance-diego,deploy-eirini,smoke-eirini,rotate-eirini,brain-eirini,
-        smoke-rotated-eirini,acceptance-eirini,sync-integration-tests-diego,brain-tests-diego
+         {{ join $prod "," }}
       trigger: "PR"
       metadata_path: "kubecf-pr/.git/resource/url"
       github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
@@ -618,6 +616,8 @@ jobs:
       run:
         path: "/bin/bash"
         args: *test_args
+
+{{- if eq $cfScheduler "diego" }}
   on_success:
     put: commit-to-test
     params:
@@ -627,8 +627,12 @@ jobs:
       commit_path: "commit-to-test/.git/resource/ref"
       version_path: "commit-to-test/.git/resource/version"
       github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
+{{- end }}
+
   on_failure:
     do:
+
+{{- if eq $cfScheduler "diego" }}
     - put: commit-to-test
       params:
         description: "Acceptance tests on {{ $cfScheduler }} failed"
@@ -637,6 +641,8 @@ jobs:
         version_path: "commit-to-test/.git/resource/version"
         contexts: "acceptance-{{ $cfScheduler }}"
         github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
+{{- end }}
+
     - task: cleanup-cluster
       config:
         <<: *cleanup-cluster
@@ -699,25 +705,28 @@ jobs:
       run:
         path: "/bin/bash"
         args: *test_args
-  on_success:
-    put: commit-to-test
-    params:
-      description: "Sync Integration tests on {{ $cfScheduler }} succeeded"
-      state: "success"
-      contexts: "sync-integration-tests-{{ $cfScheduler }}"
-      commit_path: "commit-to-test/.git/resource/ref"
-      version_path: "commit-to-test/.git/resource/version"
-      github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
+# Disable github status reporting for no-prod jobs
+#  on_success:
+#    put: commit-to-test
+#    params:
+#      description: "Sync Integration tests on {{ $cfScheduler }} succeeded"
+#      state: "success"
+#      contexts: "sync-integration-tests-{{ $cfScheduler }}"
+#      commit_path: "commit-to-test/.git/resource/ref"
+#      version_path: "commit-to-test/.git/resource/version"
+#      github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
   on_failure:
     do:
-    - put: commit-to-test
-      params:
-        description: "Sync Integration tests on {{ $cfScheduler }} failed"
-        state: "failure"
-        commit_path: "commit-to-test/.git/resource/ref"
-        version_path: "commit-to-test/.git/resource/version"
-        contexts: "sync-integration-tests-{{ $cfScheduler }}"
-        github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
+
+# Disable github status reporting for no-prod jobs
+#    - put: commit-to-test
+#      params:
+#        description: "Sync Integration tests on {{ $cfScheduler }} failed"
+#        state: "failure"
+#        commit_path: "commit-to-test/.git/resource/ref"
+#        version_path: "commit-to-test/.git/resource/version"
+#        contexts: "sync-integration-tests-{{ $cfScheduler }}"
+#        github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
     - task: cleanup-cluster
       config:
         <<: *cleanup-cluster
@@ -777,25 +786,27 @@ jobs:
       run:
         path: "/bin/bash"
         args: *rotate_args
-  on_success:
-    put: commit-to-test
-    params:
-      description: "Rotating secrets on {{ $cfScheduler }} was successful"
-      state: "success"
-      commit_path: "commit-to-test/.git/resource/ref"
-      version_path: "commit-to-test/.git/resource/version"
-      contexts: "rotate-{{ $cfScheduler }}"
-      github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
+# Disable github status reporting for no-prod jobs
+#  on_success:
+#    put: commit-to-test
+#    params:
+#      description: "Rotating secrets on {{ $cfScheduler }} was successful"
+#      state: "success"
+#      commit_path: "commit-to-test/.git/resource/ref"
+#      version_path: "commit-to-test/.git/resource/version"
+#      contexts: "rotate-{{ $cfScheduler }}"
+#      github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
   on_failure:
     do:
-    - put: commit-to-test
-      params:
-        description: "Rotating secrets on {{ $cfScheduler }} failed"
-        commit_path: "commit-to-test/.git/resource/ref"
-        version_path: "commit-to-test/.git/resource/version"
-        state: "failure"
-        contexts: "rotate-{{ $cfScheduler }}"
-        github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
+# Disable github status reporting for no-prod jobs
+#    - put: commit-to-test
+#      params:
+#        description: "Rotating secrets on {{ $cfScheduler }} failed"
+#        commit_path: "commit-to-test/.git/resource/ref"
+#        version_path: "commit-to-test/.git/resource/version"
+#        state: "failure"
+#        contexts: "rotate-{{ $cfScheduler }}"
+#        github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
     - task: cleanup-cluster
       config:
         <<: *cleanup-cluster
@@ -859,25 +870,27 @@ jobs:
       run:
         path: "/bin/bash"
         args: *test_args
-  on_success:
-    put: commit-to-test
-    params:
-      description: "Smoke tests on {{ $cfScheduler }} after rotating secrets was successful"
-      state: "success"
-      commit_path: "commit-to-test/.git/resource/ref"
-      version_path: "commit-to-test/.git/resource/version"
-      contexts: "smoke-rotated-{{ $cfScheduler }}"
-      github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
+# Disable github status reporting for no-prod jobs
+#  on_success:
+#    put: commit-to-test
+#    params:
+#      description: "Smoke tests on {{ $cfScheduler }} after rotating secrets was successful"
+#      state: "success"
+#      commit_path: "commit-to-test/.git/resource/ref"
+#      version_path: "commit-to-test/.git/resource/version"
+#      contexts: "smoke-rotated-{{ $cfScheduler }}"
+#      github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
   on_failure:
     do:
-    - put: commit-to-test
-      params:
-        description: "Smoke tests on {{ $cfScheduler }} after rotating secrets failed"
-        commit_path: "commit-to-test/.git/resource/ref"
-        version_path: "commit-to-test/.git/resource/version"
-        state: "failure"
-        contexts: "smoke-rotated-{{ $cfScheduler }}"
-        github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
+# Disable github status reporting for no-prod jobs
+#    - put: commit-to-test
+#      params:
+#        description: "Smoke tests on {{ $cfScheduler }} after rotating secrets failed"
+#        commit_path: "commit-to-test/.git/resource/ref"
+#        version_path: "commit-to-test/.git/resource/version"
+#        state: "failure"
+#        contexts: "smoke-rotated-{{ $cfScheduler }}"
+#        github_status: {{ if (has . "github_status") }}{{ .github_status }}{{ else }}true{{ end }}
     - task: cleanup-cluster
       config:
         <<: *cleanup-cluster


### PR DESCRIPTION
Also adds comment on prod and no-prod jobs and move disabled brains at the bottom

Fixes #593 #580 #597 and #455 

## Description
Move SITS and ccdb rotation jobs at the end of the pipeline. They haven't proved to be stable yet. Also it does the separation between "prod" and "no-prod" jobs and it just post the contexts of the prod jobs to Github (not all of them). 

I've added also the ability to post the status on Github for jobs in progress, so it covers #455, too.

## Motivation and Context
They gate PRs CI runs even if they fails consistently

## How Has This Been Tested?
Deployed on https://concourse.suse.dev/teams/main/pipelines/kubecf

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
