### PR TITLE
CI: Set required_review_approvals for PR resources

### DIFF
--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -55,6 +55,7 @@ resources:
     repository: {{ if has . "kubecf_repository" }}{{ .kubecf_repository }}{{ else }}{{ "cloudfoundry-incubator/kubecf" }}{{ end }}
     access_token: ((github-access-token))
     disable_forks: true # Trigger on kubecf branches only
+    required_review_approvals: 1
 
 - name: kubecf-fork-pr
   type: pull-request
@@ -63,6 +64,7 @@ resources:
     repository: {{ if has . "kubecf_repository" }}{{ .kubecf_repository }}{{ else }}{{ "cloudfoundry-incubator/kubecf" }}{{ end }}
     access_token: ((github-access-token))
     disable_forks: false # Trigger on kubecf branches only
+    required_review_approvals: 1
 
 - name: catapult
   type: git


### PR DESCRIPTION
In this way the CI will run tests only if someone has approved it before, this could be also a gating mechanisms for forks, and we could also drop the special case for it. Discussed with @viovanov 

## Description
Sets `required_review_approvals` to 1 . It is enough 1 review to trigger CI runs, however the PR can be merged only if the required tests (prod) are successful. See https://github.com/telia-oss/github-pr-resource#source-configuration for more info about that option

## Motivation and Context
In this way CI won't fire right immediately, and we can avoid to waste cycles for changes to the pipeline, or readme files for e.g.

## How Has This Been Tested?
N/A


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
