### PR TITLE
fix: add missing quotes when using [] syntax

### DIFF
--- a/deploy/helm/kubecf/assets/operations/instance_groups/adapter.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/adapter.yaml
@@ -12,4 +12,4 @@
           readiness:
             # The healthcheck port is bound to localhost only
             exec:
-              command: [curl, --fail, --head, --silent, http://localhost:8080/health]
+              command: ["curl", "--fail", "--head", "--silent", "http://localhost:8080/health"]

--- a/deploy/helm/kubecf/assets/operations/instance_groups/api.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/api.yaml
@@ -210,7 +210,14 @@
         cloud_controller_ng:
           readiness: &cloud_controller_ng_readiness
             exec:
-              command: [curl, --fail, --head, --silent, --unix-socket, /var/vcap/data/cloud_controller_ng/cloud_controller.sock, http:/healthz]
+              command:
+              - curl
+              - --fail
+              - --head
+              - --silent
+              - --unix-socket
+              - /var/vcap/data/cloud_controller_ng/cloud_controller.sock
+              - http:/healthz
           # We don't want a liveness probe here as we do migration here, and we
           # do not want to interrupt that.  We may want to consider using a
           # startupProbe in the future (once that feature stabilizes).
@@ -236,7 +243,7 @@
     post_start:
       condition:
         exec:
-          command: [curl, --fail, --head, --silent, http://127.0.0.1:9022/healthz]
+          command: ["curl", "--fail", "--head", "--silent", "http://127.0.0.1:9022/healthz"]
 
 # Add quarks properties for cc_uploader.
 - type: replace
@@ -301,7 +308,7 @@
       condition:
         exec:
           # policy-server doesn't support HTTP HEAD requests
-          command: [curl, --insecure, --fail, --silent, https://localhost:4002/]
+          command: ["curl", "--insecure", "--fail", "--silent", "https://localhost:4002/"]
 
 # Add quarks properties for policy-server-internal.
 - type: replace
@@ -317,7 +324,7 @@
       condition:
         exec:
           # policy-server-internal doesn't support HTTP HEAD requests
-          command: [curl, --fail, --silent, http://localhost:31946/]
+          command: ["curl", "--fail", "--silent", "http://localhost:31946/"]
 
 - type: replace
   path: /instance_groups/name=api/jobs/name=route_registrar/properties/quarks?/run/healthcheck/route_registrar
@@ -328,7 +335,7 @@
 
 - type: replace
   path: /instance_groups/name=api/jobs/name=loggr-udp-forwarder/properties/quarks?/run/healthcheck/loggr-udp-forwarder/readiness/exec/command
-  value: [sh, -c, ss -nlu sport = 3457 | grep :3457]
+  value: ["sh", "-c", "ss -nlu sport = 3457 | grep :3457"]
 
 {{- $root := . }}
 {{- if .Values.features.suse_buildpacks.enabled }}

--- a/deploy/helm/kubecf/assets/operations/instance_groups/diego-cell.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/diego-cell.yaml
@@ -110,7 +110,7 @@
         garden:
           readiness:
             exec:
-              command: [curl, --head, --fail, --silent, http://127.0.0.1:17019/debug/vars]
+              command: ["curl", "--head", "--fail", "--silent", "http://127.0.0.1:17019/debug/vars"]
     post_start:
       condition:
         exec:
@@ -135,7 +135,7 @@
         route_emitter:
           readiness: &route_emitter_readiness
             exec:
-              command: [curl, --fail, --silent, http://127.0.0.1:17011/ping]
+              command: ["curl", "--fail", "--silent", "http://127.0.0.1:17011/ping"]
     post_start:
       condition: *route_emitter_readiness
 

--- a/deploy/helm/kubecf/assets/operations/instance_groups/doppler.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/doppler.yaml
@@ -28,7 +28,7 @@
         doppler:
           readiness:
             exec:
-              command: [curl, --fail, --head, --silent, http://localhost:14825/health]
+              command: ["curl", "--fail", "--head", "--silent", "http://localhost:14825/health"]
 
 # Add quarks properties for log-cache.
 - type: replace
@@ -84,7 +84,7 @@
       # Unfortunately, by default the health port listens on localhost only
       # and isn't easily configurable
       exec:
-        command: [curl, --fail, --head, --silent, http://localhost:6061/debug/pprof/cmdline]
+        command: ["curl", "--fail", "--head", "--silent", "http://localhost:6061/debug/pprof/cmdline"]
 
 - type: replace
   path: /instance_groups/name=doppler/jobs/name=route_registrar/properties/quarks?/run/healthcheck/route_registrar

--- a/deploy/helm/kubecf/assets/operations/instance_groups/log-api.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/log-api.yaml
@@ -17,7 +17,7 @@
         loggregator_trafficcontroller:
           readiness:
             exec:
-              command: [curl, --fail, --silent, --head, http://localhost:14825/health]
+              command: ["curl", "--fail", "--silent", "--head", "http://localhost:14825/health"]
 
 # Add quarks properties for reverse_log_proxy.
 - type: replace
@@ -35,14 +35,14 @@
         reverse_log_proxy:
           readiness:
             exec:
-              command: [curl, --fail, --silent, --head, http://localhost:14826/health]
+              command: ["curl", "--fail", "--silent", "--head", "http://localhost:14826/health"]
 
 - type: replace
   path: /instance_groups/name=log-api/jobs/name=reverse_log_proxy_gateway/properties/quarks?/bpm/processes/name=reverse_log_proxy_gateway/env/PPROF_PORT?
   value: "33045"
 - type: replace
   path: /instance_groups/name=log-api/jobs/name=reverse_log_proxy_gateway/properties/quarks?/run/healthcheck/reverse_log_proxy_gateway/readiness/exec/command
-  value: [curl, --fail, --head, --silent, http://localhost:33045/debug/pprof/cmdline]
+  value: ["curl", "--fail", "--head", "--silent", "http://localhost:33045/debug/pprof/cmdline"]
 
 - type: replace
   path: /instance_groups/name=log-api/jobs/name=route_registrar/properties/quarks?/run/healthcheck/route_registrar

--- a/deploy/helm/kubecf/assets/operations/instance_groups/router.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/router.yaml
@@ -19,7 +19,7 @@
     post_start:
       condition:
         exec:
-          command: [curl, --fail, --head, http://127.0.0.1:8080/health]
+          command: ["curl", "--fail", "--head", "http://127.0.0.1:8080/health"]
 
 # Disable tuning /proc/sys kernel parameters as things are running on a container.
 - type: replace
@@ -31,7 +31,7 @@
   value:
     readiness:
       exec:
-        command: [sh, -c, 'ss -nlu sport = 3457 | grep :3457']
+        command: ["sh", "-c", "ss -nlu sport = 3457 | grep :3457"]
 
 # Add necessary labels to the router instance group so that the service can select it to create the
 # endpoint.

--- a/deploy/helm/kubecf/assets/operations/instance_groups/scheduler.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/scheduler.yaml
@@ -4,7 +4,7 @@
   value:
     readiness:
       exec:
-        command: [curl, --fail, --head, --silent, http://127.0.0.1:8080/health]
+        command: ["curl", "--fail", "--head", "--silent", "http://127.0.0.1:8080/health"]
 
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/quarks?/run/healthcheck/cloud_controller_clock
@@ -12,7 +12,7 @@
     readiness:
       # There is no good readiness check for the scheduled tasks
       exec:
-        command: [pgrep, --full, clock:start]
+        command: ["pgrep", "--full", "clock:start"]
 
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cc_deployment_updater/properties/quarks?/run/healthcheck/cc_deployment_updater
@@ -26,17 +26,17 @@
         - tac /var/vcap/sys/log/cc_deployment_updater/cc_deployment_updater.log | grep --max-count=1 Sleeping | jq -r '(now - .timestamp) < 10'
     liveness:
       exec:
-        command: [pgrep, --full, deployment_updater:start]
+        command: ["pgrep", "--full", "deployment_updater:start"]
 
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=statsd_injector/properties/quarks?/run/healthcheck/statsd_injector/readiness/exec/command
-  value: [/bin/sh, -c, ss -nlu src localhost:8125 | grep :8125]
+  value: ["/bin/sh", "-c", "ss -nlu src localhost:8125 | grep :8125"]
 
 {{- if not .Values.features.eirini.enabled }}
 
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=tps/properties/quarks?/run/healthcheck/watcher/readiness/exec/command
-  value: [curl, --fail, --silent, http://127.0.0.1:17015/debug/pprof/cmdline]
+  value: ["curl", "--fail", "--silent", "http://127.0.0.1:17015/debug/pprof/cmdline"]
 
 # Add quarks properties for the ssh_proxy job.
 - type: replace

--- a/deploy/helm/kubecf/assets/operations/instance_groups/uaa.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/uaa.yaml
@@ -29,7 +29,7 @@
 
 - type: replace
   path: /instance_groups/name=uaa/jobs/name=statsd_injector/properties/quarks?/run/healthcheck/statsd_injector/readiness/exec/command
-  value: [/bin/sh, -c, ss -nlu src localhost:8125 | grep :8125]
+  value: ["/bin/sh", "-c", "ss -nlu src localhost:8125 | grep :8125"]
 
 {{- if .Values.features.credhub.enabled }}
 


### PR DESCRIPTION
Some YAML parsers won't like strings with colons without being quoted.
This commit fixes this by adding missing quotes.