### PR TITLE
feat: improve testing targets

### DIFF
--- a/doc/tests.md
+++ b/doc/tests.md
@@ -1,13 +1,13 @@
 # Testing
 
-The smoke, brain, acceptance, and sync integration tests can be run after Kubecf
+The smoke, brain, acceptance, and sync integration tests can be run after KubeCF
 deployment has completed, via:
 
 ```sh
-bazel run //testing/smoke_tests
-bazel run //testing/brain_tests
-bazel run //testing/acceptance_tests
-bazel run //testing/sync_integration_tests
+bazel run //testing:smoke_tests
+bazel run //testing:brain_tests
+bazel run //testing:acceptance_tests
+bazel run //testing:sync_integration_tests
 ```
 
 The [acceptance tests] can be limited to specific suites of interest,

--- a/doc/tests_brain.md
+++ b/doc/tests_brain.md
@@ -1,6 +1,6 @@
 # Brain tests
 
-The bazel target __//testing/brain_tests__ starts a run of the
+The bazel target __//testing:brain_tests__ starts a run of the
 [SUSE Brain Tests].
 
 [SUSE Brain Tests]: https://github.com/SUSE/brain-tests-release

--- a/doc/tests_cat.md
+++ b/doc/tests_cat.md
@@ -1,6 +1,6 @@
 # Acceptance tests
 
-The bazel target __//testing/acceptance_tests__ starts a run of the
+The bazel target __//testing:acceptance_tests__ starts a run of the
 [Cloud Foundry Acceptance Tests].
 
 [Cloud Foundry Acceptance Tests]: https://github.com/SUSE/cf-acceptance-tests-release

--- a/doc/tests_sits.md
+++ b/doc/tests_sits.md
@@ -1,6 +1,6 @@
 # Sync Integration tests
 
-The bazel target __//testing/sync_integration_tests__ starts a run of the
+The bazel target __//testing:sync_integration_tests__ starts a run of the
 [SUSE Sync Integration Tests].
 
 [SUSE Sync Integration Tests]: https://github.com/SUSE/sync-integration-tests-release

--- a/doc/tests_smoke.md
+++ b/doc/tests_smoke.md
@@ -1,6 +1,6 @@
 # Smoke tests
 
-The bazel target __//testing/smoke_tests__ starts a run of the
+The bazel target __//testing:smoke_tests__ starts a run of the
 [Cloud Foundry Smoke Tests].
 
 [Cloud Foundry Smoke Tests]: https://github.com/cloudfoundry/cf-smoke-tests-release

--- a/rules/kubecf/BUILD.bazel
+++ b/rules/kubecf/BUILD.bazel
@@ -2,4 +2,5 @@ package(default_visibility = ["//visibility:public"])
 
 exports_files([
     "image_list.tmpl.rb",
+    "test.tmpl.sh",
 ])

--- a/rules/kubecf/test.tmpl.sh
+++ b/rules/kubecf/test.tmpl.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o pipefail
+
+alias kubectl="[[kubectl]]"
+qjob_name="[[qjob_name]]"
+namespace="[[namespace]]"
+
+# Trigger the test.
+kubectl patch qjob "${qjob_name}" \
+  --namespace "${namespace}" \
+  --type merge \
+  --patch '{ "spec": { "trigger": { "strategy": "now" } } }'
+
+pod_name() {
+  kubectl get pods \
+    --namespace "${namespace}" \
+    --selector "quarks.cloudfoundry.org/qjob-name=${qjob_name}" \
+    --output name \
+    | sed 's|^pod\/||' \
+    | grep "${qjob_name}"
+}
+
+container_name() {
+  kubectl get pods \
+    --namespace "${namespace}" \
+    --selector "quarks.cloudfoundry.org/qjob-name=${qjob_name}" \
+    --output jsonpath='{ .items[].spec.containers[0].name }'
+}
+
+is_container_running() {
+  local pod_name="$1"
+  local container_name="$2"
+  if [[ "$(kubectl get pods "${pod_name}" \
+            --namespace "${namespace}" \
+            --output jsonpath="{.status.containerStatuses[?(@.name == \"${container_name}\")].state.running}")" != "" ]]; then
+    return 0
+  fi
+  return 1
+}
+
+# Wait for test pod to start.
+wait_for_test_running() {
+  local timeout="300"
+  until pod_name 1> /dev/null || [[ "$timeout" == "0" ]]; do
+    sleep 1
+    timeout=$((timeout - 1))
+  done
+  if [[ "${timeout}" == 0 ]]; then return 1; fi
+  pod_name="$(pod_name)"
+  container_name="$(container_name)"
+  until is_container_running "${pod_name}" "${container_name}" || [[ "$timeout" == "0" ]]; do
+    sleep 1
+    timeout=$((timeout - 1))
+  done
+  if [[ "${timeout}" == 0 ]]; then return 1; fi
+  return 0
+}
+
+echo "Waiting for the ${qjob_name} pod to start..."
+wait_for_test_running || {
+  >&2 echo "Timed out waiting for the ${qjob_name} pod"
+  exit 1
+}
+
+# Tail the test logs.
+pod_name="$(pod_name)"
+container_name="$(container_name)"
+kubectl logs "${pod_name}" \
+  --follow \
+  --namespace "${namespace}" \
+  --container "${container_name}"
+
+# Wait for the container to terminate and then exit the script with the container's exit code.
+jsonpath="{.status.containerStatuses[?(@.name == \"${container_name}\")].state.terminated.exitCode}"
+while true; do
+  exit_code="$(kubectl get pod "${pod_name}" --namespace "${namespace}" --output "jsonpath=${jsonpath}")"
+  if [[ -n "${exit_code}" ]]; then
+    exit "${exit_code}"
+  fi
+  sleep 1
+done

--- a/testing/BUILD.bazel
+++ b/testing/BUILD.bazel
@@ -1,0 +1,23 @@
+load("//rules/kubecf:def.bzl", "test")
+
+package(default_visibility = ["//visibility:public"])
+
+test(
+    name = "acceptance_tests",
+    qjob_name = "acceptance-tests",
+)
+
+test(
+    name = "brain_tests",
+    qjob_name = "brain-tests",
+)
+
+test(
+    name = "smoke_tests",
+    qjob_name = "smoke-tests",
+)
+
+test(
+    name = "sync_integration_tests",
+    qjob_name = "sync-integration-tests",
+)

--- a/testing/acceptance_tests/BUILD.bazel
+++ b/testing/acceptance_tests/BUILD.bazel
@@ -1,13 +1,8 @@
+load("//rules/kubecf:def.bzl", "test")
+
 package(default_visibility = ["//visibility:public"])
 
-load("//rules/kubectl:def.bzl", kubectl_patch = "patch")
-load("//:def.bzl", "project")
-
-kubectl_patch(
+test(
     name = "acceptance_tests",
-    namespace = project.namespace,
-    resource_type = "qjob",
-    resource_name = "acceptance-tests",
-    patch_type = "merge",
-    patch_file = ":trigger.yaml",
+    qjob_name = "acceptance-tests",
 )

--- a/testing/acceptance_tests/BUILD.bazel
+++ b/testing/acceptance_tests/BUILD.bazel
@@ -1,8 +1,0 @@
-load("//rules/kubecf:def.bzl", "test")
-
-package(default_visibility = ["//visibility:public"])
-
-test(
-    name = "acceptance_tests",
-    qjob_name = "acceptance-tests",
-)

--- a/testing/acceptance_tests/trigger.yaml
+++ b/testing/acceptance_tests/trigger.yaml
@@ -1,3 +1,0 @@
-spec:
-  trigger:
-    strategy: now

--- a/testing/brain_tests/BUILD.bazel
+++ b/testing/brain_tests/BUILD.bazel
@@ -1,15 +1,8 @@
+load("//rules/kubecf:def.bzl", "test")
+
 package(default_visibility = ["//visibility:public"])
 
-load("//rules/kubectl:def.bzl", kubectl_patch = "patch")
-load("//:def.bzl", "project")
-
-# TODO: Make brain_tests target also stream the logs. It'll need a new rule for it that takes the
-# kubectl_patch script as a dependency.
-kubectl_patch(
+test(
     name = "brain_tests",
-    namespace = project.namespace,
-    resource_type = "qjob",
-    resource_name = "brain-tests",
-    patch_type = "merge",
-    patch_file = ":trigger.yaml",
+    qjob_name = "brain-tests",
 )

--- a/testing/brain_tests/BUILD.bazel
+++ b/testing/brain_tests/BUILD.bazel
@@ -1,8 +1,0 @@
-load("//rules/kubecf:def.bzl", "test")
-
-package(default_visibility = ["//visibility:public"])
-
-test(
-    name = "brain_tests",
-    qjob_name = "brain-tests",
-)

--- a/testing/brain_tests/trigger.yaml
+++ b/testing/brain_tests/trigger.yaml
@@ -1,3 +1,0 @@
-spec:
-  trigger:
-    strategy: now

--- a/testing/smoke_tests/BUILD.bazel
+++ b/testing/smoke_tests/BUILD.bazel
@@ -1,8 +1,0 @@
-load("//rules/kubecf:def.bzl", "test")
-
-package(default_visibility = ["//visibility:public"])
-
-test(
-    name = "smoke_tests",
-    qjob_name = "smoke-tests",
-)

--- a/testing/smoke_tests/BUILD.bazel
+++ b/testing/smoke_tests/BUILD.bazel
@@ -1,15 +1,8 @@
+load("//rules/kubecf:def.bzl", "test")
+
 package(default_visibility = ["//visibility:public"])
 
-load("//rules/kubectl:def.bzl", kubectl_patch = "patch")
-load("//:def.bzl", "project")
-
-# TODO: Make smoke_tests target also stream the logs. It'll need a new rule for it that takes the
-# kubectl_patch script as a dependency.
-kubectl_patch(
+test(
     name = "smoke_tests",
-    namespace = project.namespace,
-    patch_file = ":trigger.yaml",
-    patch_type = "merge",
-    resource_name = "smoke-tests",
-    resource_type = "qjob",
+    qjob_name = "smoke-tests",
 )

--- a/testing/smoke_tests/trigger.yaml
+++ b/testing/smoke_tests/trigger.yaml
@@ -1,3 +1,0 @@
-spec:
-  trigger:
-    strategy: now

--- a/testing/sync_integration_tests/BUILD.bazel
+++ b/testing/sync_integration_tests/BUILD.bazel
@@ -1,13 +1,8 @@
+load("//rules/kubecf:def.bzl", "test")
+
 package(default_visibility = ["//visibility:public"])
 
-load("//rules/kubectl:def.bzl", kubectl_patch = "patch")
-load("//:def.bzl", "project")
-
-kubectl_patch(
+test(
     name = "sync_integration_tests",
-    namespace = project.namespace,
-    resource_type = "qjob",
-    resource_name = "sync-integration-tests",
-    patch_type = "merge",
-    patch_file = ":trigger.yaml",
+    qjob_name = "sync-integration-tests",
 )

--- a/testing/sync_integration_tests/BUILD.bazel
+++ b/testing/sync_integration_tests/BUILD.bazel
@@ -1,8 +1,0 @@
-load("//rules/kubecf:def.bzl", "test")
-
-package(default_visibility = ["//visibility:public"])
-
-test(
-    name = "sync_integration_tests",
-    qjob_name = "sync-integration-tests",
-)

--- a/testing/sync_integration_tests/trigger.yaml
+++ b/testing/sync_integration_tests/trigger.yaml
@@ -1,3 +1,0 @@
-spec:
-  trigger:
-    strategy: now


### PR DESCRIPTION
## Description

Each target triggers the test, waits for the pod to exist and then tails the test logs. The exit code of the script is the exit code of the test container.

## Motivation and Context

There was no script to do the whole testing flow in the project.

## How Has This Been Tested?

Ran each of the tests under the `//testing` package. To list the targets:
```
bazel query //testing/...
```

To run each test:
```
bazel run <target>
```

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
