### PR TITLE
Enable different CATs test to be run

### DIFF
--- a/deploy/helm/kubecf/assets/operations/instance_groups/acceptance-tests.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/acceptance-tests.yaml
@@ -19,7 +19,7 @@
           credhub_mode: assisted
           credhub_secret: ((credhub_admin_client_secret))
           {{- end }}
-          include: '+tcp_routing'
+          include: '+tcp_routing,+docker,+security_groups,+service_discovery,+tasks,+zipkin,+apps,+routing,+container_networking,v3'
           skip_ssl_validation: true
           timeout_scale: 3
         bpm:

--- a/deploy/helm/kubecf/values.yaml
+++ b/deploy/helm/kubecf/values.yaml
@@ -312,7 +312,7 @@ testing:
   brain_tests:
     enabled: false
   cf_acceptance_tests:
-    enabled: false
+    enabled: true
   smoke_tests:
     enabled: true
   sync_integration_tests:


### PR DESCRIPTION
This is a FAKE PR, just to see the output of CATS, when enabling the following:

```yaml
include: '+tcp_routing,+docker,+security_groups,+service_discovery,+tasks,+zipkin,+apps,+routing,+container_networking,v3'
```