### PR TITLE
fix: brains: drop app prefix for insecure registry

### DIFF
--- a/deploy/helm/kubecf/assets/operations/instance_groups/api.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/api.yaml
@@ -17,7 +17,7 @@
 # For brain tests, allow CC access to the insecure registry they will create.
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/diego/insecure_docker_registry_list?/-
-  value: "insecure-registry.tcp.((system_domain)):20005"
+  value: "tcp.((system_domain)):20005"
 {{- end}}
 
 {{- $path := "/var/vcap/data/shared-packages/" }}

--- a/deploy/helm/kubecf/assets/operations/instance_groups/diego-cell.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/diego-cell.yaml
@@ -120,10 +120,10 @@
 # For brain tests, allow garden access to the insecure registry they will create.
 - type: replace
   path: /instance_groups/name=diego-cell/jobs/name=garden/properties/garden/insecure_docker_registry_list?/-
-  value: "insecure-registry.tcp.((system_domain)):20005"
+  value: "tcp.((system_domain)):20005"
 - type: replace
   path: /instance_groups/name=diego-cell/jobs/name=garden/properties/grootfs?/insecure_docker_registry_list/-
-  value: "insecure-registry.tcp.((system_domain)):20005"
+  value: "tcp.((system_domain)):20005"
 {{- end}}
 
 # Add quarks properties for route_emitter.


### PR DESCRIPTION
## Description
This drops the app hostname prefix for the brains tests (`insecure-registry.tcp.*`) as that is not configured correctly for some deployments (e.g. kind).

Requires https://github.com/SUSE/brain-tests-release/pull/13

## Motivation and Context
Required for https://github.com/SUSE/brain-tests-release/pull/13 to work correctly.

This is part of the fix for #29.

## How Has This Been Tested?
Running the changed test locally (minikube + `ClusterIP`).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
