### PR TITLE
Add imagelist to helmchart

### DIFF
--- a/deploy/helm/kubecf/BUILD.bazel
+++ b/deploy/helm/kubecf/BUILD.bazel
@@ -9,7 +9,6 @@ load(
     "//rules/kubecf:def.bzl",
     "image_list",
     "metadata_file_generator",
-    "chart_with_imagelist",
 )
 load("//rules/yaml_extractor:defs.bzl", "yaml_extractor")
 load("//:def.bzl", "project")
@@ -86,10 +85,18 @@ helm_package(
     ],
 )
 
-chart_with_imagelist(
-    name = "with_imagelist",
-    chart = ":kubecf",
-    image_list = ":image_list",
+genrule(
+    name = "release_chart",
+    tools = [
+        "//rules/kubecf:release_chart.sh",
+        "@jq//:binary"
+    ],
+    srcs = [
+        ":kubecf",
+        ":image_list",
+    ],
+    outs = ["kubecf_release.tgz"],
+    cmd = "$(location //rules/kubecf:release_chart.sh) $(location :kubecf) $(location :image_list) $@ $(location @jq//:binary)",
 )
 
 # Generates a file containing only the KubeCF version.

--- a/deploy/helm/kubecf/BUILD.bazel
+++ b/deploy/helm/kubecf/BUILD.bazel
@@ -9,6 +9,7 @@ load(
     "//rules/kubecf:def.bzl",
     "image_list",
     "metadata_file_generator",
+    "chart_with_imagelist",
 )
 load("//rules/yaml_extractor:defs.bzl", "yaml_extractor")
 load("//:def.bzl", "project")
@@ -83,6 +84,12 @@ helm_package(
         ":cf_deployment",
         ":extracted_jobs",
     ],
+)
+
+chart_with_imagelist(
+    name = "with_imagelist",
+    chart = ":kubecf",
+    image_list = ":image_list",
 )
 
 # Generates a file containing only the KubeCF version.

--- a/rules/kubecf/BUILD.bazel
+++ b/rules/kubecf/BUILD.bazel
@@ -2,4 +2,5 @@ package(default_visibility = ["//visibility:public"])
 
 exports_files([
     "image_list.tmpl.rb",
+    "release_chart.sh",
 ])

--- a/rules/kubecf/def.bzl
+++ b/rules/kubecf/def.bzl
@@ -21,69 +21,6 @@ def metadata_file_generator(name, file, operator_chart, visibility=None):
         visibility = visibility,
     )
 
-def _chart_with_imagelist_impl(ctx):
-    """A specialized rule for KubeCF to generate a helm chart including a list of referenced images
-
-    This function runs the kubecf image list and the helm-chart target and repacks them
-    including the image_list.json
-    """
-    output= ctx.actions.declare_file("{}.tgz".format(ctx.attr.name))
-    outputs = [output]
-    script_name = paths.basename(ctx.file._script_tmpl.path)
-    script = ctx.actions.declare_file(script_name)
-    ctx.actions.expand_template(
-        output = script,
-        substitutions = {
-        },
-        template = ctx.file._script_tmpl,
-    )
-    ctx.actions.run_shell(
-        command = "bash \"{script}\" \"{chart}\" \"{image_list}\" \"{target}\" \"{jq}\"".format(
-            script=script.path,
-            chart=ctx.file.chart.path,
-            image_list=ctx.file.image_list.path,
-            target=output.path,
-            jq=ctx.executable._jq.path,
-            ),
-        inputs = [
-            script,
-            ctx.file.chart,
-            ctx.file.image_list
-        ],
-        outputs = outputs,
-        tools = [
-            ctx.executable._jq,
-        ]
-    )
-    return [DefaultInfo(files = depset(outputs))]
-
-chart_with_imagelist = rule(
-    implementation = _chart_with_imagelist_impl,
-    attrs = {
-        "chart": attr.label(
-            allow_single_file = True,
-            default = "//deploy/helm/kubecf:kubecf",
-            doc = "The KubeCF chart file",
-            mandatory = True,
-        ),
-        "image_list": attr.label(
-            allow_single_file = True,
-            default = "//deploy/helm/kubecf:image_list",
-            mandatory = True,
-        ),
-        "_jq": attr.label(
-            allow_single_file = True,
-            cfg = "host",
-            default = "@jq//:binary",
-            executable = True,
-        ),
-        "_script_tmpl": attr.label(
-            allow_single_file = True,
-            default = "//rules/kubecf:release_chart.sh",
-        ),
-    },
-)
-
 def _image_list_impl(ctx):
     """A specialized rule for KubeCF to list all the container images being used by the project.
 

--- a/rules/kubecf/def.bzl
+++ b/rules/kubecf/def.bzl
@@ -21,6 +21,69 @@ def metadata_file_generator(name, file, operator_chart, visibility=None):
         visibility = visibility,
     )
 
+def _chart_with_imagelist_impl(ctx):
+    """A specialized rule for KubeCF to generate a helm chart including a list of referenced images
+
+    This function runs the kubecf image list and the helm-chart target and repacks them
+    including the image_list.json
+    """
+    output= ctx.actions.declare_file("{}.tgz".format(ctx.attr.name))
+    outputs = [output]
+    script_name = paths.basename(ctx.file._script_tmpl.path)
+    script = ctx.actions.declare_file(script_name)
+    ctx.actions.expand_template(
+        output = script,
+        substitutions = {
+        },
+        template = ctx.file._script_tmpl,
+    )
+    ctx.actions.run_shell(
+        command = "bash \"{script}\" \"{chart}\" \"{image_list}\" \"{target}\" \"{jq}\"".format(
+            script=script.path,
+            chart=ctx.file.chart.path,
+            image_list=ctx.file.image_list.path,
+            target=output.path,
+            jq=ctx.executable._jq.path,
+            ),
+        inputs = [
+            script,
+            ctx.file.chart,
+            ctx.file.image_list
+        ],
+        outputs = outputs,
+        tools = [
+            ctx.executable._jq,
+        ]
+    )
+    return [DefaultInfo(files = depset(outputs))]
+
+chart_with_imagelist = rule(
+    implementation = _chart_with_imagelist_impl,
+    attrs = {
+        "chart": attr.label(
+            allow_single_file = True,
+            default = "//deploy/helm/kubecf:kubecf",
+            doc = "The KubeCF chart file",
+            mandatory = True,
+        ),
+        "image_list": attr.label(
+            allow_single_file = True,
+            default = "//deploy/helm/kubecf:image_list",
+            mandatory = True,
+        ),
+        "_jq": attr.label(
+            allow_single_file = True,
+            cfg = "host",
+            default = "@jq//:binary",
+            executable = True,
+        ),
+        "_script_tmpl": attr.label(
+            allow_single_file = True,
+            default = "//rules/kubecf:release_chart.sh",
+        ),
+    },
+)
+
 def _image_list_impl(ctx):
     """A specialized rule for KubeCF to list all the container images being used by the project.
 

--- a/rules/kubecf/release_chart.sh
+++ b/rules/kubecf/release_chart.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# This is a helper script which combines a helm chart tarball and an image list
+# into a new tarball.
+
+if [ ! -e "$1" ]; then
+  echo "Helm chart tarball '$1' does not exist, bailing out!"; exit 1
+fi
+
+if [ ! -e "$2" ]; then
+  echo "Image list '$2' has not been created, bailing out!"; exit 1
+fi
+
+BASENAME=$(dirname $(tar tf "$1" | head -n1))
+KUBECF_IMAGELIST_TXT_PATH="${BASENAME}/imagelist.txt"
+JQ_PATH="$4"
+
+tar xfv "$1"
+
+$JQ_PATH '.images | .[]' -r < $2 > "${KUBECF_IMAGELIST_TXT_PATH}"
+
+tar cfv "$3" "${BASENAME}/"

--- a/rules/kubecf/release_chart.sh
+++ b/rules/kubecf/release_chart.sh
@@ -3,19 +3,25 @@
 # This is a helper script which combines a helm chart tarball and an image list
 # into a new tarball.
 
-if [ ! -e "$1" ]; then
-  echo "Helm chart tarball '$1' does not exist, bailing out!"; exit 1
+KUBECF_CHART="$1"
+KUBECF_IMAGE_LIST_JSON_FILE="$2"
+OUTPUT="$3"
+JQ="$4"
+
+if [ ! -e "${KUBECF_CHART}" ]; then
+  >&2 echo "Helm chart tarball '${KUBECF_CHART}' does not exist, bailing out!"; exit 1
 fi
 
-if [ ! -e "$2" ]; then
-  echo "Image list '$2' has not been created, bailing out!"; exit 1
+if [ ! -e "${KUBECF_IMAGE_LIST_JSON_FILE}" ]; then
+  >&2 echo "Image list '${KUBECF_IMAGE_LIST_JSON_FILE}' has not been created, bailing out!"; exit 1
 fi
 
-BASENAME=$(dirname $(tar tf "$1" | head -n1))
-KUBECF_IMAGELIST_TXT_PATH="${BASENAME}/imagelist.txt"
-JQ_PATH="$4"
+BASENAME=$(dirname "$(tar tf "${KUBECF_CHART}" | head -n1)")
+KUBECF_IMAGE_LIST_TXT_FILE="${BASENAME}/imagelist.txt"
 
-tar xfv "$1"
-$JQ_PATH '.images | .[]' -r < $2 > "${KUBECF_IMAGELIST_TXT_PATH}"
+tar xf "${KUBECF_CHART}"
+"${JQ}" '.images | .[]' -r \
+  < "${KUBECF_IMAGE_LIST_JSON_FILE}" \
+  > "${KUBECF_IMAGE_LIST_TXT_FILE}"
 
-tar czf "$3" "${BASENAME}/"
+tar czf "${OUTPUT}" "${BASENAME}/"

--- a/rules/kubecf/release_chart.sh
+++ b/rules/kubecf/release_chart.sh
@@ -16,7 +16,6 @@ KUBECF_IMAGELIST_TXT_PATH="${BASENAME}/imagelist.txt"
 JQ_PATH="$4"
 
 tar xfv "$1"
-
 $JQ_PATH '.images | .[]' -r < $2 > "${KUBECF_IMAGELIST_TXT_PATH}"
 
-tar cfv "$3" "${BASENAME}/"
+tar czf "$3" "${BASENAME}/"


### PR DESCRIPTION
This PR creates a helm-chart including the imagelist.txt based on @f0rmiga previous work.

## Description
We have added a new bazel target `//deploy/helm/kubecf:release_chart` which will unpack the helm chart created by `//deploy/helm/kubecf` and add the imagelist.txt containing all used images in the chart.

## Motivation and Context
The imagelist helps us when creating tools consuming the helmchart and/or the contained images.
## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
