### PR TITLE
Consume deps inside of docker catapult CI image

### DIFF
--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -194,6 +194,7 @@ rotate_args: &rotate_args
 - |
   export BACKEND=imported
   export KUBECF_NAMESPACE="scf"
+  export QUIET_OUTPUT=true
   export DOWNLOAD_CATAPULT_DEPS=false
   export CLUSTER_NAME="$(cat kind-environments/name)"
   export KUBECFG="$(readlink -f kind-environments/metadata)"
@@ -486,7 +487,6 @@ jobs:
       - name: output
       params:
         DEFAULT_STACK: cflinuxfs3
-        QUIET_OUTPUT: true
         ENABLE_EIRINI: {{ eq $cfScheduler "eirini" }}
         CLUSTER_NAME_PREFIX: kubecf-{{ $cfScheduler }}
       run:

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -164,6 +164,7 @@ deploy_args: &deploy_args
   export BACKEND=imported
   export DOCKER_ORG=cap-staging
   export QUIET_OUTPUT=true
+  export DOWNLOAD_CATAPULT_DEPS=false
   export CLUSTER_NAME="$(cat kind-environments/name)"
   export KUBECFG="$(readlink -f kind-environments/metadata)"
   pushd catapult
@@ -179,6 +180,7 @@ test_args: &test_args
   export SCF_LOCAL="${PWD}/commit-to-test"
   export KUBECF_NAMESPACE="scf"
   export QUIET_OUTPUT=true
+  export DOWNLOAD_CATAPULT_DEPS=false
   export CLUSTER_NAME="$(cat kind-environments/name)"
   export KUBECFG="$(readlink -f kind-environments/metadata)"
   export KUBECF_CHECKOUT="${PWD}/commit-to-test"
@@ -192,6 +194,7 @@ rotate_args: &rotate_args
 - |
   export BACKEND=imported
   export KUBECF_NAMESPACE="scf"
+  export DOWNLOAD_CATAPULT_DEPS=false
   export CLUSTER_NAME="$(cat kind-environments/name)"
   export KUBECFG="$(readlink -f kind-environments/metadata)"
   export KUBECF_CHECKOUT="${PWD}/commit-to-test"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This makes catapult consume yq, yaml-patch, bazel, etc from the catapult CI
image run by concourse.

See: SUSE/catapult#162


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Speeds up and simplifies CI runs.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- An important detail to include is the version of the used cf-operator -->

The CI is already running on the refreshed catapult image built from https://concourse.suse.de/teams/main/pipelines/catapult.

Hijacked a build and checked that all new binaries are present and working on the image.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
