### PR TITLE
fix: remove --- from routing-api ops-file

### DIFF
--- a/deploy/helm/kubecf/assets/operations/instance_groups/routing-api.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/routing-api.yaml
@@ -1,4 +1,3 @@
----
 {{- if .Values.features.routing_api.enabled }}
 
 # Add quarks properties for routing-api.


### PR DESCRIPTION
Ops-files should be single YAML documents.
When --- is used, each YAML file is set to contain multiple documents,
which is undesirable when parsing many ops-files.
This is especially true for building the image list for KubeCF.
