### PR TITLE
feat: user-provided ClusterRole rules for Eirini

### DIFF
--- a/deploy/helm/kubecf/templates/eirini.yaml
+++ b/deploy/helm/kubecf/templates/eirini.yaml
@@ -12,7 +12,7 @@ metadata:
 rules:
 - apiGroups: ['admissionregistration.k8s.io']
   resources: ['mutatingwebhookconfigurations']
-  verbs:     ['*']
+  verbs: ['*']
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -27,6 +27,31 @@ subjects:
 - kind: ServiceAccount
   name: eirini
   namespace: {{ .Release.Namespace }}
+
+{{- if gt (len .Values.features.eirini.cluster_role.rules) 0 }}
+# eirini-webhook-user-provided cluster role for eirini service account.
+# If user provides a customized cluster role, it is used to implement eirinix extensions.
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Namespace }}:eirini-webhook-user-provided
+rules: {{ .Values.features.eirini.cluster_role.rules | toJson }}
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Namespace }}:eirini-webhook-user-provided
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Namespace }}:eirini-webhook-user-provided
+subjects:
+- kind: ServiceAccount
+  name: eirini
+  namespace: {{ .Release.Namespace }}
+{{- end }}
 
 # A service for the cc uploader
 ---

--- a/deploy/helm/kubecf/templates/eirini.yaml
+++ b/deploy/helm/kubecf/templates/eirini.yaml
@@ -28,7 +28,7 @@ subjects:
   name: eirini
   namespace: {{ .Release.Namespace }}
 
-{{- if gt (len .Values.features.eirini.cluster_role.rules) 0 }}
+{{- if gt (len .Values.features.eirini.rbac.webhook.cluster_role.rules) 0 }}
 # eirini-webhook-user-provided cluster role for eirini service account.
 # If user provides a customized cluster role, it is used to implement eirinix extensions.
 ---
@@ -36,7 +36,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ .Release.Namespace }}:eirini-webhook-user-provided
-rules: {{ .Values.features.eirini.cluster_role.rules | toJson }}
+rules: {{ .Values.features.eirini.rbac.webhook.cluster_role.rules | toJson }}
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/helm/kubecf/values.yaml
+++ b/deploy/helm/kubecf/values.yaml
@@ -238,6 +238,8 @@ features:
     registry:
       service:
         nodePort: 32123
+    cluster_role:
+          rules: []
   ingress:
     enabled: false
     tls:

--- a/deploy/helm/kubecf/values.yaml
+++ b/deploy/helm/kubecf/values.yaml
@@ -238,7 +238,9 @@ features:
     registry:
       service:
         nodePort: 32123
-    cluster_role:
+    rbac:
+      webhook:
+        cluster_role:
           rules: []
   ingress:
     enabled: false


### PR DESCRIPTION
Fixes #595.

## Description
1. Added eirini cluster-role resources and verb properties under feature eirini. 
2. Add if condition in values.yaml, set customized resources and verb if eirini enabled and there are customized values for them. 

## Motivation and Context
Since there is no way to extend the resources rules in https://github.com/cloudfoundry-incubator/kubecf/blob/master/deploy/helm/kubecf/templates/eirini.yaml#L12 , unless you apply a manual change or a patch of the file. For some IaaS, the resources list requires more items, for example in IKS cluster, it needs this resource list: 
```
resources: ['mutatingwebhookconfigurations', 'nodes', 'nodes/proxy']
```

## How Has This Been Tested?
I did two tests, one is only to enable eirini feature, no properties under it. 
The other is to enable eirini feature, and added customized resources under it. 
Both deployment succeeded. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has security implications.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
