### PR TITLE
fix: simplify the output of external_binary rule

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,8 +1,8 @@
-package(default_visibility = ["//visibility:public"])
-
 load("@external_binaries//:def.bzl", "binary_location")
 load("@workspace_status//:def.bzl", "workspace_status")
 load(":def.bzl", "project")
+
+package(default_visibility = ["//visibility:public"])
 
 workspace_status(
     name = "workspace_status",

--- a/def.bzl
+++ b/def.bzl
@@ -8,128 +8,136 @@ project = struct(
 
     # External binaries; see external_binary() invocation in WORKSPACE.
     external_binaries = {
-        "bosh_cli": struct(
-            sha256 = {
+        "bosh_cli": {
+            "sha256": {
                 "darwin": "1d2ced5edc7a9406616df7ad9c0d4e3ade10d66d33e753885ab8e245c037e280",
                 "linux": "ca7580008abfd4942dcb1dd6218bde04d35f727717a7d08a2bc9f7d346bce0f6",
                 "windows": "77c736c15001b1eb320ae61042fb6c72a1addde143e0a9af703ddda35b2c5bce",
             },
-            url = {
+            "url": {
                 "darwin": "https://github.com/cloudfoundry/bosh-cli/releases/download/v{version}/bosh-cli-{version}-darwin-amd64",
                 "linux": "https://github.com/cloudfoundry/bosh-cli/releases/download/v{version}/bosh-cli-{version}-linux-amd64",
                 "windows": "https://github.com/cloudfoundry/bosh-cli/releases/download/v{version}/bosh-cli-{version}-windows-amd64.exe",
             },
-            version = "6.2.1",
-        ),
-        "docker": struct(
-            sha256 = {
-                "linux":   "50cdf38749642ec43d6ac50f4a3f1f7f6ac688e8d8b4e1c5b7be06e1a82f06e9",
+            "version": "6.2.1",
+        },
+        "docker": {
+            "sha256": {
+                "linux": "50cdf38749642ec43d6ac50f4a3f1f7f6ac688e8d8b4e1c5b7be06e1a82f06e9",
             },
-            url = {
-                "linux":   "https://download.docker.com/linux/static/stable/x86_64/docker-{version}.tgz",
+            "url": {
+                "linux": "https://download.docker.com/linux/static/stable/x86_64/docker-{version}.tgz",
             },
-            version = "19.03.5",
-        ),
-        "helm": struct(
-            sha256 = {
+            "strip_prefix": {
+                "linux": "docker",
+            },
+            "version": "19.03.5",
+        },
+        "helm": {
+            "sha256": {
                 "darwin":  "5e27bc6ecf838ed28a6a480ee14e6bec137b467a56f427dbc3cf995f9bdcf85c",
                 "linux":   "fc75d62bafec2c3addc87b715ce2512820375ab812e6647dc724123b616586d6",
                 "windows": "c52065cb70ad9d88b195638e1591db64852f4ad150448e06fca907d47a07fe4c",
             },
-            url = {
+            "url": {
                 "darwin":  "https://get.helm.sh/helm-v{version}-darwin-amd64.tar.gz",
                 "linux":   "https://get.helm.sh/helm-v{version}-linux-amd64.tar.gz",
                 "windows": "https://get.helm.sh/helm-v{version}-windows-amd64.zip",
             },
-            version = "3.0.3",
-        ),
-        "jq": struct(
-            sha256 = {
+            "version": "3.0.3",
+            "strip_prefix": {
+                "darwin": "darwin-amd64",
+                "linux": "linux-amd64",
+                "windows": "windows-amd64",
+            },
+        },
+        "jq": {
+            "sha256": {
                 "darwin":  "5c0a0a3ea600f302ee458b30317425dd9632d1ad8882259fcaf4e9b868b2b1ef",
                 "linux":   "af986793a515d500ab2d35f8d2aecd656e764504b789b66d7e1a0b727a124c44",
                 "windows": "a51d36968dcbdeabb3142c6f5cf9b401a65dc3a095f3144bd0c118d5bb192753",
             },
-            url = {
+            "url": {
                 "darwin":  "https://github.com/stedolan/jq/releases/download/jq-{version}/jq-osx-amd64",
                 "linux":   "https://github.com/stedolan/jq/releases/download/jq-{version}/jq-linux64",
                 "windows": "https://github.com/stedolan/jq/releases/download/jq-{version}/jq-win64.exe",
             },
-            version = "1.6",
-        ),
-        "k3s": struct(
-            sha256 = {
+            "version": "1.6",
+        },
+        "k3s": {
+            "sha256": {
                 "linux":   "9f8bea3fa6f88066ca51cc896000aab2794e3f585d6fc982dd5aa7da8ee9fe85",
             },
-            url = {
+            "url": {
                 "linux":   "https://github.com/rancher/k3s/releases/download/v{version}/k3s",
             },
-            version = "0.9.1",
-        ),
-        "kind": struct(
-            sha256 = {
+            "version": "0.9.1",
+        },
+        "kind": {
+            "sha256": {
                 "darwin":  "eba1480b335f1fd091bf3635dba3f901f9ebd9dc1fb32199ca8a6aaacf69691e",
                 "linux":   "b68e758f5532db408d139fed6ceae9c1400b5137182587fc8da73a5dcdb950ae",
                 "windows": "f022a4800363bd4a0c17ee84b58d3e5f654a945dcaf5f66e2c1c230e417b05fb",
             },
-            url = {
+            "url": {
                 "darwin":  "https://github.com/kubernetes-sigs/kind/releases/download/v{version}/kind-darwin-amd64",
                 "linux":   "https://github.com/kubernetes-sigs/kind/releases/download/v{version}/kind-linux-amd64",
                 "windows": "https://github.com/kubernetes-sigs/kind/releases/download/v{version}/kind-windows-amd64",
             },
-            version = "0.6.0",
-        ),
-        "kubectl": struct(
-            sha256 = {
+            "version": "0.6.0",
+        },
+        "kubectl": {
+            "sha256": {
                 "darwin":  "1b8e747984ae3f9aa5a199bd444823d703dcd4dbf0617347b3b3aea254ada7b1",
                 "linux":   "522115e0f11d83c08435a05e76120c89ea320782ccaff8e301bd14588ec50145",
                 "windows": "cd134c5746e39b985df979a944876c0d61ae88e79d954f8534a66bc84cd8a7fb",
             },
-            url = {
+            "url": {
                 "darwin":  "https://storage.googleapis.com/kubernetes-release/release/v{version}/bin/darwin/amd64/kubectl",
                 "linux":   "https://storage.googleapis.com/kubernetes-release/release/v{version}/bin/linux/amd64/kubectl",
                 "windows": "https://storage.googleapis.com/kubernetes-release/release/v{version}/bin/windows/amd64/kubectl.exe",
             },
-            version = "1.15.6",
-        ),
-        "minikube": struct(
-            sha256 = {
+            "version": "1.15.6",
+        },
+        "minikube": {
+            "sha256": {
                 "darwin":  "5ea5168a80597ee6221bf50a524429a24a37f0c0f36725e6b297dc5a7a6a2105",
                 "linux":   "eabd027438953d29a4b0f7b810c801919cc13bef3ebe7aff08c9534ac2b091ab",
                 "windows": "79d66c874cfe3497656e9ba191680cc95abd92d2f722b10de38f00b76ef82393",
             },
-            url = {
+            "url": {
                 "darwin":  "https://storage.googleapis.com/minikube/releases/v{version}/minikube-darwin-amd64",
                 "linux":   "https://storage.googleapis.com/minikube/releases/v{version}/minikube-linux-amd64",
                 "windows": "https://storage.googleapis.com/minikube/releases/v{version}/minikube-windows-amd64.exe",
             },
-            version = "1.6.2",
-        ),
-        "shellcheck": struct(
-            sha256 = {
+            "version": "1.6.2",
+        },
+        "shellcheck": {
+            "sha256": {
                 "darwin":  "a5d77cbe4c3e92916bce712b959f6d54392f94bcf8ea84f80ba425a9e72e2afe",
                 "linux":   "c37d4f51e26ec8ab96b03d84af8c050548d7288a47f755ffb57706c6c458e027",
                 "windows": "8aafdeff31095613308e92ce6a13e3c41249b51e757fd4fcdfdfc7a81d29286a",
             },
-            url = {
+            "url": {
                 "darwin":  "https://storage.googleapis.com/shellcheck/shellcheck-v{version}.darwin-x86_64",
                 "linux":   "https://storage.googleapis.com/shellcheck/shellcheck-v{version}.linux-x86_64",
                 "windows": "https://storage.googleapis.com/shellcheck/shellcheck-v{version}.exe",
             },
-            version = "0.7.0",
-        ),
-        "yq": struct(
-            sha256 = {
+            "version": "0.7.0",
+        },
+        "yq": {
+            "sha256": {
                 "darwin":  "06732685917646c0bbba8cc17386cd2a39b214ad3cd128fb4b8b410ed069101c",
                 "linux":   "754c6e6a7ef92b00ef73b8b0bb1d76d651e04d26aa6c6625e272201afa889f8b",
                 "windows": "bdfd2a00bab3d8171edf57aaf4e9a2f7d0395e7a36d42b07f0e35503c00292a3",
             },
-            url = {
+            "url": {
                 "darwin":  "https://github.com/mikefarah/yq/releases/download/{version}/yq_darwin_amd64",
                 "linux":   "https://github.com/mikefarah/yq/releases/download/{version}/yq_linux_amd64",
                 "windows": "https://github.com/mikefarah/yq/releases/download/{version}/yq_windows_amd64.exe",
             },
-            version = "2.4.1",
-        ),
+            "version": "2.4.1",
+        },
     },
 
     # External bazel libraries; see http_archive() invocation in WORKSPACE.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The structure of the files exported by the repository_rule is simpler, allowing for easier dependency consumption from other repository rules.

## Motivation and Context

Repository rules dislike symlinks for binary dependencies that we want to consume. E.g. passing the Helm binary to a repository rule requires the use of the real path, rather than the `:binary` target that returns a symlink to the real path.

With this change, the Helm binary can also be consumed via `@helm//:helm`, which happens to be the real path.

The `:binary` symlink is still useful for regular rules and should not be impacted by these changes.

## How Has This Been Tested?

Ran the `--help` for each of the binary dependencies we currently have using the `:binary` targets, as well as tried out the explicit binary location for helm and kubectl, which asserts that a `.tgz` and a binary src work well with the rule.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
