### PR TITLE
feat: docker suite enabled by default on CATS

### DIFF
--- a/deploy/helm/kubecf/assets/operations/instance_groups/acceptance-tests.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/acceptance-tests.yaml
@@ -25,9 +25,7 @@
           credhub_mode: assisted
           credhub_secret: ((credhub_admin_client_secret))
           {{- end }}
-          {{- if .Values.features.routing_api.enabled }}
-          include: '+tcp_routing,docker'
-          {{- end }}
+          include: '+docker{{ if .Values.features.routing_api.enabled }},tcp_routing{{ end }}'
           skip_ssl_validation: true
           timeout_scale: 3
         bpm:

--- a/deploy/helm/kubecf/assets/operations/instance_groups/acceptance-tests.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/acceptance-tests.yaml
@@ -26,7 +26,7 @@
           credhub_secret: ((credhub_admin_client_secret))
           {{- end }}
           {{- if .Values.features.routing_api.enabled }}
-          include: '+tcp_routing'
+          include: '+tcp_routing,docker'
           {{- end }}
           skip_ssl_validation: true
           timeout_scale: 3

--- a/deploy/helm/kubecf/values.yaml
+++ b/deploy/helm/kubecf/values.yaml
@@ -52,7 +52,10 @@ releases:
       os: SLE_15_SP1
       version: 23.11-7.0.0_374.gb8e8e6af
   cf-acceptance-tests:
-    version: 0.0.12
+    version: 0.0.13
+    stemcell:
+      os: SLE_15_SP1
+      version: 23.21-7.0.0_374.gb8e8e6af
   # pxc is not a BOSH release.
   pxc:
     image:


### PR DESCRIPTION
## Description

Fixes #625.

## Motivation and Context

By default, the docker feature is disabled, making the docker suite on CATS to fail if not manually enabled.
The bump on the CATS release included in this PR handles this by enabling the docker feature while running CATS, then disabling it as part of the cleanup step.

## How Has This Been Tested?

Running CATS with the docker suite enabled by default and not having manually enabled the docker feature.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
