### PR TITLE
Remove tiller check from dev/kube/kube-ready-state-check.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ At the time of this writing these were:
 |minikube      | 1.6.2             |                                    |
 |kind          | 0.6.0             |                                    |
 |kubectl       | 1.15.6            |                                    |
-|Helm          | 3.1.1             |                                    |
+|Helm          | 3.0.3             |                                    |
 |CF Operator   | 2.0.0-0.g0142d1e9 |                                    |
 |cf-deployment | 12.18.0           |                                    |
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ At the time of this writing these were:
 |minikube      | 1.6.2             |                                    |
 |kind          | 0.6.0             |                                    |
 |kubectl       | 1.15.6            |                                    |
-|Helm          | 2.16.1            | 2.(latest_minor) and 3 should work |
+|Helm          | 3.1.1             |                                    |
 |CF Operator   | 2.0.0-0.g0142d1e9 |                                    |
 |cf-deployment | 12.18.0           |                                    |
 

--- a/dev/kube/kube-ready-state-check.sh
+++ b/dev/kube/kube-ready-state-check.sh
@@ -114,12 +114,6 @@ if having_category kube ; then
     status "all kube-dns pods should be running (show N/N ready)"
 fi
 
-# tiller-deploy shows all pods ready
-if having_category kube ; then
-    kubectl get pods --namespace=kube-system --selector name=tiller 2> /dev/null | grep -Eq '([0-9])/\1 *Running'
-    status "all tiller pods should be running (N/N ready)"
-fi
-
 # ntp or systemd-timesyncd is installed and running
 if having_category api node ; then
     pgrep -x ntpd >& /dev/null || pgrep -x chronyd >& /dev/null || systemctl is-active systemd-timesyncd >& /dev/null


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Checking for Tiller is not needed anymore, we require helm >= 3.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- An important detail to include is the version of the used cf-operator -->

Run `kube-ready-state-check.sh` by hand.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
