### PR TITLE
fix: Update database_encryption keys for cc_deployment_updater

### DIFF
--- a/deploy/helm/kubecf/assets/operations/instance_groups/api.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/api.yaml
@@ -122,6 +122,13 @@
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/database_encryption?
   value: *encryption_info
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cc_deployment_updater/properties/cc/database_encryption?
+  value: *encryption_info
+# XXX encryption_info is also used by cc_route_syncer (see CF-K8s-Networking)
+#- type: replace
+#  path: /instance_groups/name=?????/jobs/name=cc_route_syncer/properties/cc/database_encryption?
+#  value: *encryption_info
 
 # core_file_pattern should be disabled as CC is not running on a VM.
 - type: replace


### PR DESCRIPTION
## Description

While investigating #524 I noticed that our ops-file to setup additional encryption keys does not keep the `cc_deployment_updater` job in sync. I didn't notice any effect of this, and it doesn't seem to be responsible for #524 either, which I couldn't reproduce even without this change in place.

I've also added a comment about the `cc_route_syncer` job, which is not part of cf-deployment, but used byCF-K8s-Networking. If we ever start using it, then it too will need to be updated with the encryption keys.

## Motivation and Context

I have not looked how we are using `cc_deployment_updater` in kubecf (or if it is just a vestigial part from upstream that we don't use). I've not noticed any issues, but created this PR just for correctness sake.

## How Has This Been Tested?

I've tested this change locally with minikube.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
