### PR TITLE
feat: helm dependencies rules

### DIFF
--- a/deploy/helm/kubecf/.gitignore
+++ b/deploy/helm/kubecf/.gitignore
@@ -1,0 +1,3 @@
+# The charts directory under the root of the Helm chart definitions is ignore as it is cached and
+# managed with Bazel.
+/charts/

--- a/rules/helm/BUILD.bazel
+++ b/rules/helm/BUILD.bazel
@@ -11,7 +11,8 @@ gomplate_binary(
 )
 
 exports_files([
-    "template.sh",
     "delete.tmpl.rb",
+    "dependencies_charts.BUILD.bazel",
+    "template.sh",
     "upgrade.tmpl.rb",
 ])

--- a/rules/helm/def.bzl
+++ b/rules/helm/def.bzl
@@ -16,6 +16,7 @@ def _package_impl(ctx):
             "[[tars]]": multipath_sep.join([f.path for f in ctx.files.tars]),
             "[[generated]]": multipath_sep.join([f.path for f in ctx.files.generated]),
             "[[version]]": ctx.attr.version,
+            "[[subcharts]]": multipath_sep.join([f.path for f in ctx.files.subcharts]),
             "[[helm]]": ctx.executable._helm.path,
             "[[output_tgz]]": output_tgz.path,
         },
@@ -23,7 +24,11 @@ def _package_impl(ctx):
     )
     ctx.actions.run_shell(
         command = "ruby {}".format(package_script.path),
-        inputs = [package_script] + ctx.files.srcs + ctx.files.tars + ctx.files.generated,
+        inputs = [package_script] +
+            ctx.files.srcs +
+            ctx.files.tars +
+            ctx.files.generated +
+            ctx.files.subcharts,
         outputs = outputs,
         tools = [ctx.executable._helm],
     )
@@ -44,6 +49,7 @@ _package = rule(
             mandatory = False,
             default = "",
         ),
+        "subcharts": attr.label_list(),
         "_helm": attr.label(
             allow_single_file = True,
             cfg = "host",

--- a/rules/helm/def.bzl
+++ b/rules/helm/def.bzl
@@ -90,18 +90,7 @@ def _dependencies_impl(ctx):
     ctx.file("BUILD.bazel", 'package(default_visibility = ["//visibility:public"])\n')
 
     # Create the charts/BUILD.bazel exporting the fetched charts.
-    charts_build = """
-    package(default_visibility = ["//visibility:public"])
-
-    filegroup(
-        name = "charts",
-        srcs = glob(
-            ["**/*"],
-            exclude = ["**/BUILD.bazel"],
-        ),
-    )
-    """
-    charts_build = '\n'.join([x.lstrip(' ') for x in charts_build.splitlines()])
+    charts_build = ctx.read(ctx.path(ctx.attr._charts_build_bazel))
     ctx.file("charts/BUILD.bazel", charts_build)
 
 dependencies = repository_rule(
@@ -128,6 +117,11 @@ dependencies = repository_rule(
             mandatory = True,
         ),
         "_helm": _helm_attr,
+        "_charts_build_bazel": attr.label(
+            allow_single_file = True,
+            default = "//rules/helm:dependencies_charts.BUILD.bazel",
+            doc = "The BUILD.bazel file used to export the fetched sub-chart dependencies",
+        ),
     },
     local = True,
 )

--- a/rules/helm/dependencies_charts.BUILD.bazel
+++ b/rules/helm/dependencies_charts.BUILD.bazel
@@ -1,0 +1,13 @@
+# This file is used as a template for the BUILD.bazel file created in the charts/BUILD.bazel for the
+# helm dependencies repository rule. It exposes the sub-charts downloaded from the `helm dep up`
+# command.
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "charts",
+    srcs = glob(
+        ["**/*"],
+        exclude = ["**/BUILD.bazel"],
+    ),
+)

--- a/rules/helm/package.tmpl.rb
+++ b/rules/helm/package.tmpl.rb
@@ -7,6 +7,7 @@ package_dir = "[[package_dir]]"
 multipath_sep = "[[multipath_sep]]"
 tarsStr = "[[tars]]"
 generatedStr = "[[generated]]"
+subcharts_str = '[[subcharts]]'
 version = "[[version]]"
 helm = "[[helm]]"
 output_tgz = "[[output_tgz]]"
@@ -45,6 +46,15 @@ begin
   generated.each do |file|
     file = File.readlink(file) while File.ftype(file) == "link"
     FileUtils.cp(file, build_dir)
+  end
+
+  # Copy the subcharts into the temporary build directory.
+  subcharts = subcharts_str.split(multipath_sep)
+  subcharts_dst = File.join(build_dir, 'charts')
+  FileUtils.mkdir_p(subcharts_dst) if subcharts.length.positive?
+  subcharts.each do |file|
+    file = File.readlink(file) while File.ftype(file) == 'link'
+    FileUtils.cp(file, subcharts_dst)
   end
 
   # A semver that matches what Helm uses.


### PR DESCRIPTION
## Description

The dependencies repository rule is suited for fetching and caching Helm dependencies declared in the requirements.yaml file. Those dependencies are also known as sub-charts and are fetched as .tgz files under the charts/ directory. The rule exports a filegroup that selects all the charts to be used with the package rule.

## Motivation and Context

This PR is to support the Eirini native Helm charts PR: https://github.com/cloudfoundry-incubator/kubecf/pull/651.

We want to include the Helm sub-charts in the final package, but still keep the fetching as part of a repository rule so it is aggressively cached to avoid network interaction during the build phase.

## How Has This Been Tested?

Added a few sub-charts to KubeCF and used the repository rule implemented in this PR:

```
# WORKSPACE

load("//rules/helm:def.bzl", helm_dependencies = "dependencies")

helm_dependencies(
    name = "kubecf_helm_dependencies",
    chart_yaml = "//deploy/helm/kubecf:Chart.yaml",
    requirements = "//deploy/helm/kubecf:requirements.yaml",
    requirements_lock = "//deploy/helm/kubecf:requirements.lock",
)
```

Then added the `subcharts` property to the `kubecf` target:
```
# //deploy/helm/kubecf/BUILD.bazel

# Packages the KubeCF Helm chart.
helm_package(
    name = "kubecf",
    srcs = [
        ":chart_files_static",
    ],
    generated = [
        ":metadata",
    ],
    tars = [
        "//bosh/releases:pre_render_scripts",
        ":cf_deployment",
        ":extracted_jobs",
    ],
    subcharts = ["@kubecf_helm_dependencies//charts"],
)
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
