### PR TITLE
feat: allow user to provide inline operations

### DIFF
--- a/deploy/helm/kubecf/templates/bosh_deployment.yaml
+++ b/deploy/helm/kubecf/templates/bosh_deployment.yaml
@@ -60,3 +60,7 @@ spec:
 {{- end }}
   - name: user-provided-properties
     type: configmap
+{{- if gt (len .Values.operations.inline) 0 }}
+  - name: user-provided-inline-operations
+    type: configmap
+{{- end }}

--- a/deploy/helm/kubecf/templates/bosh_deployment.yaml
+++ b/deploy/helm/kubecf/templates/bosh_deployment.yaml
@@ -58,9 +58,9 @@ spec:
   - name: {{ $ops | quote }}
     type: configmap
 {{- end }}
-  - name: user-provided-properties
-    type: configmap
 {{- if gt (len .Values.operations.inline) 0 }}
   - name: user-provided-inline-operations
     type: configmap
 {{- end }}
+  - name: user-provided-properties
+    type: configmap

--- a/deploy/helm/kubecf/templates/ops.yaml
+++ b/deploy/helm/kubecf/templates/ops.yaml
@@ -51,3 +51,22 @@ data:
 {{- range $path, $bytes := .Files.Glob "assets/operations/*" }}
 {{ include "kubecf.ops" (dict "Root" $root "Path" $path) }}
 {{- end }}
+
+{{- if gt (len .Values.operations.inline) 0 }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: user-provided-inline-operations
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app.kubernetes.io/component: operations
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: {{ include "kubecf.fullname" . }}
+    app.kubernetes.io/version: {{ default .Chart.Version .Chart.AppVersion | quote }}
+    helm.sh/chart: {{ include "kubecf.chart" . }}
+data:
+  ops: |-
+    {{- .Values.operations.inline | toYaml | nindent 4 }}
+{{- end }}

--- a/deploy/helm/kubecf/values.yaml
+++ b/deploy/helm/kubecf/values.yaml
@@ -353,6 +353,15 @@ ccdb:
 operations:
   # A list of configmap names that should be applied to the BOSH manifest.
   custom: []
+  # Inlined operations that get into generated ConfigMaps. E.g. adding a password variable:
+  # operations:
+  #   inline:
+  #   - type: replace
+  #     path: /variables/-
+  #     value:
+  #       name: my_password
+  #       type: password
+  inline: []
 
 k8s-host-url: ""
 k8s-service-token: ""


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Allowing users to provide inline operations via Helm helps with custom logic that needs to be applied on top of KubeCF. E.g.:

```yaml
operations:
  inline:
  - type: replace
    path: /variables/-
    value:
      name: my_password
      type: password
```

This reduces the number of manual steps to get a custom ops-file into KubeCF.

## Motivation and Context

Improve the customization experience for the KubeCF user.

## How Has This Been Tested?

Locally, applying the above example. Then, verified that `var-my-password` gets created.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
