### PR TITLE
feat: release v2.1.0 setup

### DIFF
--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -10,7 +10,7 @@
 # Variables
 {{ $availableCfSchedulers := slice "diego" "eirini" }} # Diego / Eirini
 {{ $pr_resources := slice "pr" "fork-pr" }}
-{{ $branches := slice "master"}} # Repository branches to track
+{{ $branches := slice "master" "v2.1.0"}} # Repository branches to track
 
 # Prod and no-prod jobs
 # Jobs that are stable and ready should go into $prod.

--- a/deploy/helm/kubecf/BUILD.bazel
+++ b/deploy/helm/kubecf/BUILD.bazel
@@ -101,6 +101,7 @@ helm_package(
         ":cf_deployment",
         ":extracted_jobs",
     ],
+    version = "v2.0.0"
 )
 
 genrule(


### PR DESCRIPTION
## Description

Sets up KubeCF for v2.1.0 release.

## Motivation and Context

There's still this manual step to release KubeCF.

## How Has This Been Tested?

Built the following targets locally:

//deploy/helm/kubecf:kubecf
//deploy/bundle:kubecf-bundle
//deploy/helm/kubecf:release_chart
Asserted that the chart for the correct version:

```
apiVersion: v1
appVersion: v2.1.0
description: A Helm chart for KubeCF
name: kubecf
version: v2.1.0
```
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
