### PR TITLE
fix: sanitize branch names in the pipeline yaml anchors

### DIFF
--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -242,6 +242,8 @@ jobs:
 {{ $path = ".git/short_ref" }}
 {{ end }}
 
+{{ $sanitized_branch_name := replaceAll "." "_" $branch }}
+
 - name: lint-{{ $branch }}
   public: true
   plan:
@@ -252,7 +254,7 @@ jobs:
     version: "every"
 {{- if has $prod "lint" }}
   - put: status-{{ $branch }}.src
-    params: &lint_{{ $branch }}_status
+    params: &lint_{{ $sanitized_branch_name }}_status
         context: lint
         description: "Lint started"
         path: kubecf-{{ $branch }}/{{ $path }}
@@ -282,12 +284,12 @@ jobs:
     on_success:
       put: status-{{ $branch }}.src
       params:
-        << : *lint_{{ $branch }}_status
+        << : *lint_{{ $sanitized_branch_name }}_status
         state: success
     on_failure:
       put: status-{{ $branch }}.src
       params:
-        << : *lint_{{ $branch }}_status
+        << : *lint_{{ $sanitized_branch_name }}_status
         state: failure
 {{- end }}
 
@@ -301,7 +303,7 @@ jobs:
     - lint-{{ $branch }}
 {{- if has $prod "build" }}
   - put: status-{{ $branch }}.src
-    params: &build_{{ $branch }}_status
+    params: &build_{{ $sanitized_branch_name }}_status
         context: build
         description: "Build started"
         path: kubecf-{{ $branch }}/{{ $path }}
@@ -330,12 +332,12 @@ jobs:
     on_success:
       put: status-{{ $branch }}.src
       params:
-        << : *build_{{ $branch }}_status
+        << : *build_{{ $sanitized_branch_name }}_status
         state: success
     on_failure:
       put: status-{{ $branch }}.src
       params:
-        << : *build_{{ $branch }}_status
+        << : *build_{{ $sanitized_branch_name }}_status
         state: failure
 {{- end }}
   - put: s3.kubecf-ci
@@ -373,7 +375,7 @@ jobs:
   - get: catapult
 {{- if has $prod (printf "deploy-%s" $cfScheduler) }}
   - put: status-{{ $branch }}.src
-    params: &deploy_{{ $cfScheduler }}_{{ $branch }}_status
+    params: &deploy_{{ $cfScheduler }}_{{ $sanitized_branch_name }}_status
         context: "deploy-{{ $cfScheduler }}"
         description: "Deploy {{ $cfScheduler }}"
         path: kubecf-{{ $branch }}/{{ $path }}
@@ -409,7 +411,7 @@ jobs:
   on_success:
     put: status-{{ $branch }}.src
     params:
-      << : *deploy_{{ $cfScheduler }}_{{ $branch }}_status
+      << : *deploy_{{ $cfScheduler }}_{{ $sanitized_branch_name }}_status
       state: success
 {{- end }}
   on_failure:
@@ -417,7 +419,7 @@ jobs:
 {{- if has $prod (printf "deploy-%s" $cfScheduler) }}
     - put: status-{{ $branch }}.src
       params:
-        << : *deploy_{{ $cfScheduler }}_{{ $branch }}_status
+        << : *deploy_{{ $cfScheduler }}_{{ $sanitized_branch_name }}_status
         state: failure
 {{- end }}
     - task: cleanup-cluster
@@ -451,7 +453,7 @@ jobs:
 {{- if has $prod (printf "deploy-%s" $cfScheduler) }}
     - put: status-{{ $branch }}.src
       params:
-        << : *deploy_{{ $cfScheduler }}_{{ $branch }}_status
+        << : *deploy_{{ $cfScheduler }}_{{ $sanitized_branch_name }}_status
         state: failure
 {{- end }}
   on_error:
@@ -464,7 +466,7 @@ jobs:
 {{- if has $prod (printf "deploy-%s" $cfScheduler) }}
     - put: status-{{ $branch }}.src
       params:
-        << : *deploy_{{ $cfScheduler }}_{{ $branch }}_status
+        << : *deploy_{{ $cfScheduler }}_{{ $sanitized_branch_name }}_status
         state: failure
 {{- end }}
 
@@ -488,7 +490,7 @@ jobs:
   - get: catapult
 {{- if has $prod (printf "smoke-tests-%s" $cfScheduler) }}
   - put: status-{{ $branch }}.src
-    params: &smoke_{{ $cfScheduler }}_{{ $branch }}_status
+    params: &smoke_{{ $cfScheduler }}_{{ $sanitized_branch_name }}_status
         context: "smoke-tests-{{ $cfScheduler }}"
         description: "Smoke tests {{ $cfScheduler }}"
         path: kubecf-{{ $branch }}/{{ $path }}
@@ -522,7 +524,7 @@ jobs:
   on_success:
     put: status-{{ $branch }}.src
     params:
-      << : *smoke_{{ $cfScheduler }}_{{ $branch }}_status
+      << : *smoke_{{ $cfScheduler }}_{{ $sanitized_branch_name }}_status
       state: success
 {{- end }}
   on_failure:
@@ -530,7 +532,7 @@ jobs:
 {{- if has $prod (printf "smoke-tests-%s" $cfScheduler) }}
     - put: status-{{ $branch }}.src
       params:
-        << : *smoke_{{ $cfScheduler }}_{{ $branch }}_status
+        << : *smoke_{{ $cfScheduler }}_{{ $sanitized_branch_name }}_status
         state: failure
 {{- end }}
     - task: cleanup-cluster
@@ -548,7 +550,7 @@ jobs:
 {{- if has $prod (printf "smoke-tests-%s" $cfScheduler) }}
     - put: status-{{ $branch }}.src
       params:
-        << : *smoke_{{ $cfScheduler }}_{{ $branch }}_status
+        << : *smoke_{{ $cfScheduler }}_{{ $sanitized_branch_name }}_status
         state: failure
 {{- end }}
   on_error:
@@ -561,7 +563,7 @@ jobs:
 {{- if has $prod (printf "smoke-tests-%s" $cfScheduler) }}
     - put: status-{{ $branch }}.src
       params:
-        << : *smoke_{{ $cfScheduler }}_{{ $branch }}_status
+        << : *smoke_{{ $cfScheduler }}_{{ $sanitized_branch_name }}_status
         state: failure
 {{- end }}
 
@@ -585,7 +587,7 @@ jobs:
   - get: catapult
 {{- if has $prod (printf "cf-acceptance-tests-%s" $cfScheduler) }}
   - put: status-{{ $branch }}.src
-    params: &cats_{{ $cfScheduler }}_{{ $branch }}_status
+    params: &cats_{{ $cfScheduler }}_{{ $sanitized_branch_name }}_status
         context: "cf-acceptance-tests-{{ $cfScheduler }}"
         description: "Acceptance tests {{ $cfScheduler }}"
         path: kubecf-{{ $branch }}/{{ $path }}
@@ -620,7 +622,7 @@ jobs:
   on_success:
     put: status-{{ $branch }}.src
     params:
-      << : *cats_{{ $cfScheduler }}_{{ $branch }}_status
+      << : *cats_{{ $cfScheduler }}_{{ $sanitized_branch_name }}_status
       state: success
 {{- end }}
 
@@ -634,7 +636,7 @@ jobs:
 {{- if has $prod (printf "cf-acceptance-tests-%s" $cfScheduler) }}
     - put: status-{{ $branch }}.src      
       params:
-        << : *cats_{{ $cfScheduler }}_{{ $branch }}_status
+        << : *cats_{{ $cfScheduler }}_{{ $sanitized_branch_name }}_status
         state: failure
 {{- end }}
   on_abort:
@@ -647,7 +649,7 @@ jobs:
 {{- if has $prod (printf "cf-acceptance-tests-%s" $cfScheduler) }}
     - put: status-{{ $branch }}.src
       params:
-        << : *cats_{{ $cfScheduler }}_{{ $branch }}_status
+        << : *cats_{{ $cfScheduler }}_{{ $sanitized_branch_name }}_status
         state: failure
 {{- end }}
   on_error:
@@ -660,7 +662,7 @@ jobs:
 {{- if has $prod (printf "cf-acceptance-tests-%s" $cfScheduler) }}
     - put: status-{{ $branch }}.src
       params:
-        << : *cats_{{ $cfScheduler }}_{{ $branch }}_status
+        << : *cats_{{ $cfScheduler }}_{{ $sanitized_branch_name }}_status
         state: failure
 {{- end }}
 
@@ -686,7 +688,7 @@ jobs:
   - get: catapult
 {{- if has $prod (printf "sync-integration-tests-%s" $cfScheduler) }}
   - put: status-{{ $branch }}.src
-    params: &sits_{{ $cfScheduler }}_{{ $branch }}_status
+    params: &sits_{{ $cfScheduler }}_{{ $sanitized_branch_name }}_status
         context: "sync-integration-tests-{{ $cfScheduler }}"
         description: "Sync Integration tests {{ $cfScheduler }}"
         path: kubecf-{{ $branch }}/{{ $path }}
@@ -720,7 +722,7 @@ jobs:
   on_success:
     put: status-{{ $branch }}.src
     params:
-      << : *sits_{{ $cfScheduler }}_{{ $branch }}_status
+      << : *sits_{{ $cfScheduler }}_{{ $sanitized_branch_name }}_status
       state: success
 {{- end }}
   on_failure:
@@ -729,7 +731,7 @@ jobs:
 {{- if has $prod (printf "sync-integration-tests-%s" $cfScheduler) }}
     - put: status-{{ $branch }}.src
       params:
-        << : *sits_{{ $cfScheduler }}_{{ $branch }}_status
+        << : *sits_{{ $cfScheduler }}_{{ $sanitized_branch_name }}_status
         state: failure
 {{- end }}
 
@@ -749,7 +751,7 @@ jobs:
 {{- if has $prod (printf "sync-integration-tests-%s" $cfScheduler) }}
     - put: status-{{ $branch }}.src
       params:
-        << : *sits_{{ $cfScheduler }}_{{ $branch }}_status
+        << : *sits_{{ $cfScheduler }}_{{ $sanitized_branch_name }}_status
         state: failure
 {{- end }}
 
@@ -763,7 +765,7 @@ jobs:
 {{- if has $prod (printf "sync-integration-tests-%s" $cfScheduler) }}
     - put: status-{{ $branch }}.src
       params:
-        << : *sits_{{ $cfScheduler }}_{{ $branch }}_status
+        << : *sits_{{ $cfScheduler }}_{{ $sanitized_branch_name }}_status
         state: failure
 {{- end }}
 
@@ -787,7 +789,7 @@ jobs:
   - get: catapult
 {{- if has $prod (printf "rotate-%s" $cfScheduler) }}
   - put: status-{{ $branch }}.src
-    params: &rotate_{{ $cfScheduler }}_{{ $branch }}_status
+    params: &rotate_{{ $cfScheduler }}_{{ $sanitized_branch_name }}_status
         context: "rotate-{{ $cfScheduler }}"
         description: "Rotating secrets {{ $cfScheduler }}"
         path: kubecf-{{ $branch }}/{{ $path }}
@@ -821,7 +823,7 @@ jobs:
   on_success:
     put: status-{{ $branch }}.src
     params:
-      << : *rotate_{{ $cfScheduler }}_{{ $branch }}_status
+      << : *rotate_{{ $cfScheduler }}_{{ $sanitized_branch_name }}_status
       state: success
 {{- end }}
 
@@ -830,7 +832,7 @@ jobs:
 {{- if has $prod (printf "rotate-%s" $cfScheduler) }}
     - put: status-{{ $branch }}.src
       params:
-        << : *rotate_{{ $cfScheduler }}_{{ $branch }}_status
+        << : *rotate_{{ $cfScheduler }}_{{ $sanitized_branch_name }}_status
         state: failure
 {{- end }}
     - task: cleanup-cluster
@@ -851,7 +853,7 @@ jobs:
 {{- if has $prod (printf "rotate-%s" $cfScheduler) }}
     - put: status-{{ $branch }}.src
       params:
-        << : *rotate_{{ $cfScheduler }}_{{ $branch }}_status
+        << : *rotate_{{ $cfScheduler }}_{{ $sanitized_branch_name }}_status
         state: failure
 {{- end }}
   on_error:
@@ -864,7 +866,7 @@ jobs:
 {{- if has $prod (printf "rotate-%s" $cfScheduler) }}
     - put: status-{{ $branch }}.src
       params:
-        << : *rotate_{{ $cfScheduler }}_{{ $branch }}_status
+        << : *rotate_{{ $cfScheduler }}_{{ $sanitized_branch_name }}_status
         state: failure
 {{- end }}
 
@@ -888,7 +890,7 @@ jobs:
   - get: catapult
 {{- if has $prod (printf "smoke-rotated-{%s" $cfScheduler) }}
   - put: status-{{ $branch }}.src
-    params: &smoke_rotate_{{ $cfScheduler }}_{{ $branch }}_status
+    params: &smoke_rotate_{{ $cfScheduler }}_{{ $sanitized_branch_name }}_status
         context: "smoke-rotated-{{ $cfScheduler }}"
         description: "Smoke tests after rotating secrets {{ $cfScheduler }}"
         path: kubecf-{{ $branch }}/{{ $path }}
@@ -923,7 +925,7 @@ jobs:
   on_success:
     put: status-{{ $branch }}.src
     params:
-      << : *smoke_rotate_{{ $cfScheduler }}_{{ $branch }}_status
+      << : *smoke_rotate_{{ $cfScheduler }}_{{ $sanitized_branch_name }}_status
       state: success
 {{- end }}
 
@@ -933,7 +935,7 @@ jobs:
 {{- if has $prod (printf "smoke-rotated-{%s" $cfScheduler) }}
     - put: status-{{ $branch }}.src
       params:
-        << : *smoke_rotate_{{ $cfScheduler }}_{{ $branch }}_status
+        << : *smoke_rotate_{{ $cfScheduler }}_{{ $sanitized_branch_name }}_status
         state: failure
 {{- end }}
 
@@ -952,7 +954,7 @@ jobs:
 {{- if has $prod (printf "smoke-rotated-{%s" $cfScheduler) }}
     - put: status-{{ $branch }}.src
       params:
-        << : *smoke_rotate_{{ $cfScheduler }}_{{ $branch }}_status
+        << : *smoke_rotate_{{ $cfScheduler }}_{{ $sanitized_branch_name }}_status
         state: failure
 {{- end }}
   on_error:
@@ -965,7 +967,7 @@ jobs:
 {{- if has $prod (printf "smoke-rotated-{%s" $cfScheduler) }}
     - put: status-{{ $branch }}.src
       params:
-        << : *smoke_rotate_{{ $cfScheduler }}_{{ $branch }}_status
+        << : *smoke_rotate_{{ $cfScheduler }}_{{ $sanitized_branch_name }}_status
         state: failure
 {{- end }}
 


### PR DESCRIPTION
## Description
Branch releases has dots in the names, which aren't supported by YAML anchors from `fly` :shrug: 

## Motivation and Context
We can't deploy the pipeline for releases,  otherwise it fails with:
```
gomplate version 3.6.0, build 564f5588
config is:
input: pipeline.yaml.gomplate
output: -

rendered 1 template(s) with 0 error(s) in 597.951072ms
error: yaml: line 1716: did not find expected alphabetic or numeric character
```

## How Has This Been Tested?
With `fly` , now deployed on https://concourse.suse.dev/teams/main/pipelines/kubecf

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
