### PR TITLE
feat: eirini extensions as a subchart

### DIFF
--- a/deploy/helm/kubecf/requirements.lock
+++ b/deploy/helm/kubecf/requirements.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 1.0.14
 - name: eirini-extensions
   repository: https://opensource.suse.com/eirinix-helm-release/
-  version: '0.0.0-9+g6b37279'
-digest: sha256:8f523da4056508c11c6a17d789e6fd8920d60df3be930332b6bdf2bbf9ce339e
-generated: "2020-05-06T05:35:40.116133371+03:00"
+  version: '>= 0-0'
+digest: sha256:ada05d269e97901296f3e67922b59b02fa4a7ba732c74f7187a5de466e436213
+generated: "2020-05-06T11:53:34.20461864+03:00"

--- a/deploy/helm/kubecf/requirements.lock
+++ b/deploy/helm/kubecf/requirements.lock
@@ -5,5 +5,8 @@ dependencies:
 - name: bits
   repository: http://opensource.suse.com/bits-service-release/
   version: 1.0.14
+- name: eirini-extensions
+  repository: https://opensource.suse.com/eirinix-helm-release/
+  version: '0.0.0-9+g6b37279'
 digest: sha256:8f523da4056508c11c6a17d789e6fd8920d60df3be930332b6bdf2bbf9ce339e
 generated: "2020-05-06T05:35:40.116133371+03:00"

--- a/deploy/helm/kubecf/requirements.yaml
+++ b/deploy/helm/kubecf/requirements.yaml
@@ -7,3 +7,7 @@ dependencies:
   version: 1.0.14
   repository: http://opensource.suse.com/bits-service-release/
   condition: features.eirini.enabled
+- name: eirini-extensions
+  repository: https://opensource.suse.com/eirinix-helm-release/
+  version: ">= 0-0"
+  condition: features.eirini.enabled

--- a/deploy/helm/kubecf/requirements.yaml
+++ b/deploy/helm/kubecf/requirements.yaml
@@ -9,5 +9,5 @@ dependencies:
   condition: features.eirini.enabled
 - name: eirini-extensions
   repository: https://opensource.suse.com/eirinix-helm-release/
-  version: ">= 0-0"
+  version: "0.0.0-9+g6b37279"
   condition: features.eirini.enabled


### PR DESCRIPTION
## Description
Install eirini extensions as a subchart, so we don't need it separately.

## Motivation and Context
Fixes #578 

## Dependencies:
* https://github.com/SUSE/eirinix-helm-release/pull/4
  - so that we have a proper chart to use, instead of just using my development helm repository.
* #729
  - otherwise loggregator-bridge is prone to crashing at startup

## How Has This Been Tested?
Deployed locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
