### PR TITLE
fix: Disable the eirini rootfspatcher job.

### DIFF
--- a/deploy/helm/kubecf/values.yaml
+++ b/deploy/helm/kubecf/values.yaml
@@ -447,7 +447,7 @@ eirini:
           caPath: "ca"
 
     rootfsPatcher:
-      enable: true
+      enable: false
       timeout: 2m
 
     routing:


### PR DESCRIPTION
## Description

Trivially done by flipping the associated setting in the sub-chart configuration of kubecf.

## Motivation and Context

Ref #796 

## How Has This Been Tested?

Tested locally in a minikube setup, SA. confirmed that the change removes the rootfsPatcher job and service account (vs present without the change). Smoke test has single identical failure regardless of change present or not. Not an issue of the change.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

I suspect the security implications (less internet access from the system, so higher sec ?!)
Unclear if this is something we mention in the docs.

- [x] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
