### PR TITLE
fix: use the helm dependencies rules

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -74,3 +74,12 @@ pip_install()
 load("@rules_gomplate//:repositories.bzl", "gomplate_repositories")
 
 gomplate_repositories()
+
+load("//rules/helm:def.bzl", helm_dependencies = "dependencies")
+
+helm_dependencies(
+    name = "kubecf_helm_dependencies",
+    chart_yaml = "//deploy/helm/kubecf:Chart.yaml",
+    requirements = "//deploy/helm/kubecf:requirements.yaml",
+    requirements_lock = "//deploy/helm/kubecf:requirements.lock",
+)

--- a/deploy/helm/kubecf/BUILD.bazel
+++ b/deploy/helm/kubecf/BUILD.bazel
@@ -101,6 +101,7 @@ helm_package(
         ":cf_deployment",
         ":extracted_jobs",
     ],
+    subcharts = ["@kubecf_helm_dependencies//charts"],
 )
 
 genrule(

--- a/deploy/helm/kubecf/requirements.lock
+++ b/deploy/helm/kubecf/requirements.lock
@@ -5,5 +5,5 @@ dependencies:
 - name: bits
   repository: https://cloudfoundry-incubator.github.io/bits-service-release/helm
   version: 2.37.0
-digest: sha256:8a51416695972d573c77578bf79209a6313d305de677dce998e7aaf18870c571
-generated: "2020-04-23T18:22:33.689637339+03:00"
+digest: sha256:da2e55f5d36538df3f682e34d0d1340f406e64bf9d87d11f7ab1b6bd82ff584e
+generated: "2020-05-05T12:11:36.648937118-05:00"

--- a/deploy/helm/kubecf/requirements.yaml
+++ b/deploy/helm/kubecf/requirements.yaml
@@ -1,9 +1,9 @@
 dependencies:
-  - name: eirini
-    version: 1.4.0
-    repository: https://cloudfoundry-incubator.github.io/eirini-release
-    condition: features.eirini.enabled
-  - name: bits
-    version: 2.37.0
-    repository: https://cloudfoundry-incubator.github.io/bits-service-release/helm
-    condition: features.eirini.enabled
+- name: eirini
+  version: 1.4.0
+  repository: https://cloudfoundry-incubator.github.io/eirini-release
+  condition: features.eirini.enabled
+- name: bits
+  version: 2.37.0
+  repository: https://cloudfoundry-incubator.github.io/bits-service-release/helm
+  condition: features.eirini.enabled

--- a/rules/helm/package.tmpl.rb
+++ b/rules/helm/package.tmpl.rb
@@ -66,7 +66,6 @@ begin
 
   # Package and return the output path.
   package_cmd = <<-EOS
-    '#{helm}' dep up '#{build_dir}' &&
     '#{helm}' package '#{build_dir}' \
       --version='#{version}' \
       --app-version='#{version}'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

There was a workaround on the packaging rule that called `helm dep up` on every build.
This was wrong and the helm dependencies rule should be used.

## Motivation and Context

Avoid network access during the build phase.

## How Has This Been Tested?

Built the chart locally using the correct rule and asserted the sub-charts are present in the final tarball.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
