### PR TITLE
feat: Implement credentials and variables settings in values.yaml

### DIFF
--- a/deploy/helm/kubecf/templates/bosh_deployment.yaml
+++ b/deploy/helm/kubecf/templates/bosh_deployment.yaml
@@ -15,6 +15,16 @@ spec:
   manifest:
     name: cf-deployment
     type: configmap
+  vars:
+{{- $creds := dict }}
+{{- range $name, $value := .Values.credentials }}
+  {{- $parts := splitList "." $name }}
+  {{- $_ := set $creds (first $parts) nil }}
+{{- end }}
+{{- range $name, $value := $creds }}
+  - name: {{ $name | quote }}
+    secret: {{ printf "cred-%s" ($name | replace "_" "-" | replace "." "-") | quote }}
+{{- end }}
   ops:
 {{- range $path, $_ := .Files.Glob "assets/operations/job_moving/*" }}
   - name: {{ include "kubecf.ops-name" (dict "ReleaseName" $root.Release.Name "Path" $path) }}

--- a/deploy/helm/kubecf/templates/bosh_deployment.yaml
+++ b/deploy/helm/kubecf/templates/bosh_deployment.yaml
@@ -15,6 +15,7 @@ spec:
   manifest:
     name: cf-deployment
     type: configmap
+{{- if gt (len .Values.credentials) 0}}
   vars:
 {{- $creds := dict }}
 {{- range $name, $value := .Values.credentials }}
@@ -24,6 +25,9 @@ spec:
 {{- range $name, $value := $creds }}
   - name: {{ $name | quote }}
     secret: {{ printf "cred-%s" ($name | replace "_" "-" | replace "." "-") | quote }}
+{{- end }}
+{{- else }}
+  vars: []
 {{- end }}
   ops:
 {{- range $path, $_ := .Files.Glob "assets/operations/job_moving/*" }}

--- a/deploy/helm/kubecf/templates/credentials.yaml
+++ b/deploy/helm/kubecf/templates/credentials.yaml
@@ -1,0 +1,36 @@
+{{- $creds := dict }}
+{{- range $name, $value := .Values.credentials }}
+  {{- $parts := splitList "." $name }}
+  {{- $key := first $parts }}
+  {{- if not (hasKey $creds $key) }}
+    {{- $_ := set $creds $key dict }}
+  {{- end }}
+  {{- $dict := get $creds $key }}
+  {{- if eq (len $parts) 1 }}
+    {{- if eq (kindOf $value) "map" }}
+      {{- range $key, $value := $value }}
+        {{- $_ := set $dict $key (toString $value) }}
+      {{- end }}
+    {{- else }}
+      {{- $_ := set $dict "password" (toString $value) }}
+    {{- end }}
+  {{- else }}
+    {{- $_ := set $dict ($parts | rest | first) (toString $value) }}
+  {{- end }}
+{{- end }}
+{{- range $name, $values := $creds }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "cred-%s" ($name | replace "_" "-" | replace "." "-") | quote }}
+  namespace: {{ $.Release.Namespace | quote }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service | quote }}
+    app.kubernetes.io/name: {{ include "kubecf.fullname" $ }}
+    app.kubernetes.io/version: {{ default $.Chart.Version $.Chart.AppVersion | quote }}
+    helm.sh/chart: {{ include "kubecf.chart" $ }}
+type: Opaque
+stringData: {{ $values | toJson }}
+{{- end }}

--- a/deploy/helm/kubecf/templates/implicit_vars.yaml
+++ b/deploy/helm/kubecf/templates/implicit_vars.yaml
@@ -30,3 +30,21 @@ stringData:
 {{ include "kubecf.implicit-var" (list . "k8s-service-token" "k8s-service-token") }}
 {{ include "kubecf.implicit-var" (list . "k8s-service-username" "k8s-service-username") }}
 {{ include "kubecf.implicit-var" (list . "k8s-node-ca" "k8s-node-ca") }}
+
+{{- range $name, $value := .Values.variables }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "var-%s" ($name | replace "_" "-" | replace "." "-") | quote }}
+  namespace: {{ $.Release.Namespace | quote }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service | quote }}
+    app.kubernetes.io/name: {{ include "kubecf.fullname" $ }}
+    app.kubernetes.io/version: {{ default $.Chart.Version $.Chart.AppVersion | quote }}
+    helm.sh/chart: {{ include "kubecf.chart" $ }}
+type: Opaque
+stringData:
+  value: {{ $value | quote }}
+{{- end }}

--- a/deploy/helm/kubecf/values.yaml
+++ b/deploy/helm/kubecf/values.yaml
@@ -25,6 +25,10 @@ system_domain: ~
 #             default_size: "1Gi"
 properties: {}
 
+credentials: {}
+
+variables: {}
+
 kube:
   # The storage class to be used for the instance groups that need it (e.g. bits, database and
   # singleton-blobstore). If it's not set, the default storage class will be used.


### PR DESCRIPTION
Credentials can be specified either with dot notation, or as a map:

```
credentials:
  cf_admin_password: changeme
  credhub_tls.ca: credhub-ca
  credhub_tls.certificate: the-cert
  credhub_tls.private_key: the-key
  credhub_tls.is_ca: false
  credhub_ca:
    certificate: cert
    is_ca: true
    private_key: key
```

Variables are a simple list of key/value pairs:

```
variables:
  system_domain: example.com
```

Note that setting the `system_domain` variable doesn't actually work because it is treated specially by the templates and has to be defined as `.Values.system_domain` instead.

See cloudfoundry-incubator/quarks-operator#895 for more details.