### PR TITLE
Update ccdb rotation qjob name in sample + doc

### DIFF
--- a/doc/secret_rotation.md
+++ b/doc/secret_rotation.md
@@ -42,7 +42,7 @@ installed to the `kubecf` namespace. These values may be different depending on 
 installed.
 
 ```sh
-kubectl patch qjob kubecf-rotate-cc-database-key \
+kubectl patch qjob rotate-cc-database-key \
   --namespace kubecf \
   --type merge \
   --patch '{"spec":{"trigger":{"strategy":"now"}}}'

--- a/testing/ccdb_key_rotation/rotate-ccdb-keys-test.sh
+++ b/testing/ccdb_key_rotation/rotate-ccdb-keys-test.sh
@@ -218,7 +218,7 @@ echo Trigger rotation ...
 echo
 
 # Trigger the actual rotation of the keys
-kubectl patch qjob "${KUBECF_INSTALL_NAME}-rotate-cc-database-key" \
+kubectl patch qjob "rotate-cc-database-key" \
   --namespace "${KUBECF_NAMESPACE}" \
   --type merge \
   --patch '{"spec":{"trigger":{"strategy":"now"}}}'


### PR DESCRIPTION
Update ccdb rotation qjob name in sample + doc

The qjob name is no longer prefixed with `kubecf` (or other helm release name)