### PR TITLE
fix: eirini not showing app metrics

### DIFF
--- a/deploy/helm/kubecf/values.yaml
+++ b/deploy/helm/kubecf/values.yaml
@@ -460,6 +460,7 @@ eirini:
 
     logs:
       enable: false # disable fluentd, use eirinix-loggregator-bridge
+      serviceName: doppler
 
     metrics:
       enable: true


### PR DESCRIPTION
## Description
In 8df8fd1d0a7cc8fd84ae3454af458340356285c3 we removed the eirini helm config value eirini.opi.logs.serviceName; this caused the eirini metrics pod to look for doppler-doppler instead (being the eirini chart's default value).  This caused the metrics to not be emitted correctly.

## Motivation and Context
Fixes #803

## How Has This Been Tested?
Locally deployed with eirini, pushed an app, and checked that memory is reported as non-zero.

```
     state     since                  cpu     memory        disk
#0   running   2020-05-07T21:28:58Z   99.8%   7.8M of 32M   40K of 100M
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
