### PR TITLE
fix: repackage using helm instead of tar

### DIFF
--- a/rules/kubecf/release_chart.sh
+++ b/rules/kubecf/release_chart.sh
@@ -24,4 +24,6 @@ tar xf "${KUBECF_CHART}"
   < "${KUBECF_IMAGE_LIST_JSON_FILE}" \
   > "${KUBECF_IMAGE_LIST_TXT_FILE}"
 
-tar czf "${OUTPUT}" "${BASENAME}/"
+helm package kubecf/
+
+mv kubecf-*.tgz "${OUTPUT}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The tarball produced by `tar` is not in the format that `helm` expects it to be. Repackaging should be done by `helm` itself.

## Motivation and Context

The `.tgz` file produced with the image list is not use-able directly without extraction.

## How Has This Been Tested?

Using `helm inspect chart`.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
