### PR TITLE
Bump eirinix release to where the prefixes are removed.

### DIFF
--- a/deploy/helm/kubecf/requirements.lock
+++ b/deploy/helm/kubecf/requirements.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 1.0.14
 - name: eirini-extensions
   repository: https://opensource.suse.com/eirinix-helm-release/
-  version: 0.0.0-9+g6b37279
-digest: sha256:397ee81a25da29278da3b1d6e0bec6b94fdcf82b7be194433b85d7addca9933b
-generated: "2020-05-06T22:54:52.11703327+03:00"
+  version: 0.0.0-10+g3df5bb4
+digest: sha256:b07ec982acce3951548e2f4a15fb68b3dd974ac0500e9d270b9a953b3a7451d8
+generated: "2020-05-13T09:20:47.01515391-07:00"

--- a/deploy/helm/kubecf/requirements.yaml
+++ b/deploy/helm/kubecf/requirements.yaml
@@ -10,5 +10,5 @@ dependencies:
 - name: eirini-extensions
   alias: eirinix
   repository: https://opensource.suse.com/eirinix-helm-release/
-  version: "0.0.0-9+g6b37279"
+  version: "0.0.0-10+g3df5bb4"
   condition: features.eirini.enabled


### PR DESCRIPTION
## Description

Bump the eirinix release to the version which has the resources prefixes removed.

## Motivation and Context

See https://github.com/cloudfoundry-incubator/kubecf/issues/817

## How Has This Been Tested?

Manual in a minikube environment. Brought cluster up to the point where it was possible to confirm the removal of prefixes from the eirinix pods.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
