### PR TITLE
Bump the gke cluster version before we even deploy

### DIFF
--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -438,7 +438,7 @@ jobs:
         path: kubecf-{{ $branch }}/{{ $path }}
         state: pending
 {{- end }}
-  - get: semver.gke-cluster
+  - put: semver.gke-cluster
     params: {bump: patch}
   - task: deploy
     privileged: true
@@ -468,9 +468,6 @@ jobs:
 {{- if has $prod (printf "deploy-%s" $cfScheduler) }}
   on_success:
     do:
-    - put: semver.gke-cluster
-      params:
-        file: semver.gke-cluster/version
     - put: status-{{ $branch }}.src
       params:
         << : *deploy_{{ $cfScheduler }}_{{ $sanitized_branch_name }}_status
@@ -1095,7 +1092,7 @@ jobs:
       passed:
       - build-{{ $branch }}
     - get: catapult
-    - get: semver.gke-cluster
+    - put: semver.gke-cluster
       params: {bump: patch}
   - task: upgrade
     input_mapping:


### PR DESCRIPTION
otherwise all parallel jobs will try to deploy a cluster with the same
name (the next version).


## How Has This Been Tested?
Deployed the pipeline

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
