### PR TITLE
kind development environment: enable `ready` plugin for CoreDNS

### DIFF
--- a/dev/kind/start.sh
+++ b/dev/kind/start.sh
@@ -32,6 +32,7 @@ data:
     .:53 {
       errors
       health
+      ready
       kubernetes cluster.local in-addr.arpa ip6.arpa {
          pods insecure
          upstream


### PR DESCRIPTION
## Description
The `Corefile` for CoreDNS in the kind development environment is not
enabling the `ready` plugin when overriding the CoreDNS ConfigMap, but
it's relying on the :8181 endpoint for the readiness probe as of kubeadm 1.16.0
(6821d21260e3f7ad6eec0b0e5e8989187ac11794).

## Motivation and Context
Then starting the `kind` environment, the `ConfigMap` of CoreDNS will be overriden but will not enable the `ready` plugin, so the `readinessProbe` will never succeed (introduced since kubeadm 1.16.0).

## How Has This Been Tested?
I created a `bazelisk run //dev/kind:start` environment. Before this change, `CoreDNS` pods will never reach a `Ready` state.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code has security implications.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
