### PR TITLE
fix: ensure patches are applied

### DIFF
--- a/bosh/releases/pre_render_scripts/api/cc_uploader/jobs/patch_pre-start.sh
+++ b/bosh/releases/pre_render_scripts/api/cc_uploader/jobs/patch_pre-start.sh
@@ -5,8 +5,11 @@ set -o errexit -o nounset
 target="/var/vcap/all-releases/jobs-src/capi/cc_uploader/templates/pre-start.erb"
 sentinel="${target}.patch_sentinel"
 if [[ -f "${sentinel}" ]]; then
-  echo "Patch already applied. Skipping"
-  exit 0
+  if sha256sum --check "${sentinel}" ; then
+    echo "Patch already applied. Skipping"
+    exit 0
+  fi
+  echo "Sentinel mismatch, re-patching"
 fi
 
 # Remove sysctl calls as we are running in containers.
@@ -22,4 +25,4 @@ patch --verbose "${target}" <<'EOT'
 -sysctl -e -w net.ipv4.tcp_tw_reuse=1
 EOT
 
-touch "${sentinel}"
+sha256sum "${target}" > "${sentinel}"

--- a/bosh/releases/pre_render_scripts/api/cloud_controller_ng/bpm/patch_bpm.sh
+++ b/bosh/releases/pre_render_scripts/api/cloud_controller_ng/bpm/patch_bpm.sh
@@ -5,8 +5,11 @@ set -o errexit -o nounset
 target="/var/vcap/all-releases/jobs-src/capi/cloud_controller_ng/templates/bpm.yml.erb"
 sentinel="${target}.patch_sentinel"
 if [[ -f "${sentinel}" ]]; then
-  echo "Patch already applied. Skipping"
-  exit 0
+  if sha256sum --check "${sentinel}" ; then
+    echo "Patch already applied. Skipping"
+    exit 0
+  fi
+  echo "Sentinel mismatch, re-patching"
 fi
 
 # Patch a few things on the BPM:
@@ -33,4 +36,4 @@ patch --verbose "${target}" <<'EOT'
  }
 EOT
 
-touch "${sentinel}"
+sha256sum "${target}" > "${sentinel}"

--- a/bosh/releases/pre_render_scripts/api/cloud_controller_ng/jobs/patch_cc_uploader_ctl.sh
+++ b/bosh/releases/pre_render_scripts/api/cloud_controller_ng/jobs/patch_cc_uploader_ctl.sh
@@ -5,8 +5,11 @@ set -o errexit -o nounset
 target="/var/vcap/all-releases/jobs-src/capi/cc_uploader/templates/cc_uploader_ctl.erb"
 sentinel="${target}.patch_sentinel"
 if [[ -f "${sentinel}" ]]; then
-  echo "Patch already applied. Skipping"
-  exit 0
+  if sha256sum --check "${sentinel}" ; then
+    echo "Patch already applied. Skipping"
+    exit 0
+  fi
+  echo "Sentinel mismatch, re-patching"
 fi
 
 patch --verbose "${target}" <<'EOT'
@@ -21,4 +24,4 @@ patch --verbose "${target}" <<'EOT'
      export GODEBUG=netdns=cgo
 EOT
 
-touch "${sentinel}"
+sha256sum "${target}" > "${sentinel}"

--- a/bosh/releases/pre_render_scripts/api/cloud_controller_ng/jobs/patch_cloud_controller_api_ctl.sh
+++ b/bosh/releases/pre_render_scripts/api/cloud_controller_ng/jobs/patch_cloud_controller_api_ctl.sh
@@ -5,8 +5,11 @@ set -o errexit -o nounset
 target="/var/vcap/all-releases/jobs-src/capi/cloud_controller_ng/templates/cloud_controller_api_ctl.erb"
 sentinel="${target}.patch_sentinel"
 if [[ -f "${sentinel}" ]]; then
-  echo "Patch already applied. Skipping"
-  exit 0
+  if sha256sum --check "${sentinel}" ; then
+    echo "Patch already applied. Skipping"
+    exit 0
+  fi
+  echo "Sentinel mismatch, re-patching"
 fi
 
 patch --verbose "${target}" <<'EOT'
@@ -21,4 +24,4 @@ patch --verbose "${target}" <<'EOT'
      exec /var/vcap/jobs/cloud_controller_ng/bin/cloud_controller_ng
 EOT
 
-touch "${sentinel}"
+sha256sum "${target}" > "${sentinel}"

--- a/bosh/releases/pre_render_scripts/api/cloud_controller_ng/jobs/patch_file_server_ctl.sh
+++ b/bosh/releases/pre_render_scripts/api/cloud_controller_ng/jobs/patch_file_server_ctl.sh
@@ -5,8 +5,11 @@ set -o errexit -o nounset
 target="/var/vcap/all-releases/jobs-src/diego/file_server/templates/file_server_ctl.erb"
 sentinel="${target}.patch_sentinel"
 if [[ -f "${sentinel}" ]]; then
-  echo "Patch already applied. Skipping"
-  exit 0
+  if sha256sum --check "${sentinel}" ; then
+    echo "Patch already applied. Skipping"
+    exit 0
+  fi
+  echo "Sentinel mismatch, re-patching"
 fi
 
 patch --verbose "${target}" <<'EOT'
@@ -22,4 +25,4 @@ patch --verbose "${target}" <<'EOT'
      ;;
 EOT
 
-touch "${sentinel}"
+sha256sum "${target}" > "${sentinel}"

--- a/bosh/releases/pre_render_scripts/asdatabase/postgres/jobs/patch_pre-start.sh
+++ b/bosh/releases/pre_render_scripts/asdatabase/postgres/jobs/patch_pre-start.sh
@@ -5,10 +5,13 @@ set -o errexit -o nounset
 target="/var/vcap/all-releases/jobs-src/postgres/postgres/templates/pre-start.sh.erb"
 sentinel="${target}.patch_sentinel"
 if [[ -f "${sentinel}" ]]; then
-  echo "Patch already applied. Skipping"
-  exit 0
+  if sha256sum --check "${sentinel}" ; then
+    echo "Patch already applied. Skipping"
+    exit 0
+  fi
+  echo "Sentinel mismatch, re-patching"
 fi
 
 sed -i "s/sysctl/#sysctl/g" "${target}"
 
-touch "${sentinel}"
+sha256sum "${target}" > "${sentinel}"

--- a/bosh/releases/pre_render_scripts/auctioneer/auctioneer/jobs/patch_auctioneer_ctl.sh
+++ b/bosh/releases/pre_render_scripts/auctioneer/auctioneer/jobs/patch_auctioneer_ctl.sh
@@ -5,8 +5,11 @@ set -o errexit -o nounset
 target="/var/vcap/all-releases/jobs-src/diego/auctioneer/templates/auctioneer_ctl.erb"
 sentinel="${target}.patch_sentinel"
 if [[ -f "${sentinel}" ]]; then
-  echo "Patch already applied. Skipping"
-  exit 0
+  if sha256sum --check "${sentinel}" ; then
+    echo "Patch already applied. Skipping"
+    exit 0
+  fi
+  echo "Sentinel mismatch, re-patching"
 fi
 
 patch --verbose "${target}" <<'EOT'
@@ -22,4 +25,4 @@ patch --verbose "${target}" <<'EOT'
      ;;
 EOT
 
-touch "${sentinel}"
+sha256sum "${target}" > "${sentinel}"

--- a/bosh/releases/pre_render_scripts/diego-api/bbs/jobs/patch_bbs_ctl.sh
+++ b/bosh/releases/pre_render_scripts/diego-api/bbs/jobs/patch_bbs_ctl.sh
@@ -5,8 +5,11 @@ set -o errexit -o nounset
 target="/var/vcap/all-releases/jobs-src/diego/bbs/templates/bbs_ctl.erb"
 sentinel="${target}.patch_sentinel"
 if [[ -f "${sentinel}" ]]; then
-  echo "Patch already applied. Skipping"
-  exit 0
+  if sha256sum --check "${sentinel}" ; then
+    echo "Patch already applied. Skipping"
+    exit 0
+  fi
+  echo "Sentinel mismatch, re-patching"
 fi
 
 patch --verbose "${target}" <<'EOT'
@@ -27,4 +30,4 @@ patch --verbose "${target}" <<'EOT'
      ;;
 EOT
 
-touch "${sentinel}"
+sha256sum "${target}" > "${sentinel}"

--- a/bosh/releases/pre_render_scripts/diego-api/bbs/jobs/patch_bbs_json.sh
+++ b/bosh/releases/pre_render_scripts/diego-api/bbs/jobs/patch_bbs_json.sh
@@ -5,8 +5,11 @@ set -o errexit -o nounset
 target="/var/vcap/all-releases/jobs-src/diego/bbs/templates/bbs.json.erb"
 sentinel="${target}.patch_sentinel"
 if [[ -f "${sentinel}" ]]; then
-  echo "Patch already applied. Skipping"
-  exit 0
+  if sha256sum --check "${sentinel}" ; then
+    echo "Patch already applied. Skipping"
+    exit 0
+  fi
+  echo "Sentinel mismatch, re-patching"
 fi
 
 # Advertise our spec address.
@@ -17,4 +20,4 @@ patch --verbose "${target}" <<'EOT'
 >     "#{scheme}://#{spec.address}:#{port}"
 EOT
 
-touch "${sentinel}"
+sha256sum "${target}" > "${sentinel}"

--- a/bosh/releases/pre_render_scripts/diego-api/locket/jobs/patch_locket_ctl.sh
+++ b/bosh/releases/pre_render_scripts/diego-api/locket/jobs/patch_locket_ctl.sh
@@ -5,8 +5,11 @@ set -o errexit -o nounset
 target="/var/vcap/all-releases/jobs-src/diego/locket/templates/locket_ctl.erb"
 sentinel="${target}.patch_sentinel"
 if [[ -f "${sentinel}" ]]; then
-  echo "Patch already applied. Skipping"
-  exit 0
+  if sha256sum --check "${sentinel}" ; then
+    echo "Patch already applied. Skipping"
+    exit 0
+  fi
+  echo "Sentinel mismatch, re-patching"
 fi
 
 patch --verbose "${target}" <<'EOT'
@@ -22,4 +25,4 @@ patch --verbose "${target}" <<'EOT'
      ;;
 EOT
 
-touch "${sentinel}"
+sha256sum "${target}" > "${sentinel}"

--- a/bosh/releases/pre_render_scripts/diego-cell/cflinuxfs3-rootfs-setup/jobs/patch_pre-start.sh
+++ b/bosh/releases/pre_render_scripts/diego-cell/cflinuxfs3-rootfs-setup/jobs/patch_pre-start.sh
@@ -5,8 +5,11 @@ set -o errexit -o nounset
 target="/var/vcap/all-releases/jobs-src/cflinuxfs3/cflinuxfs3-rootfs-setup/templates/pre-start"
 sentinel="${target}.patch_sentinel"
 if [[ -f "${sentinel}" ]]; then
-  echo "Patch already applied. Skipping"
-  exit 0
+  if sha256sum --check "${sentinel}" ; then
+    echo "Patch already applied. Skipping"
+    exit 0
+  fi
+  echo "Sentinel mismatch, re-patching"
 fi
 
 # Use the ephemeral data directory for the rootfs
@@ -23,4 +26,4 @@ patch --verbose "${target}" <<'EOT'
  CA_DIR=$ROOTFS_DIR/usr/local/share/ca-certificates/
 EOT
 
-touch "${sentinel}"
+sha256sum "${target}" > "${sentinel}"

--- a/bosh/releases/pre_render_scripts/diego-cell/garden/jobs/patch_post-start.sh
+++ b/bosh/releases/pre_render_scripts/diego-cell/garden/jobs/patch_post-start.sh
@@ -5,8 +5,11 @@ set -o errexit -o nounset
 target="/var/vcap/all-releases/jobs-src/garden-runc/garden/templates/bin/post-start"
 sentinel="${target}.patch_sentinel"
 if [[ -f "${sentinel}" ]]; then
-  echo "Patch already applied. Skipping"
-  exit 0
+  if sha256sum --check "${sentinel}" ; then
+    echo "Patch already applied. Skipping"
+    exit 0
+  fi
+  echo "Sentinel mismatch, re-patching"
 fi
 
 # Patch the post-start script to use netcat instead of curl when performing the ping to a unix
@@ -41,4 +44,4 @@ patch --verbose "${target}" <<'EOT'
    fi
 EOT
 
-touch "${sentinel}"
+sha256sum "${target}" > "${sentinel}"

--- a/bosh/releases/pre_render_scripts/diego-cell/garden/jobs/patch_pre-start.sh
+++ b/bosh/releases/pre_render_scripts/diego-cell/garden/jobs/patch_pre-start.sh
@@ -5,8 +5,11 @@ set -o errexit -o nounset
 target="/var/vcap/all-releases/jobs-src/garden-runc/garden/templates/bin/bpm-pre-start.erb"
 sentinel="${target}.patch_sentinel"
 if [[ -f "${sentinel}" ]]; then
-  echo "Patch already applied. Skipping"
-  exit 0
+  if sha256sum --check "${sentinel}" ; then
+    echo "Patch already applied. Skipping"
+    exit 0
+  fi
+  echo "Sentinel mismatch, re-patching"
 fi
 
 # Patch the pre-start script to setup /var/vcap/data
@@ -20,4 +23,4 @@ patch --verbose "${target}" <<'EOT'
 > chmod ugo+rx /var/vcap/data/grootfs
 EOT
 
-touch "${sentinel}"
+sha256sum "${target}" > "${sentinel}"

--- a/bosh/releases/pre_render_scripts/diego-cell/rep/bpm/patch_bpm.sh
+++ b/bosh/releases/pre_render_scripts/diego-cell/rep/bpm/patch_bpm.sh
@@ -5,8 +5,11 @@ set -o errexit -o nounset
 target="/var/vcap/all-releases/jobs-src/diego/rep/templates/bpm.yml.erb"
 sentinel="${target}.patch_sentinel"
 if [[ -f "${sentinel}" ]]; then
-  echo "Patch already applied. Skipping"
-  exit 0
+  if sha256sum --check "${sentinel}" ; then
+    echo "Patch already applied. Skipping"
+    exit 0
+  fi
+  echo "Sentinel mismatch, re-patching"
 fi
 
 # Patch BPM, since we're actually running in-cluster without BPM
@@ -22,4 +25,4 @@ patch --verbose "${target}" <<'EOT'
      - path : /var/vcap/data/garden
 EOT
 
-touch "${sentinel}"
+sha256sum "${target}" > "${sentinel}"

--- a/bosh/releases/pre_render_scripts/diego-cell/rep/jobs/patch_pre-start.sh
+++ b/bosh/releases/pre_render_scripts/diego-cell/rep/jobs/patch_pre-start.sh
@@ -5,8 +5,11 @@ set -o errexit -o nounset
 target="/var/vcap/all-releases/jobs-src/diego/rep/templates/bpm-pre-start.erb"
 sentinel="${target}.patch_sentinel"
 if [[ -f "${sentinel}" ]]; then
-  echo "Patch already applied. Skipping"
-  exit 0
+  if sha256sum --check "${sentinel}" ; then
+    echo "Patch already applied. Skipping"
+    exit 0
+  fi
+  echo "Sentinel mismatch, re-patching"
 fi
 
 # Use the ephemeral data directory for the rootfs.
@@ -21,4 +24,4 @@ patch --verbose "${target}" <<'EOT'
 +cp -r /var/vcap/packages/proxy /var/vcap/data/shared-packages/
 EOT
 
-touch "${sentinel}"
+sha256sum "${target}" > "${sentinel}"

--- a/bosh/releases/pre_render_scripts/diego-cell/rep/jobs/patch_rep_ctl.sh
+++ b/bosh/releases/pre_render_scripts/diego-cell/rep/jobs/patch_rep_ctl.sh
@@ -5,8 +5,11 @@ set -o errexit -o nounset
 target="/var/vcap/all-releases/jobs-src/diego/rep/templates/rep_ctl.erb"
 sentinel="${target}.patch_sentinel"
 if [[ -f "${sentinel}" ]]; then
-  echo "Patch already applied. Skipping"
-  exit 0
+  if sha256sum --check "${sentinel}" ; then
+    echo "Patch already applied. Skipping"
+    exit 0
+  fi
+  echo "Sentinel mismatch, re-patching"
 fi
 
 patch --verbose "${target}" <<'EOT'
@@ -22,4 +25,4 @@ patch --verbose "${target}" <<'EOT'
      ;;
 EOT
 
-touch "${sentinel}"
+sha256sum "${target}" > "${sentinel}"

--- a/bosh/releases/pre_render_scripts/diego-cell/rep/jobs/patch_rep_json.sh
+++ b/bosh/releases/pre_render_scripts/diego-cell/rep/jobs/patch_rep_json.sh
@@ -5,8 +5,11 @@ set -o errexit -o nounset
 target="/var/vcap/all-releases/jobs-src/diego/rep/templates/rep.json.erb"
 sentinel="${target}.patch_sentinel"
 if [[ -f "${sentinel}" ]]; then
-  echo "Patch already applied. Skipping"
-  exit 0
+  if sha256sum --check "${sentinel}" ; then
+    echo "Patch already applied. Skipping"
+    exit 0
+  fi
+  echo "Sentinel mismatch, re-patching"
 fi
 
 # Don't share /var/vcap/packages between containers.
@@ -31,4 +34,4 @@ patch --verbose "${target}" <<'EOT'
      evacuation_timeout: "#{p("diego.rep.evacuation_timeout_in_seconds")}s",
 EOT
 
-touch "${sentinel}"
+sha256sum "${target}" > "${sentinel}"

--- a/bosh/releases/pre_render_scripts/diego-cell/sle15-rootfs-setup/jobs/patch_pre-start.sh
+++ b/bosh/releases/pre_render_scripts/diego-cell/sle15-rootfs-setup/jobs/patch_pre-start.sh
@@ -5,8 +5,11 @@ set -o errexit -o nounset
 target="/var/vcap/all-releases/jobs-src/sle15/sle15-rootfs-setup/templates/pre-start"
 sentinel="${target}.patch_sentinel"
 if [[ -f "${sentinel}" ]]; then
-  echo "Patch already applied. Skipping"
-  exit 0
+  if sha256sum --check "${sentinel}" ; then
+    echo "Patch already applied. Skipping"
+    exit 0
+  fi
+  echo "Sentinel mismatch, re-patching"
 fi
 
 # Use the ephemeral data directory for the rootfs
@@ -21,4 +24,4 @@ patch --verbose "${target}" <<'EOT'
 +ROOTFS_TAR=/var/vcap/data/rep/sle15/rootfs.tar
 EOT
 
-touch "${sentinel}"
+sha256sum "${target}" > "${sentinel}"

--- a/bosh/releases/pre_render_scripts/eirini/opi/bpm/patch_bpm.sh
+++ b/bosh/releases/pre_render_scripts/eirini/opi/bpm/patch_bpm.sh
@@ -5,8 +5,11 @@ set -o errexit -o nounset
 target="/var/vcap/all-releases/jobs-src/eirini/opi/templates/bpm.yml.erb"
 sentinel="${target}.patch_sentinel"
 if [[ -f "${sentinel}" ]]; then
-  echo "Patch already applied. Skipping"
-  exit 0
+  if sha256sum --check "${sentinel}" ; then
+    echo "Patch already applied. Skipping"
+    exit 0
+  fi
+  echo "Sentinel mismatch, re-patching"
 fi
 
 # Patch BPM, since we're actually running in-cluster without BPM
@@ -31,4 +34,4 @@ patch --verbose "${target}" <<'EOT'
 -    <% end %>
 EOT
 
-touch "${sentinel}"
+sha256sum "${target}" > "${sentinel}"

--- a/bosh/releases/pre_render_scripts/router/gorouter/jobs/patch_pre-start.sh
+++ b/bosh/releases/pre_render_scripts/router/gorouter/jobs/patch_pre-start.sh
@@ -5,8 +5,11 @@ set -o errexit -o nounset
 target="/var/vcap/all-releases/jobs-src/routing/gorouter/templates/pre-start.erb"
 sentinel="${target}.patch_sentinel"
 if [[ -f "${sentinel}" ]]; then
-  echo "Patch already applied. Skipping"
-  exit 0
+  if sha256sum --check "${sentinel}" ; then
+    echo "Patch already applied. Skipping"
+    exit 0
+  fi
+  echo "Sentinel mismatch, re-patching"
 fi
 
 patch --verbose "${target}" <<'EOT'
@@ -24,4 +27,4 @@ patch --verbose "${target}" <<'EOT'
  chown root:vcap /etc/profile.d/jq.sh
 EOT
 
-touch "${sentinel}"
+sha256sum "${target}" > "${sentinel}"

--- a/bosh/releases/pre_render_scripts/routing-api/routing-api/bpm/patch_bpm.sh
+++ b/bosh/releases/pre_render_scripts/routing-api/routing-api/bpm/patch_bpm.sh
@@ -5,8 +5,11 @@ set -o errexit -o nounset
 target="/var/vcap/all-releases/jobs-src/routing/routing-api/templates/bpm.yml.erb"
 sentinel="${target}.patch_sentinel"
 if [[ -f "${sentinel}" ]]; then
-  echo "Patch already applied. Skipping"
-  exit 0
+  if sha256sum --check "${sentinel}" ; then
+    echo "Patch already applied. Skipping"
+    exit 0
+  fi
+  echo "Sentinel mismatch, re-patching"
 fi
 
 patch --verbose "${target}" <<'EOT'
@@ -24,4 +27,4 @@ patch --verbose "${target}" <<'EOT'
        pre_start: /var/vcap/jobs/routing-api/bin/bpm-pre-start
 EOT
 
-touch "${sentinel}"
+sha256sum "${target}" > "${sentinel}"

--- a/bosh/releases/pre_render_scripts/scheduler/ssh_proxy/jobs/patch_ssh_proxy_ctl.sh
+++ b/bosh/releases/pre_render_scripts/scheduler/ssh_proxy/jobs/patch_ssh_proxy_ctl.sh
@@ -5,8 +5,11 @@ set -o errexit -o nounset
 target="/var/vcap/all-releases/jobs-src/diego/ssh_proxy/templates/ssh_proxy_ctl.erb"
 sentinel="${target}.patch_sentinel"
 if [[ -f "${sentinel}" ]]; then
-  echo "Patch already applied. Skipping"
-  exit 0
+  if sha256sum --check "${sentinel}" ; then
+    echo "Patch already applied. Skipping"
+    exit 0
+  fi
+  echo "Sentinel mismatch, re-patching"
 fi
 
 patch --verbose "${target}" <<'EOT'
@@ -22,4 +25,4 @@ patch --verbose "${target}" <<'EOT'
      ;;
 EOT
 
-touch "${sentinel}"
+sha256sum "${target}" > "${sentinel}"

--- a/bosh/releases/pre_render_scripts/singleton-blobstore/blobstore/jobs/patch_blobstore_pre-start.sh
+++ b/bosh/releases/pre_render_scripts/singleton-blobstore/blobstore/jobs/patch_blobstore_pre-start.sh
@@ -7,8 +7,11 @@ set -o errexit -o nounset
 target="/var/vcap/all-releases/jobs-src/capi/blobstore/templates/pre-start.sh.erb"
 sentinel="${target}.patch_sentinel"
 if [[ -f "${sentinel}" ]]; then
-  echo "Patch already applied. Skipping"
-  exit 0
+  if sha256sum --check "${sentinel}" ; then
+    echo "Patch already applied. Skipping"
+    exit 0
+  fi
+  echo "Sentinel mismatch, re-patching"
 fi
 
 patch --verbose "${target}" <<'EOT'
@@ -31,4 +34,4 @@ patch --verbose "${target}" <<'EOT'
    if [ $num_needing_chown -gt 0 ]; then
 EOT
 
-touch "${sentinel}"
+sha256sum "${target}" > "${sentinel}"

--- a/bosh/releases/pre_render_scripts/smoke-tests/smoke_tests/jobs/patch_test.sh
+++ b/bosh/releases/pre_render_scripts/smoke-tests/smoke_tests/jobs/patch_test.sh
@@ -3,8 +3,11 @@
 target="/var/vcap/all-releases/jobs-src/cf-smoke-tests/smoke_tests/templates/test.erb"
 sentinel="${target}.patch_sentinel"
 if [[ -f "${sentinel}" ]]; then
-  echo "Patch already applied. Skipping"
-  exit 0
+  if sha256sum --check "${sentinel}" ; then
+    echo "Patch already applied. Skipping"
+    exit 0
+  fi
+  echo "Sentinel mismatch, re-patching"
 fi
 
 # Patch test.erb to add the correct cf-cli path to $PATH.
@@ -15,4 +18,4 @@ patch --verbose "${target}" <<'EOT'
 > export PATH=/var/vcap/data/shared-packages/cf-cli-6-linux/bin:${PATH} # put the cli on the path
 EOT
 
-touch "${sentinel}"
+sha256sum "${target}" > "${sentinel}"

--- a/bosh/releases/pre_render_scripts/uaa/uaa/jobs/patch_pre-start.sh
+++ b/bosh/releases/pre_render_scripts/uaa/uaa/jobs/patch_pre-start.sh
@@ -5,8 +5,11 @@ set -o errexit -o nounset
 target="/var/vcap/all-releases/jobs-src/uaa/uaa/templates/bin/pre-start.erb"
 sentinel="${target}.patch_sentinel"
 if [[ -f "${sentinel}" ]]; then
-  echo "Patch already applied. Skipping"
-  exit 0
+  if sha256sum --check "${sentinel}" ; then
+    echo "Patch already applied. Skipping"
+    exit 0
+  fi
+  echo "Sentinel mismatch, re-patching"
 fi
 
 # Patch bin/pre-start.erb for the certificates to work with SUSE.
@@ -43,4 +46,4 @@ patch --verbose "${target}" <<'EOT'
  function new_cache_files_are_identical {
 EOT
 
-touch "${sentinel}"
+sha256sum "${target}" > "${sentinel}"


### PR DESCRIPTION
## Description
If the pod / containers go away unexpectedly (e.g. when a given node dies), we can get into a situation where the volumes holding the rendered job configs persist and things go bad for us:

1. Node goes away, the pod restarts (keeping volumes)
2. `cf-operator util template-render` re-renders the templates
   (This clobbers our patched changes)
3. The patch script runs, seeing the sentinel file (because the volume
   managed to survive), skipping the patching.

This fixes things by storing the digest of the _patched_ file in the sentinel, so that when this happens we see that the patch target has an unexpected checksum and we re-patch.

## Motivation and Context
Fixes #852

## How Has This Been Tested?
Deployed locally. Murdered docker, see that issue does not recur.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
