### PR TITLE
Increase CATs ginkgo nodes

### DIFF
--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -460,7 +460,7 @@ jobs:
       - name: output
       params:
         DEFAULT_STACK: cflinuxfs3
-        CATS_NODES: 2
+        CATS_NODES: 15
         ENABLE_EIRINI: {{ eq $cfScheduler "eirini" }}
       run:
         path: "/bin/bash"


### PR DESCRIPTION
because we are now running on gke and we got CATs passing there in 23m
using 15 nodes.
