### PR TITLE
Delete pvc disks associated with the GKE cluster in CI jobs

### DIFF
--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -502,6 +502,13 @@ jobs:
             export GKE_PROJECT={{ if has . "gke_project" }}{{ .gke_project }}{{ else }}"suse-225215"{{ end }}
             export GKE_CLUSTER_ZONE={{ if has . "gke_zone" }}{{ .gke_zone }}{{ else }}"europe-west3-c"{{ end }}
             export GKE_CLUSTER_NAME="kubecf-ci-$(cat semver.gke-cluster/version | sed 's/\./-/g')"
+            # Delete pvc disks associated to the cluster
+            IDS=$(gcloud compute disks list \
+                  --filter="zone~${GKE_CLUSTER_ZONE}" --filter="name~${GKE_CLUSTER_NAME}" \
+                  --format="value(id)" \
+                  --project=${GKE_PROJECT})
+            for ID in ${IDS}; do gcloud compute disks delete ${ID} --zone=${GKE_CLUSTER_ZONE} --quiet; done
+            # Delete cluster
             gcloud --quiet container --project "${GKE_PROJECT}" clusters delete "${GKE_CLUSTER_NAME}" --zone "${GKE_CLUSTER_ZONE}"
 
   on_abort:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Needed, since storageclasses and pvcs of the clusters have `reclaimPolicy:
Delete `, and the docs say that the disks corresponding to the pvcs default to
delete, but doesn't seem to be true. See:
  https://cloud.google.com/kubernetes-engine/docs/concepts/persistent-volumes
  https://cloud.google.com/sdk/gcloud/reference/compute/instances/set-disk-auto-delete

The gcloud account needs the following permissions:
 - Required 'compute.disks.list' permission for 'projects/foo'
 - Required 'compute.regions.list' permission for 'projects/foo'

Another implementation could be to label the cluster on creation and operate on
that.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- An important detail to include is the version of the used cf-operator -->

Tested succesfully by hijacking a CI job, settings GKE_* vars manually, and using the commands to remove dangling disks of cluster kubecf-ci-0-0-27.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
