### PR TITLE
Release branch names are release-x.y and not vx.y.z

### DIFF
--- a/doc/release/release-guidelines.md
+++ b/doc/release/release-guidelines.md
@@ -14,15 +14,15 @@ Move to the origin/master branch:
 
 Create a release branch following the semver rules:
 ```
-> git checkout -b v2.0.0
+> git checkout -b release-2.0
 ```
 
 ```
-> git push --set-upstream origin v2.0.0
+> git push --set-upstream origin release-2.0
 ```
 
 
-Check [here](https://github.com/cloudfoundry-incubator/kubecf/branches) if the v2.0.0 branch is protected by verifying if the release branch as the lock icon:
+Check [here](https://github.com/cloudfoundry-incubator/kubecf/branches) if the release-2.0 branch is protected by verifying if the release branch as the lock icon:
 
 ![](https://i.imgur.com/n8DHyeF.png)
 
@@ -52,7 +52,7 @@ helm_package(
 ```
 
 Update the Concourse pipeline _.concourse/pipeline.yaml.gomplate_ by adding the new release branch to the list of branches:
-```{{ $branches := slice "master" "v2.0.0" }} # Repository branches to track```
+```{{ $branches := slice "master" "release-2.0" }} # Repository branches to track```
 
 ## Concourse
 

--- a/doc/release/release.md
+++ b/doc/release/release.md
@@ -10,16 +10,9 @@ KubeCF follows the [semver](https://semver.org/) for versioning and does it auto
 
 A *release* branch is created from the *master* and can ONLY get bug-fix commits. When fixes are added, then a manual cherry-pick to the *master* will happen immediately after.
 
-If the *release* branch name is not semver compatible, a version 0.0.0 will be associated to the KubeCF package indicating an **UNOFFICIAL** package release.
-
-Examples
-
-* git *release* branch named **v1.0.0** will generate a **KubeCF-v1.0.0** package file :+1:
-* git branch name **non-semver** will generate a **KubeCF-v0.0.0** package file that indicates it's an **UNOFFICIAL** release.
-
 ### Minor and Patch Releases
 
-A minor or a patch release can occur during a version life cyle and if so, a *release patch* branch MUST be created from the original *release* branch version and it will contain the improvements and/or bug fixes that later will be cherry-picked into the *master* branch.
+Each minor release uses it's own release branch named `release-x.y`. Further patch releases will always be made from this release branch, by cherry-picking bug fixes from either `master` or specific bug-fix branches.
 
 ![](https://i.imgur.com/b2DVvMw.png)
 


### PR DESCRIPTION
The `vX.Y.Z` format is used for tags and should be kept separate from the names for branches to avoid confusion once the branch and tag no longer point to the same commit.

The `release-X.Y` naming already matches the original intend, as show in the image used by `release.md`:

![](https://i.imgur.com/b2DVvMw.png)

There is no separate release branch for patch releases; they all live on the release branch for their minor release (also as shown on the image).
