### PR TITLE
fix: Add --project flag to gcloud compute disks delete

### DIFF
--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -507,7 +507,10 @@ jobs:
                   --filter="zone~${GKE_CLUSTER_ZONE}" --filter="name~${GKE_CLUSTER_NAME}" \
                   --format="value(id)" \
                   --project=${GKE_PROJECT})
-            for ID in ${IDS}; do gcloud compute disks delete ${ID} --zone=${GKE_CLUSTER_ZONE} --quiet; done
+            for ID in ${IDS}; do
+                gcloud compute disks delete ${ID} --zone=${GKE_CLUSTER_ZONE} \
+                                                  --project="${GKE_PROJECT}" --quiet;
+            done
             # Delete cluster
             gcloud --quiet container --project "${GKE_PROJECT}" clusters delete "${GKE_CLUSTER_NAME}" --zone "${GKE_CLUSTER_ZONE}"
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Project flag seems to be missing, see:
https://concourse.suse.dev/teams/main/pipelines/kubecf/jobs/cf-acceptance-tests-diego-master/builds/41#L5ebe73f8:2

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes cluster deletion task in CI.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- An important detail to include is the version of the used cf-operator -->
It has not.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
