### PR TITLE
fix: Permute the order of GKE cluster and disks deletion

### DIFF
--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -502,18 +502,18 @@ jobs:
             export GKE_PROJECT={{ if has . "gke_project" }}{{ .gke_project }}{{ else }}"suse-225215"{{ end }}
             export GKE_CLUSTER_ZONE={{ if has . "gke_zone" }}{{ .gke_zone }}{{ else }}"europe-west3-c"{{ end }}
             export GKE_CLUSTER_NAME="kubecf-ci-$(cat semver.gke-cluster/version | sed 's/\./-/g')"
-            # Delete pvc disks associated to the cluster
+            # Obtain pvc disks associated to the cluster
             IDS=$(gcloud compute disks list \
                   --filter="zone~${GKE_CLUSTER_ZONE}" --filter="name~${GKE_CLUSTER_NAME}" \
                   --format="value(id)" \
                   --project=${GKE_PROJECT})
+            # Delete cluster
+            gcloud --quiet container --project "${GKE_PROJECT}" clusters delete "${GKE_CLUSTER_NAME}" --zone "${GKE_CLUSTER_ZONE}"
+            # Delete pvc disks associated to the cluster, now that they are free
             for ID in ${IDS}; do
                 gcloud compute disks delete ${ID} --zone=${GKE_CLUSTER_ZONE} \
                                                   --project="${GKE_PROJECT}" --quiet;
             done
-            # Delete cluster
-            gcloud --quiet container --project "${GKE_PROJECT}" clusters delete "${GKE_CLUSTER_NAME}" --zone "${GKE_CLUSTER_ZONE}"
-
   on_abort:
     do:
     - task: cleanup-cluster


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Disks can't be deleted if the cluster is still around. Save the list of disks to be deleted, delete the cluster, and then the disks.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- An important detail to include is the version of the used cf-operator -->
No, difficult to test without triggering a job.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
