### PR TITLE
Remove not needed "privileged" tasks from pipelines

### DIFF
--- a/.concourse/kubecf-pool-reconciler.yaml.gomplate
+++ b/.concourse/kubecf-pool-reconciler.yaml.gomplate
@@ -45,7 +45,6 @@ jobs:
     trigger: true
   - get: catapult
   - task: deploy
-    privileged: true
     timeout: 30m
     config:
       platform: linux

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -459,7 +459,7 @@ jobs:
       - name: output
       params:
         DEFAULT_STACK: cflinuxfs3
-        CATS_NODES: 15
+        CATS_NODES: 8
         ENABLE_EIRINI: {{ eq $cfScheduler "eirini" }}
       run:
         path: "/bin/bash"

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -213,7 +213,8 @@ deploy_args: &deploy_args
     --default-max-pods-per-node "110" \
     --no-enable-master-authorized-networks \
     --addons HorizontalPodAutoscaling,HttpLoadBalancing \
-    --no-enable-autorepair
+    --no-enable-autorepair \
+    --no-enable-autoupgrade
 
   # Get a kubeconfig
   gcloud container clusters get-credentials ${GKE_CLUSTER_NAME} --zone ${GKE_CLUSTER_ZONE} --project "${GKE_PROJECT}"

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -229,6 +229,16 @@ deploy_args: &deploy_args
   export QUIET_OUTPUT=true
   export DOWNLOAD_CATAPULT_DEPS=false
   export KUBECFG="$(readlink -f ~/.kube/config)"
+
+  # https://unix.stackexchange.com/a/265151
+  read -r -d '' CONFIG_OVERRIDE <<'EOF' || true
+  sizing:
+    diego_cell:
+      ephemeral_disk:
+        size: 300000
+  EOF
+  export CONFIG_OVERRIDE
+
   pushd catapult
   # Bring up a k8s cluster and builds+deploy kubecf
   # https://github.com/SUSE/catapult/wiki/Build-and-run-SCF#build-and-run-kubecf

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -441,7 +441,6 @@ jobs:
   - put: semver.gke-cluster
     params: {bump: patch}
   - task: deploy
-    privileged: true
     timeout: 3h30m
     input_mapping:
       kubecf: kubecf-{{ $branch }}
@@ -567,7 +566,6 @@ jobs:
         state: pending
 {{- end }}
   - task: test-{{ $cfScheduler }}
-    privileged: true
     input_mapping:
       kubecf: kubecf-{{ $branch }}
     timeout: 1h30m
@@ -656,7 +654,6 @@ jobs:
         state: pending
 {{- end }}
   - task: test-{{ $cfScheduler }}
-    privileged: true
     timeout: 5h30m
     input_mapping:
       kubecf: kubecf-{{ $branch }}
@@ -750,7 +747,6 @@ jobs:
         state: pending
 {{- end }}
   - task: test-{{ $cfScheduler }}
-    privileged: true
     timeout: 1h30m
     input_mapping:
       kubecf: kubecf-{{ $branch }}
@@ -844,7 +840,6 @@ jobs:
         state: pending
 {{- end }}
   - task: rotate-{{ $cfScheduler }}
-    privileged: true
     timeout: 1h30m
     input_mapping:
       kubecf: kubecf-{{ $branch }}
@@ -936,7 +931,6 @@ jobs:
         state: pending
 {{- end }}
   - task: test-{{ $cfScheduler }}
-    privileged: true
     input_mapping:
       kubecf: kubecf-{{ $branch }}
     timeout: 1h30m
@@ -1018,7 +1012,6 @@ jobs:
 #     - sync-integration-tests-{{ $cfScheduler }}
 #   - get: catapult
 #   - task: test-{{ $cfScheduler }}
-#     privileged: true
 #     timeout: 1h30m
 #     config:
 #       platform: linux

--- a/.concourse/tasks/upgrade.sh
+++ b/.concourse/tasks/upgrade.sh
@@ -51,6 +51,15 @@ gcloud --quiet beta container \
 # Get a kubeconfig
 gcloud container clusters get-credentials "${GKE_CLUSTER_NAME}" --zone "${GKE_CLUSTER_ZONE}" --project "${GKE_PROJECT}"
 
+# https://unix.stackexchange.com/a/265151
+read -r -d '' CONFIG_OVERRIDE <<'EOF' || true
+sizing:
+  diego_cell:
+  ephemeral_disk:
+    size: 300000
+EOF
+export CONFIG_OVERRIDE
+
 pushd catapult
 # Bring up a k8s cluster and builds+deploy kubecf
 # https://github.com/SUSE/catapult/wiki/Build-and-run-SCF#build-and-run-kubecf

--- a/.concourse/tasks/upgrade.sh
+++ b/.concourse/tasks/upgrade.sh
@@ -46,7 +46,9 @@ gcloud --quiet beta container \
   --default-max-pods-per-node "110" \
   --no-enable-master-authorized-networks \
   --addons HorizontalPodAutoscaling,HttpLoadBalancing \
-  --no-enable-autorepair
+  --no-enable-autorepair \
+  --no-enable-autoupgrade
+
 
 # Get a kubeconfig
 gcloud container clusters get-credentials "${GKE_CLUSTER_NAME}" --zone "${GKE_CLUSTER_ZONE}" --project "${GKE_PROJECT}"


### PR DESCRIPTION
because there seems to be a performance penatly with overlay
baggageclaim driver in concourse and privileged containers.

https://github.com/concourse/concourse/issues/4332

With `privileged` on, it took 20 minutes to even start the `deploy` task. Without it it takes 10-20 seconds: https://concourse.suse.dev/teams/main/pipelines/kubecf/jobs/deploy-diego-master/builds/2