### PR TITLE
fix: Delete correcly GKE disks, name filters need an explicit AND

### DIFF
--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -504,12 +504,13 @@ jobs:
             export GKE_CLUSTER_NAME="kubecf-ci-$(cat semver.gke-cluster/version | sed 's/\./-/g')"
             # Obtain pvc disks associated to the cluster
             IDS=$(gcloud compute disks list \
-                  --filter="zone~${GKE_CLUSTER_ZONE}" --filter="name~${GKE_CLUSTER_NAME}" \
-                  --filter="name~pvc" \
+                  --filter="zone~${GKE_CLUSTER_ZONE}" \
+                  --filter="name~${GKE_CLUSTER_NAME} AND name~pvc" \
                   --format="value(id)" \
                   --project=${GKE_PROJECT})
             # Delete cluster
-            gcloud --quiet container --project "${GKE_PROJECT}" clusters delete "${GKE_CLUSTER_NAME}" --zone "${GKE_CLUSTER_ZONE}"
+            gcloud --quiet container --project "${GKE_PROJECT}" clusters delete "${GKE_CLUSTER_NAME}" \
+                   --zone "${GKE_CLUSTER_ZONE}"
             # Delete pvc disks associated to the cluster, now that they are free
             for ID in ${IDS}; do
                 gcloud compute disks delete ${ID} --zone=${GKE_CLUSTER_ZONE} \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Delete correctly the GKE clusters and their disks by filtering correctly for pvc disks.
Turns out that filters have an implicit `and`, but only between different types. Hence, bundle all name filters under a single  `--filter=name foo AND bar`. 


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- An important detail to include is the version of the used cf-operator -->
Tested by starting a deploy job on the kubecf pipeline, hijacking it, waiting for kubecf to be deployed so pvc disks are present, and then running the commands manually to completely delete the cluster and all its disks.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
