### PR TITLE
fix: Autoscaler should use internal URL for cloud controller

### DIFF
--- a/deploy/helm/kubecf/assets/operations/instance_groups/app-autoscaler.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/app-autoscaler.yaml
@@ -164,7 +164,7 @@
           scheduler_db_connection_config: *databaseConnectionConfig
           policy_db_connection_config: *databaseConnectionConfig
           cf: &cf_credentials
-            api: "https://api.((system_domain))"
+            api: "https://cloud-controller-ng.service.cf.internal:9024"
             grant_type: client_credentials
             client_id: "app_autoscaler"
             secret: "((uaa_clients_app_autoscaler_secret))"


### PR DESCRIPTION
Otherwise the pods will not become ready until external DNS has been set up.

Fixes #870 

Tested manually by @satadruroy and @prabalsharma 