### PR TITLE
fix: outdated comment in values.yaml.

### DIFF
--- a/deploy/helm/kubecf/values.yaml
+++ b/deploy/helm/kubecf/values.yaml
@@ -333,8 +333,7 @@ testing:
 ccdb:
   encryption:
     rotation:
-      # Key labels must be <= 240 characters long. Each label will be prepended with the
-      # "ccdb_key_label_" value.
+      # Key labels must be <= 240 characters long.
       key_labels:
       - encryption_key_0
       current_key_label: encryption_key_0


### PR DESCRIPTION
Key labels are no longer automatically prefixed. We could extend the maximum length a bit to adjust for that, but 240 character seem long enough for just a label name.

Ref #853