### PR TITLE
fix: Cherry pick packaging fix

### DIFF
--- a/deploy/helm/kubecf/BUILD.bazel
+++ b/deploy/helm/kubecf/BUILD.bazel
@@ -109,14 +109,15 @@ genrule(
     name = "release_chart",
     tools = [
         "//rules/kubecf:release_chart.sh",
-        "@jq//:binary"
+        "@jq//:binary",
+        "@helm//:binary",
     ],
     srcs = [
         ":kubecf",
         ":image_list",
     ],
     outs = ["kubecf_release.tgz"],
-    cmd = "$(location //rules/kubecf:release_chart.sh) $(location :kubecf) $(location :image_list) $@ $(location @jq//:binary)",
+    cmd = "$(location //rules/kubecf:release_chart.sh) $(location :kubecf) $(location :image_list) $@ $(location @jq//:binary) $(location @helm//:binary)",
 )
 
 # Generates a file containing only the KubeCF version.

--- a/rules/kubecf/release_chart.sh
+++ b/rules/kubecf/release_chart.sh
@@ -7,6 +7,7 @@ KUBECF_CHART="$1"
 KUBECF_IMAGE_LIST_JSON_FILE="$2"
 OUTPUT="$3"
 JQ="$4"
+HELM="$5"
 
 if [ ! -e "${KUBECF_CHART}" ]; then
   >&2 echo "Helm chart tarball '${KUBECF_CHART}' does not exist, bailing out!"; exit 1
@@ -24,6 +25,6 @@ tar xf "${KUBECF_CHART}"
   < "${KUBECF_IMAGE_LIST_JSON_FILE}" \
   > "${KUBECF_IMAGE_LIST_TXT_FILE}"
 
-helm package kubecf/
+"${HELM}" package kubecf/
 
 mv kubecf-*.tgz "${OUTPUT}"


### PR DESCRIPTION
This fix was applied after the `v2.2.0` tag, but used to build the `v2.2.0` release, but the `release-2.2` branch was based of the original tag.