### PR TITLE
fix: deploy: rename sample values file

### DIFF
--- a/deploy/bundle/BUILD.bazel
+++ b/deploy/bundle/BUILD.bazel
@@ -11,7 +11,7 @@ copy_file(
 create_sample_values_binary(
     name = "sample_values",
     input = "//deploy/helm/kubecf:values.yaml",
-    output = ":sample-values.yaml",
+    output = ":kubecf-sample-values.yaml",
 )
 
 pkg_tar(
@@ -21,6 +21,6 @@ pkg_tar(
     srcs = [
         ":cf_operator_chart",
         "//deploy/helm/kubecf:release_chart",
-        ":sample-values.yaml",
+        ":kubecf-sample-values.yaml",
     ]
 )


### PR DESCRIPTION
## Description
Make it clear that the sample values are for kubecf.

## Motivation and Context
Vlad mentioned in chat:
> should they be in the kubecf tarball? they are called "sample-values", but don't apply to the operator for example

## How Has This Been Tested?
Built locally, and inspected the output `tgz`.

## Screenshots (if appropriate):
```
$ tar tf bazel-bin/deploy/bundle/kubecf-bundle.tgz
./
./cf-operator.tgz
./kubecf_release.tgz
./kubecf-sample-values.yaml
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
