### PR TITLE
fix: deploy: move sample values into kubecf chart

### DIFF
--- a/deploy/bundle/BUILD.bazel
+++ b/deploy/bundle/BUILD.bazel
@@ -1,17 +1,10 @@
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
-load("//rules/kubecf:def.bzl", "create_sample_values_binary")
 
 copy_file(
     name = "cf_operator_chart",
     src = "@cf_operator//file",
     out = "cf-operator.tgz",
-)
-
-create_sample_values_binary(
-    name = "sample_values",
-    input = "//deploy/helm/kubecf:values.yaml",
-    output = ":sample-values.yaml",
 )
 
 pkg_tar(
@@ -21,6 +14,5 @@ pkg_tar(
     srcs = [
         ":cf_operator_chart",
         "//deploy/helm/kubecf:release_chart",
-        ":sample-values.yaml",
     ]
 )

--- a/deploy/helm/kubecf/BUILD.bazel
+++ b/deploy/helm/kubecf/BUILD.bazel
@@ -10,6 +10,7 @@ load(
     "//rules/kubecf:def.bzl",
     "image_list",
     "metadata_file_generator",
+    "create_sample_values_binary",
 )
 load("//rules/yaml_extractor:defs.bzl", "yaml_extractor")
 
@@ -91,6 +92,13 @@ pkg_tar(
     ] + [":log_cache_{}_job".format(job).replace("-", "_") for job in LOG_CACHE_JOBS],
 )
 
+# Create a values file that is mostly commented out for user reference.
+create_sample_values_binary(
+    name = "sample_values",
+    input = "//deploy/helm/kubecf:values.yaml",
+    output = ":sample-values.yaml",
+)
+
 # Packages the KubeCF Helm chart.
 helm_package(
     name = "kubecf",
@@ -99,6 +107,7 @@ helm_package(
     ],
     generated = [
         ":metadata",
+        ":sample-values.yaml",
     ],
     tars = [
         "//bosh/releases:pre_render_scripts",

--- a/rules/helm/def.bzl
+++ b/rules/helm/def.bzl
@@ -47,7 +47,9 @@ _package = rule(
         "srcs": attr.label_list(
             mandatory = True,
         ),
-        "generated": attr.label_list(),
+        "generated": attr.label_list(
+            allow_files = True,
+        ),
         "tars": attr.label_list(),
         "package_dir": attr.string(
             mandatory = True,


### PR DESCRIPTION
## Description
There was a fear that having it in the bundle was not visible enough; we will try moving it to the kubecf chart instead.

## Motivation and Context
Fixes #916

## How Has This Been Tested?
Built the chart locally and inspected it for the sample values file.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
