### PR TITLE
Bump smoke-tests to increase app memory limit

### DIFF
--- a/deploy/helm/kubecf/values.yaml
+++ b/deploy/helm/kubecf/values.yaml
@@ -48,6 +48,11 @@ releases:
     stemcell:
       os: SLE_15_SP1
       version: 23.21-7.0.0_374.gb8e8e6af
+  cf-smoke-tests:
+    version: 40.0.128
+    stemcell:
+      os: SLE_15_SP1
+      version: 25.2-7.0.0_374.gb8e8e6af
   # pxc is not a BOSH release.
   pxc:
     image:


### PR DESCRIPTION
Previous releases only allowed 16M for the smoke sample app, which turned out not to be enough for the SLE stemcell under Eirini.

See: https://github.com/cloudfoundry/cf-smoke-tests/pull/61
Fixes https://github.com/cloudfoundry-incubator/kubecf/issues/871
