### PR TITLE
Fix upgrade testing in the kubecf CI pipeline

### DIFF
--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -1305,6 +1305,11 @@ jobs:
     params:
       BRANCH: {{ $branch }}
       CFSCHEDULER: upgrade # hack to re-use the same cleanup code
+      GKE_KEY: '((gke-suse-cap-json))'
+      GKE_PROJECT: '{{ $config.gke_project }}'
+      GKE_ZONE: '{{ $config.gke_zone }}'
+      GKE_DNS_ZONE: '{{ $config.gke_dns_zone }}'
+      GKE_DOMAIN: '{{ $config.gke_domain }}'
     input_mapping:
       kubecf: kubecf-{{ $branch }}
       semver.gke-cluster: semver.gke-cluster-{{ $branch }}-upgrade

--- a/.concourse/tasks/upgrade.sh
+++ b/.concourse/tasks/upgrade.sh
@@ -1,10 +1,44 @@
 #!/bin/bash
 
-set -e
+# Notes
+# - Parameters:
+#   - GKE_KEY
+#   - GKE_PROJECT
+#   - GKE_ZONE
+#   - GKE_DNS_ZONE
+#   - GKE_DOMAIN
+#
+# - Variables used by catapult:
+#   - GKE_CLUSTER_NAME
+#   - GKE_CLUSTER_ZONE
+#   - GKE_CRED_JSON
+#   - GKE_PROJECT
+#
+#   - BACKEND
+#   - CONFIG_OVERRIDE
+#   - ENABLE_EIRINI
+#   - KUBECFG
+#   - QUIET_OUTPUT
+#   - SCF_CHART
+#   - SCF_OPERATOR
+#
+# Variables used by kubectl, gcloud, ...
+#   - KUBECONFIG
+
+set -o errexit
 
 echo "Running the upgrade test"
 
-KUBECF_LATEST_RELEASE=$(cat kubecf-github-release/version)
+# Fail early for missing parameters
+: "${GKE_KEY:?}"
+: "${GKE_PROJECT:?}"
+: "${GKE_ZONE:?}"
+: "${GKE_DNS_ZONE:?}"
+: "${GKE_DOMAIN:?}"
+
+export GKE_CLUSTER_ZONE="$GKE_ZONE"
+
+KUBECF_LATEST_RELEASE="$(cat kubecf-github-release/version)"
 export KUBECF_LATEST_RELEASE
 export SCF_CHART="https://github.com/cloudfoundry-incubator/kubecf/releases/download/v${KUBECF_LATEST_RELEASE}/kubecf-bundle-v${KUBECF_LATEST_RELEASE}.tgz"
 
@@ -13,31 +47,25 @@ export SCF_OPERATOR=true
 
 export FORCE_DELETE=true
 export HELM_VERSION="v3.1.1"
-export BACKEND=imported
-export QUIET_OUTPUT=true
+export BACKEND=gke
+export QUIET_OUTPUT=false
+
 GKE_CLUSTER_NAME="kubecf-ci-${BRANCH}-upgrade-$(sed 'y/./-/' "semver.gke-cluster/version")"
 export GKE_CLUSTER_NAME
-KUBECFG="$(readlink --canonicalize ~/.kube/config)"
-export KUBECFG
+KUBECONFIG="$(readlink --canonicalize "${PWD}/kubeconfig")"
+export KUBECONFIG
 
-printf "%s" '((gke-suse-cap-json))' > "${PWD}/gke-key.json"
-export GKE_CRED_JSON=$PWD/gke-key.json
+# log into the project
+printf "%s" "${GKE_KEY}" > "${PWD}/gke-key.json"
+export GKE_CRED_JSON="${PWD}/gke-key.json"
 gcloud auth activate-service-account --key-file "${PWD}/gke-key.json"
 
-# shellcheck disable=SC2016
-# Incorrect error; $config is for gomplate, not for bash
-export GKE_PROJECT='{{ $config.gke_project }}'
-# shellcheck disable=SC2016
-export GKE_ZONE='{{ $config.gke_zone }}'
-# shellcheck disable=SC2016
-export GKE_DNS_ZONE='{{ $config.gke_dns_zone }}'
-# shellcheck disable=SC2016
-export GKE_DOMAIN='{{ $config.gke_domain }}'
 export DOMAIN="${GKE_CLUSTER_NAME}.${GKE_DOMAIN}"
 
+# create the cluster to test with
 gcloud --quiet beta container \
   --project "${GKE_PROJECT}" clusters create "${GKE_CLUSTER_NAME}" \
-  --zone "${GKE_ZONE}" \
+  --zone "${GKE_CLUSTER_ZONE}" \
   --no-enable-basic-auth \
   --machine-type "n1-highcpu-16" \
   --image-type "UBUNTU" \
@@ -50,32 +78,34 @@ gcloud --quiet beta container \
   --enable-stackdriver-kubernetes \
   --enable-ip-alias \
   --network "projects/${GKE_PROJECT}/global/networks/default" \
-  --subnetwork "projects/${GKE_PROJECT}/regions/${GKE_ZONE%-?}/subnetworks/default" \
+  --subnetwork "projects/${GKE_PROJECT}/regions/${GKE_CLUSTER_ZONE%-?}/subnetworks/default" \
   --default-max-pods-per-node "110" \
   --no-enable-master-authorized-networks \
   --addons HorizontalPodAutoscaling,HttpLoadBalancing \
   --no-enable-autorepair \
   --no-enable-autoupgrade
 
-
-# Get a kubeconfig
+# Get a kubeconfig - Placed into KUBECONFIG
 gcloud container clusters get-credentials "${GKE_CLUSTER_NAME}" --zone "${GKE_CLUSTER_ZONE}" --project "${GKE_PROJECT}"
 
 # https://unix.stackexchange.com/a/265151
 read -r -d '' CONFIG_OVERRIDE <<'EOF' || true
 sizing:
   diego_cell:
-  ephemeral_disk:
-    size: 300000
+    ephemeral_disk:
+      size: 300000
 EOF
 export CONFIG_OVERRIDE
+
+export KUBECFG="${KUBECONFIG}"
 
 pushd catapult
 CLUSTER_PASSWORD=$(tr -dc 'a-zA-Z0-9' < /dev/random | fold -w 32 | head -n 1)
 export CLUSTER_PASSWORD
 # Bring up a k8s cluster and builds+deploy kubecf
 # https://github.com/SUSE/catapult/wiki/Build-and-run-SCF#build-and-run-kubecf
-make kubeconfig kubecf
+make kubeconfig
+make kubecf
 
 # Setup dns
 tcp_router_ip=$(kubectl  get svc -n scf tcp-router-public -o json | jq -r .status.loadBalancer.ingress[].ip | head -n 1)
@@ -94,4 +124,6 @@ gcloud --quiet beta dns --project="${GKE_PROJECT}" record-sets transaction execu
 # The chart should be in s3.kubecf-ci directory
 SCF_CHART="$(readlink -f ../s3.kubecf-ci/*.tgz)"
 export SCF_CHART
-make kubecf-chart kubecf-upgrade
+
+make kubecf-chart
+make kubecf-upgrade

--- a/.concourse/tasks/upgrade.yaml
+++ b/.concourse/tasks/upgrade.yaml
@@ -12,3 +12,9 @@ inputs:
 - name: semver.gke-cluster
 run:
   path: kubecf/.concourse/tasks/upgrade.sh
+params:
+  GKE_KEY: ~
+  GKE_PROJECT: ~
+  GKE_ZONE: ~
+  GKE_DNS_ZONE: ~
+  GKE_DOMAIN: ~


### PR DESCRIPTION
## Description

Fixes to upgrade script and pipeline spec driving it.
  - Script:
      - Placed kubeconfig at an accessible location.
      - Replaced concourse and gomplate templating with environment variables controlled by proper task parameters.
      - Added checks for parameter existence.
      - Fixed catapult backend, must be `gke`, not `imported`.
      - Fixed yaml indenting in the disk override.
      - Added comments explaining internals, and the various communication
      variables (gcloud, catapult).
  - Pipeline:
      - Fixed scoping of `kubecf_repository` usage in loop.
      - Added parameters for the upgrade task.

## Motivation and Context

See https://github.com/cloudfoundry-incubator/kubecf/issues/838

## How Has This Been Tested?

Manual testing using a non-production pipeline.
Pointed at the personal fork for the kubecf repository to use.
See  https://concourse.suse.dev/teams/main/pipelines/ak-kubecf-tkt-838-investigation
Modified vis-a-vis production using the patch at the end to disable/remove irrelevant parts.
Unremovable irrelevant tasks were paused instead.
In the end only three tasks were using in the testing:
  - `lint-master`
  - `build-master`
  - `upgrade-test-master`

Lint and build are required to get a properly made kubecf. Triggered automatically whenever a new commit of the PR was pushed to the kubecf repository in use (personal fork).

:warning: Even with the fixes the test may fail (or require an abort). Namely when either `deploy` or `deploy after upgrade` gets stuck somehow on the `ig` job. This was seen today after change consolidation. Aborted after one hour, re-triggered manually, and success on this second attempt.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Pipeline patch (outside of the fix in the PR, which is required as well)

```
diff --git a/.concourse/pipeline.yaml.gomplate b/.concourse/pipeline.yaml.gomplate
index e4b86b65..7830c5b0 100644
--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -8,17 +8,17 @@
 # time.
 
 # Variables
-{{ $availableCfSchedulers := slice "diego" "eirini" }} # Diego / Eirini
+{{ $availableCfSchedulers := slice "diego" }} # Diego / Eirini
 {{ $pr_resources := slice "pr" "fork-pr" }}
-{{ $branches := slice "master" "release-2.2"}} # Repository branches to track
+{{ $branches := slice "master" }} # Repository branches to track
 
 # Split Concourse jobs in tabs (aka groups)
 # We split by "branch" and we also split the "experimental" jobs of each branch.
 
 # Stable Jobs
 # TODO: Delete the special case here as soon as we get Eirini CATS green and we stabilize Eirini smoke (e.g. with a more large timeout)
-{{ $stable := slice "lint" "build" "deploy-diego" "deploy-eirini" "smoke-tests-diego" "smoke-tests-eirini" "cf-acceptance-tests-diego" "cleanup-diego-cluster" "cleanup-eirini-cluster" }}
-{{ $experimental := slice "cf-acceptance-tests-eirini" "sync-integration-tests" "ccdb-rotate-diego" "ccdb-rotate-eirini" "smoke-tests-post-rotate-diego" "smoke-tests-post-rotate-eirini" "upgrade-test" }}
+{{ $stable := slice "lint" "build" "deploy-diego" "smoke-tests-diego" "cf-acceptance-tests-diego" "cleanup-diego-cluster" }}
+{{ $experimental := slice "sync-integration-tests" "ccdb-rotate-diego" "smoke-tests-post-rotate-diego" "upgrade-test" }}
 
 groups:
 {{ range $_, $branch := (flatten (slice $branches $pr_resources) | uniq) }}
@@ -294,14 +294,6 @@ jobs:
     trigger: true
 {{- end }}
     version: "every"
-{{- if has $stable "lint" }}
-  - put: status-{{ $branch }}.src
-    params: &lint_{{ $sanitized_branch_name }}_status
-        context: lint
-        description: "Lint started"
-        path: kubecf-{{ $branch }}/{{ $path }}
-        state: pending
-{{- end }}
   - task: lint
     config:
       platform: linux
@@ -323,19 +315,6 @@ jobs:
           ./dev/linters/helmlint.sh
           bazel test //rules/kubecf:create_sample_values_test
 
-{{- if has $stable "lint" }}
-    on_success:
-      put: status-{{ $branch }}.src
-      params:
-        << : *lint_{{ $sanitized_branch_name }}_status
-        state: success
-    on_failure:
-      put: status-{{ $branch }}.src
-      params:
-        << : *lint_{{ $sanitized_branch_name }}_status
-        state: failure
-{{- end }}
-
 - name: build-{{ $branch }}
   public: false # TODO: public or not?
   plan:
@@ -344,14 +323,6 @@ jobs:
     version: "every"
     passed:
     - lint-{{ $branch }}
-{{- if has $stable "build" }}
-  - put: status-{{ $branch }}.src
-    params: &build_{{ $sanitized_branch_name }}_status
-        context: build
-        description: "Build started"
-        path: kubecf-{{ $branch }}/{{ $path }}
-        state: pending
-{{- end }}
   - task: build
     config:
       platform: linux
@@ -371,18 +342,6 @@ jobs:
         - |
           cd kubecf-{{ $branch }}
           ./dev/build.sh ../output
-{{- if has $stable "build" }}
-    on_success:
-      put: status-{{ $branch }}.src
-      params:
-        << : *build_{{ $sanitized_branch_name }}_status
-        state: success
-    on_failure:
-      put: status-{{ $branch }}.src
-      params:
-        << : *build_{{ $sanitized_branch_name }}_status
-        state: failure
-{{- end }}
   - put: s3.kubecf-ci
     params:
       file: output/kubecf-v*.tgz
```
