### PR TITLE
Add uuid to the CI artifacts to make sure they are not overwritten, e…

### DIFF
--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -27,8 +27,8 @@ groups:
   {{ range $_, $job := $stable }}
   - {{ $job }}-{{ $branch }}
   {{ end }}
-  {{ if eq $branch "master" }}
-  - publish
+  {{ if not ($branch | regexp.Match "^pr|fork-pr") }}
+  - publish-{{ $branch }}
   {{ end }}
 - name: {{ $branch }}-experimental
   jobs:
@@ -372,6 +372,11 @@ jobs:
         - |
           cd kubecf-{{ $branch }}
           ./dev/build.sh ../output
+          timestamp=$(date +%s%3N)
+          for file in ../output/*.tgz; do
+              mv "$file" "${file%.tgz}-${timestamp}.tgz"
+          done
+
 {{- if has $stable "build" }}
     on_success:
       put: status-{{ $branch }}.src
@@ -1124,28 +1129,70 @@ jobs:
       config:
         <<: *cleanup-cluster
 
-{{ end }} # of branch
-
-- name: publish
+{{ if not ($branch | regexp.Match "^pr|fork-pr") }}
+- name: publish-{{ $branch }}
   public: true
   plan:
-  - get: kubecf-master
-    passed:
-    - cf-acceptance-tests-diego-master
-    # TODO: Uncomment as soon as eirini tests are green
-    # TODO: Does this work? It might check the wrong thing
-    # - cf-acceptance-tests-eirini
-    trigger: true
-    version: "every"
   - get: s3.kubecf-ci
     passed:
-    - cf-acceptance-tests-diego-master
+    - cf-acceptance-tests-diego-{{ $branch }}
+    trigger: true
+    version: "every"
   - get: s3.kubecf-ci-bundle
     passed:
-    - cf-acceptance-tests-diego-master
+    - cf-acceptance-tests-diego-{{ $branch }}
+    trigger: true
+    version: "every"
+  - task: rename-artifacts
+    config:
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: thulioassis/bazel-docker-image
+          tag: 2.0.0
+      inputs:
+      - name: s3.kubecf-ci
+      - name: s3.kubecf-ci-bundle
+      outputs:
+      - name: output
+      run:
+        path: "/bin/bash"
+        args:
+        - -ce
+        - |
+          # Revert to original name without the timestamp part
+          for file in s3.kubecf-ci*/*.tgz; do
+              new_filename=$(basename $file | sed  's/-[0-9]\+\.tgz/\.tgz/')
+              mv "$file" "output/${new_filename}"
+          done
+  - task: test-if-file-exists
+    config:
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: splatform/catapult
+      params:
+        S3_BUCKET: {{ if has . "s3_final_bucket" }}{{ .s3_final_bucket }}{{ else }}kubecf{{ end }}
+        AWS_ACCESS_KEY_ID: ((aws-access-key))
+        AWS_SECRET_ACCESS_KEY: ((aws-secret-key))
+      inputs:
+      - name: output
+      run:
+        path: "/bin/bash"
+        args:
+        - -ce
+        - |
+          # Make sure that tarballs do not exist on s3 yet
+          for file in output/*.tgz; do
+              aws s3 ls "s3://${S3_BUCKET}/$(basename $file)" && (echo "Tarball already exists on s3. Aborting."; exit 1);
+          done
   - put: s3.kubecf
     params:
-      file: s3.kubecf-ci/kubecf-v*.tgz
+      file: output/kubecf-v*.tgz
   - put: s3.kubecf-bundle
     params:
-      file: s3.kubecf-ci-bundle/kubecf-bundle-v*.tgz
+      file: output/kubecf-bundle-v*.tgz
+{{ end }} # of publish
+{{ end }} # of branch


### PR DESCRIPTION
…ver.

TODO:
  Add publish task at the end of the pipeline to remove the UUID and
  copy the file to S3 if it's not already there. If it exists then fail.

<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes #930 

## Motivation and Context

The pipeline should never rewrite the artifact of a previous build. Each build should use it's own artifact. See the linked issue for more.

## How Has This Been Tested?

TODO: Deployed the pipeline and tested it.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
