### PR TITLE
When suse_buildpacks are enabled (the default) use sle15 as the default stack

### DIFF
--- a/deploy/helm/kubecf/assets/operations/instance_groups/api.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/api.yaml
@@ -1,7 +1,4 @@
 {{- if .Values.features.suse_default_stack.enabled }}
-{{- if not .Values.features.suse_buildpacks.enabled }}
-{{- fail "feature.suse_buildpacks.enabled must be true when features.suse_default_stack.enabled is true" }}
-{{- end }}
 {{- $cc_jobs := list "cloud_controller_ng" }}
 {{- $cc_jobs = append $cc_jobs "cloud_controller_worker" }}
 {{- $cc_jobs = append $cc_jobs "cloud_controller_clock" }}
@@ -10,6 +7,9 @@
 - type: replace
    path: /instance_groups/name=api/jobs/name={{ $job }}/properties/cc/default_stack?
    value: sle15
+{{- end }}
+{{- if not .Values.features.suse_buildpacks.enabled }}
+{{- fail "feature.suse_buildpacks.enabled must be true when features.suse_default_stack.enabled is set" }}
 {{- end }}
 {{- end }}
 

--- a/deploy/helm/kubecf/assets/operations/instance_groups/api.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/api.yaml
@@ -1,18 +1,3 @@
-{{- if .Values.features.suse_default_stack.enabled }}
-{{- $cc_jobs := list "cloud_controller_ng" }}
-{{- $cc_jobs = append $cc_jobs "cloud_controller_worker" }}
-{{- $cc_jobs = append $cc_jobs "cloud_controller_clock" }}
-{{- $cc_jobs = append $cc_jobs "cc_deployment_updater" }}
-{{- range $job := $cc_jobs }}
-- type: replace
-   path: /instance_groups/name=api/jobs/name={{ $job }}/properties/cc/default_stack?
-   value: sle15
-{{- end }}
-{{- if not .Values.features.suse_buildpacks.enabled }}
-{{- fail "feature.suse_buildpacks.enabled must be true when features.suse_default_stack.enabled is set" }}
-{{- end }}
-{{- end }}
-
 {{- if .Values.features.suse_buildpacks.enabled }}
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/stacks/-

--- a/deploy/helm/kubecf/assets/operations/instance_groups/api.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/api.yaml
@@ -11,6 +11,10 @@
     buildpack/sle15: buildpack_app_lifecycle/buildpack_app_lifecycle.tgz
     buildpack/cflinuxfs3: buildpack_app_lifecycle/buildpack_app_lifecycle.tgz
     docker: docker_app_lifecycle/docker_app_lifecycle.tgz
+
+- type: replace
+  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/default_stack?
+  value: "sle15"
 {{- end }}
 
 {{- if .Values.testing.brain_tests.enabled}}

--- a/deploy/helm/kubecf/assets/operations/instance_groups/eirini-helm.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/eirini-helm.yaml
@@ -2,13 +2,13 @@
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/opi?/enabled?
   value: true
-# TODO(jandubois) This check is disabled until v2.3.0 for backwards compatibility reasons.
+# XXX This check is disabled until v2.3.0 for backwards compatibility reasons.
 # {{- if not .Values.features.suse_default_stack.enabled }}
 # {{- fail "feature.suse_default_stack.enabled must be true to use Eirini" }}
 # {{- end }}
-# TODO(jandubois) This check becomes redundant once the previous check is enabled because
-# TODO(jandubois) the api.yaml file already checks that suse_buildpacks are enabled when
-# TODO(jandubois) suse_default_stack is set.
+# XXX This check becomes redundant once the previous check is enabled because
+# XXX the api.yaml file already checks that suse_buildpacks are enabled when
+# XXX suse_default_stack is set.
 {{- if not .Values.features.suse_buildpacks.enabled }}
 {{- fail "feature.suse_buildpacks.enabled must be true to use Eirini" }}
 {{- end }}

--- a/deploy/helm/kubecf/assets/operations/instance_groups/eirini-helm.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/eirini-helm.yaml
@@ -2,16 +2,6 @@
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/opi?/enabled?
   value: true
-# XXX This check is disabled until v2.3.0 for backwards compatibility reasons.
-# {{- if not .Values.features.suse_default_stack.enabled }}
-# {{- fail "feature.suse_default_stack.enabled must be true to use Eirini" }}
-# {{- end }}
-# XXX This check becomes redundant once the previous check is enabled because
-# XXX the api.yaml file already checks that suse_buildpacks are enabled when
-# XXX suse_default_stack is set.
-{{- if not .Values.features.suse_buildpacks.enabled }}
-{{- fail "feature.suse_buildpacks.enabled must be true to use Eirini" }}
-{{- end }}
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/default_stack?
   value: "sle15"

--- a/deploy/helm/kubecf/values.yaml
+++ b/deploy/helm/kubecf/values.yaml
@@ -237,7 +237,6 @@ settings:
 
 features:
   eirini:
-    # When eirini is enabled, both suse_default_stack and suse_buildpacks must be enabled as well.
     enabled: false
     registry:
       service:
@@ -250,8 +249,6 @@ features:
       key: ~
     annotations: {}
     labels: {}
-  suse_default_stack:
-    enabled: false
   suse_buildpacks:
     enabled: true
   autoscaler:


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Right now the default stack for diego is cflinuxfs3. For Eirini we already change to sle15 (https://github.com/cloudfoundry-incubator/kubecf/blob/master/deploy/helm/kubecf/assets/operations/instance_groups/eirini-helm.yaml#L6)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Consistency

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- An important detail to include is the version of the used cf-operator -->
Deploy with default values and test what the default stack is.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
