### PR TITLE
Fix the path of the suse java buildpack

### DIFF
--- a/deploy/helm/kubecf/values.yaml
+++ b/deploy/helm/kubecf/values.yaml
@@ -82,7 +82,7 @@ releases:
     stemcell:
       os: SLE_15_SP1
       version: 25.1-7.0.0_374.gb8e8e6af
-    file: suse-java-buildpack/packages/java-buildpack-sle15/java-buildpack-v4.30.0.1-3f9ee273.zip
+    file: suse-java-buildpack/packages/java-buildpack-sle15/java-buildpack-sle15-v4.30.0.1-3f9ee273.zip
   suse-ruby-buildpack:
     url: registry.suse.com/cap-staging
     version: "1.8.15.1"


### PR DESCRIPTION
automation broke it here: https://github.com/cloudfoundry-incubator/kubecf/commit/34bae8ae1

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The java buildpack for sle15 stack is missing when you deploy. The reason is the wrong path to the buildpack file.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- An important detail to include is the version of the used cf-operator -->



## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
