### PR TITLE
persi-nfs support

### DIFF
--- a/bosh/releases/pre_render_scripts/diego-cell/mapfs/bpm/patch_bpm-config.sh
+++ b/bosh/releases/pre_render_scripts/diego-cell/mapfs/bpm/patch_bpm-config.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+function patch() {
+    local target="${1}"
+    local sentinel="${1}.patch_sentinel"
+    if [[ -r "${sentinel}" ]]; then
+        if sha256sum --check "${sentinel}" ; then
+            echo "Patch already applied. Skipping ${target}"
+            return 0
+        fi
+        echo "Sentinel mismatch, re-patching ${target}"
+    fi
+    command patch --verbose --batch --strip=1 "${target}" # << STDIN
+}
+
+patch "/var/vcap/all-releases/jobs-src/mapfs/mapfs/job.MF" <<"EOP"
+diff --git a/jobs/mapfs/spec b/jobs/mapfs/spec
+index 65cbf0f..1f25355 100644
+--- a/jobs/mapfs/spec
++++ b/jobs/mapfs/spec
+@@ -3,6 +3,7 @@ name: mapfs
+ 
+ templates:
+   install.erb: bin/pre-start
++  bpm.yml.erb: config/bpm.yml
+ 
+ packages:
+ - mapfs
+EOP
+
+cat > "/var/vcap/all-releases/jobs-src/mapfs/mapfs/templates/bpm.yml.erb" <<"EOF"
+processes:
+  - name: mapfs
+    executable: /bin/sh
+    args:
+    - -c
+    - >
+      echo "Sleeping forever; mapfs only runs as pre-start" ;
+      while true ; do
+      sleep 365d ;
+      done
+hooks:
+  pre_start: /var/vcap/jobs/mapfs/bin/pre-start
+EOF

--- a/bosh/releases/pre_render_scripts/diego-cell/mapfs/bpm/patch_pre-start.sh
+++ b/bosh/releases/pre_render_scripts/diego-cell/mapfs/bpm/patch_pre-start.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+function patch() {
+    local target="${1}"
+    local sentinel="${1}.patch_sentinel"
+    if [[ -r "${sentinel}" ]]; then
+        if sha256sum --check "${sentinel}" ; then
+            echo "Patch already applied. Skipping ${target}"
+            return 0
+        fi
+        echo "Sentinel mismatch, re-patching ${target}"
+    fi
+    command patch --verbose --batch --strip=1 "${target}" # << STDIN
+}
+
+patch "/var/vcap/all-releases/jobs-src/mapfs/mapfs/templates/install.erb" <<"EOP"
+diff --git a/jobs/mapfs/templates/install.erb b/jobs/mapfs/templates/install.erb
+index dade2b9..885cb84 100644
+--- a/jobs/mapfs/templates/install.erb
++++ b/jobs/mapfs/templates/install.erb
+@@ -52,9 +52,12 @@ user_allow_other
+ EOF
+ chmod 644 /etc/fuse.conf
+ 
++<% end %>
++
+ echo "Installing mapfs"
+ 
+ chown root:vcap /var/vcap/packages/mapfs/bin/mapfs
+ chmod 750 /var/vcap/packages/mapfs/bin/mapfs
+ chmod u+s /var/vcap/packages/mapfs/bin/mapfs
+-<% end %>
+\ No newline at end of file
++
++cp /var/vcap/packages/mapfs/bin/mapfs /var/vcap/jobs/mapfs/bin/mapfs
+EOP

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -134,10 +134,11 @@ bazel_libs:
 
       files = [
           "cf-deployment.yml",
+          "operations/bits-service/configure-bits-service-s3.yml",
           "operations/bits-service/use-bits-service.yml",
+          "operations/enable-nfs-volume-service.yml",
           "operations/use-external-blobstore.yml",
           "operations/use-s3-blobstore.yml",
-          "operations/bits-service/configure-bits-service-s3.yml",
       ]
 
       filegroup(

--- a/deploy/helm/kubecf/assets/operations/instance_groups/diego-cell.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/diego-cell.yaml
@@ -224,16 +224,15 @@
   path: /instance_groups/name=diego-cell/jobs/name=garden/properties?/garden?/disable_swap_limit?
   value: true
 
-{{- if .Values.features.suse_buildpacks.enabled }}
-{{- range $bytes := .Files.Glob "assets/operations/pre_render_scripts/diego-cell_*" }}
-{{ $bytes | toString }}
-{{- end }}
-{{- else }}
-{{- range $path, $bytes := .Files.Glob "assets/operations/pre_render_scripts/diego-cell_*" }}
-{{- if not (regexMatch "diego-cell_sle15-rootfs-setup" $path) }}
-{{ $bytes | toString }}
-{{- end }}
-{{- end }}
-{{- end }}
+{{ range $path, $bytes := .Files.Glob "assets/operations/pre_render_scripts/diego-cell_*" }}
+  {{- if contains "/diego-cell_sle15-rootfs-setup" $path }}
+    # sle15-rootfs-setup is only used when using SUSE buildpacks
+    {{- if $.Values.features.suse_buildpacks.enabled }}
+      {{- "\n" }}{{ $bytes | toString }}
+    {{- end }}
+  {{- else }}
+    {{- "\n" }}{{ $bytes | toString }}
+  {{- end }}
+{{ end }}
 
 {{- end }}

--- a/deploy/helm/kubecf/assets/operations/instance_groups/diego-cell.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/diego-cell.yaml
@@ -230,6 +230,10 @@
     {{- if $.Values.features.suse_buildpacks.enabled }}
       {{- "\n" }}{{ $bytes | toString }}
     {{- end }}
+  {{- else if contains "/diego-cell_mapfs" $path }}
+    # mapfs is only used when persi-nfs is enabled; however, this will be
+    # clobbered in `nfs-broker-push.yaml` where we apply
+    # "assets/enable-nfs-volume-service.yml", so skip it for now.
   {{- else }}
     {{- "\n" }}{{ $bytes | toString }}
   {{- end }}

--- a/deploy/helm/kubecf/assets/operations/instance_groups/nfs-broker-push.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/nfs-broker-push.yaml
@@ -29,7 +29,12 @@
   path: /instance_groups/name=nfs-broker-push/jobs/name=nfsbrokerpush/properties/nfsbrokerpush/db/host
   value: {{ printf "database.%s" .Release.Namespace }}
 
-# Disable the logs container for the errand
+# Make it an auto-errand
+- type: replace
+  path: /instance_groups/name=nfs-broker-push/lifecycle?
+  value: auto-errand
+
+  # Disable the logs container for the errand
 - type: replace
   path: /instance_groups/name=nfs-broker-push/env?/bosh/agent/settings/disable_log_sidecar
   value: true

--- a/deploy/helm/kubecf/assets/operations/instance_groups/nfs-broker-push.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/nfs-broker-push.yaml
@@ -1,0 +1,57 @@
+{{- if index .Values.features "persi-nfs" "enabled" }}
+# Ops file to enable persi-nfs, most notably the "nfs-broker-push" errand
+
+{{- if index .Values.features "eirini" "enabled "}}
+{{- fail "persi-nfs is not supported with eirini enabled." }}
+{{- end }}
+
+# Need to add the database role back in to get patched
+- type: replace
+  path: /instance_groups/-
+  value:
+    name: database
+    jobs:
+    - name: pxc-mysql
+      properties:
+        seeded_databases: []
+
+{{ .Files.Get "assets/enable-nfs-volume-service.yml" }}
+
+# Remove the database instance group we added
+- type: remove
+  path: /instance_groups/name=database
+
+# Fix database access to use external PXC
+- type: replace
+  path: /instance_groups/name=nfs-broker-push/jobs/name=nfsbrokerpush/properties/nfsbrokerpush/db/ca_cert
+  value: ((pxc_tls.ca))
+- type: replace
+  path: /instance_groups/name=nfs-broker-push/jobs/name=nfsbrokerpush/properties/nfsbrokerpush/db/host
+  value: {{ printf "database.%s" .Release.Namespace }}
+
+# Disable the logs container for the errand
+- type: replace
+  path: /instance_groups/name=nfs-broker-push/env?/bosh/agent/settings/disable_log_sidecar
+  value: true
+
+# Disable most of mapfs installation
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=mapfs/properties?/disable
+  value: true
+# Put mapfs in the correct place
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=mapfs/properties?/path
+  value: /var/vcap/jobs/mapfs/bin/mapfs
+
+# Apply mapfs pre-render script
+{{- range .Files.Glob "assets/operations/pre_render_scripts/diego-cell_mapfs_*" }}
+{{ . | toString }}
+{{- end }}
+
+# Using co-located jobs doesn't really help us (as we don't share the packages
+# directory); remove the co-located cf-cli-6-linux job, and add the package into
+# the nfs-broker-push job instead.
+- type: remove
+  path: /instance_groups/name=nfs-broker-push/jobs/name=cf-cli-6-linux
+
+{{- end }}

--- a/deploy/helm/kubecf/assets/operations/releases.yaml
+++ b/deploy/helm/kubecf/assets/operations/releases.yaml
@@ -12,9 +12,6 @@
 {{- $releases = append $releases "cf-smoke-tests" }}
 {{- $releases = append $releases "cf-syslog-drain" }}
 {{- $releases = append $releases "cflinuxfs3" }}
-{{- if .Values.features.credhub.enabled }}
-  {{- $releases = append $releases "credhub" }}
-{{- end }}
 {{- $releases = append $releases "diego" }}
 {{- $releases = append $releases "dotnet-core-buildpack" }}
 {{- $releases = append $releases "garden-runc" }}
@@ -44,6 +41,10 @@
   path: /releases/-
   value:
     name: cf-acceptance-tests
+{{- end }}
+
+{{- if .Values.features.credhub.enabled }}
+  {{- $releases = append $releases "credhub" }}
 {{- end }}
 
 {{- if .Values.testing.brain_tests.enabled }}

--- a/deploy/helm/kubecf/assets/operations/releases.yaml
+++ b/deploy/helm/kubecf/assets/operations/releases.yaml
@@ -79,6 +79,11 @@
     name: postgres
 {{- end }}
 
+{{- if index .Values.features "persi-nfs" "enabled" }}
+  {{- $releases = append $releases "nfs-volume" }}
+  {{- $releases = append $releases "mapfs" }}
+{{- end }}
+
 # Loop over the releases, replacing the url and stemcell, and the version when appropriate.
 {{- range $release := $releases }}
 - type: replace

--- a/deploy/helm/kubecf/templates/database.yaml
+++ b/deploy/helm/kubecf/templates/database.yaml
@@ -343,6 +343,10 @@ spec:
 {{- $databases = append $databases (dict "name" "credhub" "path" "credhub" "secretName" "credhub") }}
 {{- end }}
 
+{{- if index .Values.features "persi-nfs" "enabled" }}
+{{- $databases = append $databases (dict "name" "nfs-broker" "path" "nfs-broker" "secretName" "nfs-broker") }}
+{{- end }}
+
 {{- if .Values.features.routing_api.enabled }}
 {{- $databases = append $databases (dict "name" "routing-api" "path" "routing-api" "secretName" "routing-api") }}
 {{- end }}

--- a/deploy/helm/kubecf/values.yaml
+++ b/deploy/helm/kubecf/values.yaml
@@ -316,6 +316,12 @@ features:
         name: credhub
         password: ~
         username: ~
+  persi-nfs:
+    # If enabled, we will be able to mount existing NFS volumes into diego-based
+    # containers as an extra volume.  Requires manually triggering the nfs
+    # broker push quarks job after deployment.  Not compatible with eirini-based
+    # deployments.
+    enabled: false
 
 # Enable or disable instance groups for the different test suites.
 # Only smoke tests should be run in production environments.


### PR DESCRIPTION
## Description
This adds preliminary support for persi-nfs when using diego.
Note that this is **not** ready for merging; it depends on:
- Resolution of https://github.com/cloudfoundry-incubator/quarks-operator/issues/963
- Resolution of https://github.com/SUSE/nfs-volume-release/pull/1
- Adding nfs-volume & mapfs release images to CI
- Updating this branch to contain all of ↑

## Motivation and Context
Fixes #382

## How Has This Been Tested?
Locally deployed with release overrides + custom cf-operator.
Will need to create & bind a service with broker `nfs-export` plan `nfs-kernel` with a config that is something like `"{\"share\": \"$(minikube ip)/data/export\"}"`. (Note lack of `:` between host and export path.)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
