### PR TITLE
CI: fix filename for suse-java-buildpack.

### DIFF
--- a/.concourse/suse-buildpacks-ci/buildpack-version-bump/pipeline.yaml.gomplate
+++ b/.concourse/suse-buildpacks-ci/buildpack-version-bump/pipeline.yaml.gomplate
@@ -43,7 +43,7 @@ resources:
   source:
     owner: SUSE
     repository: {{ $release.repo }}
-    access_token: ((github-access-token-pr))
+    access_token: ((github-access-token))
 
 - name: suse-final-release-{{ $release.name }}
   type: s3
@@ -90,7 +90,7 @@ jobs:
         suse_final_release: suse-final-release-{{ $release.name }}
         built_image: built_image
       params:
-        GITHUB_TOKEN: ((github-access-token-pr))
+        GITHUB_TOKEN: ((github-access-token))
         GITHUB_PRIVATE_KEY: ((github-private-key))
         GIT_MAIL: {{ $root.git_mail }}
         GIT_USER: {{ $root.git_user }}

--- a/.concourse/suse-buildpacks-ci/buildpack-version-bump/tasks/create_pr.sh
+++ b/.concourse/suse-buildpacks-ci/buildpack-version-bump/tasks/create_pr.sh
@@ -33,8 +33,17 @@ def represent_none(self, data):
 
 # Replaces the filename at the end of the original 'file'.
 def get_new_filename():
+    # we cant rely on java buildpack package for retrieving filename since its packaging is different.
+    # this bit will take care of inserting sle15 in file name.
+    # see: https://github.com/SUSE/cf-java-buildpack-release/blob/master/packages/java-buildpack-sle15/packaging
+    if "${BUILDPACK_NAME}" == "suse-java-buildpack":
+        new_file_name = "${NEW_FILE_NAME}".split("-")
+        new_file_name.insert(2,"sle15")
+        new_file_name = "-".join(new_file_name)
+    else:
+        new_file_name = "${NEW_FILE_NAME}"
     new_file = values['releases']["${BUILDPACK_NAME}"]['file'].split("/")[:3]
-    new_file.append("${NEW_FILE_NAME}")
+    new_file.append(new_file_name)
     return "/".join(new_file)
 
 def get_semver(s):

--- a/.concourse/suse-buildpacks-ci/stemcell-version-bump/pipeline.yaml.gomplate
+++ b/.concourse/suse-buildpacks-ci/stemcell-version-bump/pipeline.yaml.gomplate
@@ -75,7 +75,7 @@ jobs:
         s3.stemcell-version: s3.fissile-stemcell-version
       params:
         STEMCELL_VERSIONED_FILE: {{ .stemcell_version_file }}
-        GITHUB_TOKEN: ((github-access-token-pr))
+        GITHUB_TOKEN: ((github-access-token))
         GITHUB_PRIVATE_KEY: ((github-private-key))
         GIT_MAIL: {{ .git_mail }}
         GIT_USER: {{ .git_user }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds an exception for `filepath` of `suse-java-buildpack` while bumping its release image. Since [packaging](https://github.com/SUSE/cf-java-buildpack-release/blob/master/packages/java-buildpack-sle15/packaging) for java buildpack is different from others, we can't simply rely on filepaths from the buildpack package.

Also see: https://github.com/cloudfoundry-incubator/kubecf/pull/952

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This creates a problem while bumping buildpacks and creates a commit like this https://github.com/cloudfoundry-incubator/kubecf/pull/851/files which is wrong.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- An important detail to include is the version of the used cf-operator -->
https://concourse.suse.dev/

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
