### PR TITLE
fix: image_list.rb only needs to check 2 feature combinations

### DIFF
--- a/rules/kubecf/image_list.tmpl.rb
+++ b/rules/kubecf/image_list.tmpl.rb
@@ -251,10 +251,12 @@ class ConfigMap < Resource
   end
 end
 
-# Create all permutations for enabling and disabling the features.
+# Running through all permutations takes very long, and makes it impractical to
+# add additional feature flags. Some flag combinations also could throw errors.
+# So far running with features either all enabled or all disabled generates
+# the complete set of used images and is nearly instantaneous.
 features = values['features'].keys
-permutations = [true, false].repeated_permutation(features.size)
-                            .map { |v| features.zip(v).to_h }
+permutations = [ features.to_h{ |x| [x, false] }, features.to_h{ |x| [x, true] } ]
 
 # Iterate over all permutations, rendering the chart to obtain all possible
 # images.

--- a/rules/kubecf/image_list.tmpl.rb
+++ b/rules/kubecf/image_list.tmpl.rb
@@ -256,7 +256,7 @@ end
 # So far running with features either all enabled or all disabled generates
 # the complete set of used images and is nearly instantaneous.
 features = values['features'].keys
-permutations = [ features.to_h{ |x| [x, false] }, features.to_h{ |x| [x, true] } ]
+permutations = [ features.map{ |x| [x, false] }.to_h, features.map{ |x| [x, true] }.to_h ]
 
 # Iterate over all permutations, rendering the chart to obtain all possible
 # images.


### PR DESCRIPTION
The script already takes almost 10 minutes to run, and runtime will scale exponentially as more feature flags are added. Testing shows that all possible image names are detected by just expanding the templates twice: once with all features disabled, and once with all of them enabled.

Future changes are also expected to throw errors for certain feature combinations, which the current code also doesn't deal with.
