### PR TITLE
update autoscaler to 3.0.1 and add mysql support 

### DIFF
--- a/deploy/helm/kubecf/assets/operations/azs.yaml
+++ b/deploy/helm/kubecf/assets/operations/azs.yaml
@@ -41,8 +41,10 @@
 {{- end }}
 
 {{- if .Values.features.autoscaler.enabled }}
+{{- if not .Values.features.autoscaler.mysql.enabled }}
 - type: remove
   path: /instance_groups/name=asdatabase/azs?
+{{- end }}
 - type: remove
   path: /instance_groups/name=asactors/azs?
 - type: remove

--- a/deploy/helm/kubecf/assets/operations/instance_groups/database.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/database.yaml
@@ -117,6 +117,81 @@
   path: /instance_groups/name=diego-api/jobs/name=silk-controller/properties/database/ca_cert?
   value: *pxc-cluster-ca
 
+{{- if .Values.features.autoscaler.enabled }}
+{{- if .Values.features.autoscaler.mysql.enabled }}
+- type: remove
+  path: /instance_groups/name=asdatabase
+- type: replace
+  path: /instance_groups/name=asactors/jobs/name=scalingengine/properties/autoscaler/scalingengine_db
+  value: &autoscaler_database
+    sslmode: &sslmode "verify-ca"
+    tls:
+      ca: *pxc-cluster-ca
+    databases:
+    - name: autoscaler
+      tag: default
+    address: *pxc-cluster-address
+    db_scheme: mysql
+    port: 3306
+    roles:
+    - name: autoscaler
+      password: ((autoscaler_database_password))
+      tag: default
+- type: replace
+  path: /instance_groups/name=asactors/jobs/name=scalingengine/properties/autoscaler/scheduler_db
+  value: *autoscaler_database
+- type: replace
+  path: /instance_groups/name=asactors/jobs/name=scalingengine/properties/autoscaler/policy_db
+  value: *autoscaler_database
+- type: replace
+  path: /instance_groups/name=asactors/jobs/name=scheduler/properties/autoscaler/policy_db
+  value: *autoscaler_database
+- type: replace
+  path: /instance_groups/name=asactors/jobs/name=scheduler/properties/autoscaler/scheduler_db
+  value: *autoscaler_database
+- type: replace
+  path: /instance_groups/name=asactors/jobs/name=operator/properties/autoscaler/policy_db
+  value: *autoscaler_database
+- type: replace
+  path: /instance_groups/name=asactors/jobs/name=operator/properties/autoscaler/appmetrics_db
+  value: *autoscaler_database
+- type: replace
+  path: /instance_groups/name=asactors/jobs/name=operator/properties/autoscaler/instancemetrics_db
+  value: *autoscaler_database
+- type: replace
+  path: /instance_groups/name=asactors/jobs/name=operator/properties/autoscaler/scalingengine_db
+  value: *autoscaler_database
+- type: replace
+  path: /instance_groups/name=asactors/jobs/name=operator/properties/autoscaler/lock_db
+  value: *autoscaler_database
+- type: replace
+  path: /instance_groups/name=asmetrics/jobs/name=metricsserver/properties/autoscaler/instancemetrics_db
+  value: *autoscaler_database
+- type: replace
+  path: /instance_groups/name=asmetrics/jobs/name=metricsserver/properties/autoscaler/policy_db
+  value: *autoscaler_database
+- type: replace
+  path: /instance_groups/name=asmetrics/jobs/name=eventgenerator/properties/autoscaler/appmetrics_db
+  value: *autoscaler_database
+- type: replace
+  path: /instance_groups/name=asmetrics/jobs/name=eventgenerator/properties/autoscaler/policy_db
+  value: *autoscaler_database
+- type: replace
+  path: /instance_groups/name=asnozzle/jobs/name=metricsgateway/properties/autoscaler/policy_db
+  value: *autoscaler_database
+- type: replace
+  path: /instance_groups/name=asapi/jobs/name=golangapiserver/properties/autoscaler/policy_db
+  value: *autoscaler_database
+- type: replace
+  path: /instance_groups/name=asapi/jobs/name=golangapiserver/properties/autoscaler/binding_db
+  value: *autoscaler_database
+- type: replace
+  path: /instance_groups/name=asapi/jobs/name=metricsforwarder/properties/autoscaler/policy_db
+  value: *autoscaler_database
+{{- end }}
+{{- end }}
+
+
 {{- else }}
 
 # Remove the database variables.
@@ -497,3 +572,4 @@
 {{- end }}
 
 {{- end }}
+

--- a/deploy/helm/kubecf/templates/database.yaml
+++ b/deploy/helm/kubecf/templates/database.yaml
@@ -347,6 +347,12 @@ spec:
 {{- $databases = append $databases (dict "name" "routing-api" "path" "routing-api" "secretName" "routing-api") }}
 {{- end }}
 
+{{- if .Values.features.autoscaler.enabled }}
+{{- if .Values.features.autoscaler.mysql.enabled }}
+{{- $databases = append $databases (dict "name" "autoscaler" "path" "autoscaler" "secretName" "autoscaler") }}
+{{- end }}
+{{- end }}
+
 apiVersion: quarks.cloudfoundry.org/v1alpha1
 kind: QuarksJob
 metadata:
@@ -473,3 +479,4 @@ spec:
           restartPolicy: Never
 
 {{- end }}
+

--- a/deploy/helm/kubecf/values.yaml
+++ b/deploy/helm/kubecf/values.yaml
@@ -35,7 +35,7 @@ releases:
       os: SLE_15_SP1
       version: 23.21-7.0.0_374.gb8e8e6af
   app-autoscaler:
-    version: 3.0.0
+    version: 3.0.1
   bits-service:
     version: 2.28.0
   brain-tests:
@@ -253,6 +253,8 @@ features:
     enabled: true
   autoscaler:
     enabled: false
+    mysql:
+      enabled: false
   credhub:
     enabled: true
   # Disabling routing_api will also disable the tcp_router instance_group

--- a/deploy/helm/kubecf/values.yaml
+++ b/deploy/helm/kubecf/values.yaml
@@ -36,6 +36,9 @@ releases:
       version: 23.21-7.0.0_374.gb8e8e6af
   app-autoscaler:
     version: 3.0.1
+    stemcell:
+      os: SLE_15_SP1
+      version: 26.3-7.0.0_374.gb8e8e6af
   bits-service:
     version: 2.28.0
   brain-tests:


### PR DESCRIPTION


App Autoscaler released a new version 3.0.1 https://bosh.io/releases/github.com/cloudfoundry-incubator/app-autoscaler-release?all=1. This new release can use both Postgres and MySQL as database.  

## Description
This changes changes to the new version 3.0.1 and can choose embedded_database of cf deployment as database.

## Motivation and Context
To support the new Autoscaler 3.0.1 release.

## How Has This Been Tested?
Test manually in the minikube. 

cf-operator:v4.5.6-0.gffc6f942

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
