### PR TITLE
Trigger the cleanup on the semver.gke_cluster resource

### DIFF
--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -1092,6 +1092,10 @@ jobs:
     - {{ $previousTest | quote }}
     trigger: true
     version: "every"
+  - get: semver.gke-cluster
+    passed:
+    - {{ $previousTest | quote }}
+    trigger: true
   ensure:
    do:
    - task: cleanup-cluster


### PR DESCRIPTION
to make sure the cleanup triggers when the pipeline is started by a
manual trigger of a job.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Concourse won't trigger jobs if an intput hasn't changed. When we retrigger a job we need to rely on a "new" version of some resource for the following jobs to start. We did that for other jobs but the cleanup was forgotten. This left clusters behind. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- An important detail to include is the version of the used cf-operator -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
