### PR TITLE
Fix CLBO in autoscaler after transient failure to connect to UAA

### DIFF
--- a/bosh/releases/pre_render_scripts/asactors/operator/jobs/patch_operator_ctl.sh
+++ b/bosh/releases/pre_render_scripts/asactors/operator/jobs/patch_operator_ctl.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset
+
+target="/var/vcap/all-releases/jobs-src/app-autoscaler/operator/templates/operator_ctl"
+sentinel="${target}.patch_sentinel"
+if [[ -f "${sentinel}" ]]; then
+  if sha256sum --check "${sentinel}" ; then
+    echo "Patch already applied. Skipping"
+    exit 0
+  fi
+  echo "Sentinel mismatch, re-patching"
+fi
+
+sed -i "s/pid_guard/#pid_guard/g" "${target}"
+
+sha256sum "${target}" > "${sentinel}"

--- a/bosh/releases/pre_render_scripts/asactors/scalingengine/jobs/patch_scalingengine_ctl.sh
+++ b/bosh/releases/pre_render_scripts/asactors/scalingengine/jobs/patch_scalingengine_ctl.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset
+
+target="/var/vcap/all-releases/jobs-src/app-autoscaler/scalingengine/templates/scalingengine_ctl"
+sentinel="${target}.patch_sentinel"
+if [[ -f "${sentinel}" ]]; then
+  if sha256sum --check "${sentinel}" ; then
+    echo "Patch already applied. Skipping"
+    exit 0
+  fi
+  echo "Sentinel mismatch, re-patching"
+fi
+
+sed -i "s/pid_guard/#pid_guard/g" "${target}"
+
+sha256sum "${target}" > "${sentinel}"

--- a/deploy/helm/kubecf/assets/operations/instance_groups/app-autoscaler.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/app-autoscaler.yaml
@@ -1005,4 +1005,8 @@
 {{ $bytes | toString }}
 {{- end }}
 
+{{- range $bytes := .Files.Glob "assets/operations/pre_render_scripts/asactors_*" }}
+{{ $bytes | toString }}
+{{- end }}
+
 {{- end }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added autoscaler patches to render `pid_guard` in scalingengine and operator inert.

Prevents a platform from failing to properly restart these jobs at container level after a transient failure (uaa connectivity, for example) due to the new pid for the control/main process being the same as in the failed container, and thus aborting the restart in the mistaken belief of the previous process still running (while actually looking at the new process).

A side change is an extension of the `klog.sh` tool with a new option `-r` to retrieve not just logs from a CF cluster, but also the rendered scripts and configuration files.

## Motivation and Context

See #928 

## How Has This Been Tested?

Manually via catapult, see ticket comment https://github.com/cloudfoundry-incubator/kubecf/issues/928#issuecomment-634309394 Main difference from the reproduction is the source of the bundle containing the patched chart. This was generated via `bazel build //deploy/bundle:kubecf-bundle` and catapult then pointed to this new chart.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
