### PR TITLE
Make cfdot available in a properly shared location.

### DIFF
--- a/bosh/releases/pre_render_scripts/diego-api/cfdot/jobs/patch_pre-start.sh
+++ b/bosh/releases/pre_render_scripts/diego-api/cfdot/jobs/patch_pre-start.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+##
+# ATTENTION: This is part of a set of six interconnected patches.
+#            Two files spread over three instance groups.
+# See
+# - bosh/releases/pre_render_scripts/diego-cell/cfdot/jobs
+# - bosh/releases/pre_render_scripts/diego-api/cfdot/jobs
+# - bosh/releases/pre_render_scripts/scheduler/cfdot/jobs
+
+set -o errexit -o nounset
+
+target="/var/vcap/all-releases/jobs-src/diego/cfdot/templates/pre-start.erb"
+sentinel="${target}.patch_sentinel"
+if [[ -f "${sentinel}" ]]; then
+  if sha256sum --check "${sentinel}" ; then
+    echo "Patch already applied. Skipping"
+    exit 0
+  fi
+  echo "Sentinel mismatch, re-patching"
+fi
+
+# Place the cfdot related things into a location shared by all the jobs.
+##
+# Implementation note: Given the small size of the pre-start script a
+# patch is likely as large, or even larger than just the replacement
+# script, we simply do the latter.
+cat > "${target}" <<'EOT'
+#!/bin/bash -e
+
+DEST=/var/vcap/data/cfdot/bin
+mkdir -p "${DEST}"
+
+cp /var/vcap/jobs/cfdot/bin/setup     "${DEST}/cfdot.sh"
+cp /var/vcap/packages/cfdot/bin/cfdot "${DEST}/cfdot"
+chown root:vcap "${DEST}/cfdot.sh"
+EOT
+
+sha256sum "${target}" > "${sentinel}"

--- a/bosh/releases/pre_render_scripts/diego-api/cfdot/jobs/patch_setup.sh
+++ b/bosh/releases/pre_render_scripts/diego-api/cfdot/jobs/patch_setup.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+##
+# ATTENTION: This is part of a set of six interconnected patches.
+#            Two files spread over three instance groups.
+# See
+# - bosh/releases/pre_render_scripts/diego-cell/cfdot/jobs
+# - bosh/releases/pre_render_scripts/diego-api/cfdot/jobs
+# - bosh/releases/pre_render_scripts/scheduler/cfdot/jobs
+
+set -o errexit -o nounset
+
+target="/var/vcap/all-releases/jobs-src/diego/cfdot/templates/setup.erb"
+sentinel="${target}.patch_sentinel"
+if [[ -f "${sentinel}" ]]; then
+  if sha256sum --check "${sentinel}" ; then
+    echo "Patch already applied. Skipping"
+    exit 0
+  fi
+  echo "Sentinel mismatch, re-patching"
+fi
+
+# Look for cfdot in the new, shared location.
+sed -i "s|PATH=/var/vcap/packages|PATH=/var/vcap/data|g" "${target}"
+
+sha256sum "${target}" > "${sentinel}"

--- a/bosh/releases/pre_render_scripts/diego-cell/cfdot/jobs/patch_pre-start.sh
+++ b/bosh/releases/pre_render_scripts/diego-cell/cfdot/jobs/patch_pre-start.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+##
+# ATTENTION: This is part of a set of six interconnected patches.
+#            Two files spread over three instance groups.
+# See
+# - bosh/releases/pre_render_scripts/diego-cell/cfdot/jobs
+# - bosh/releases/pre_render_scripts/diego-api/cfdot/jobs
+# - bosh/releases/pre_render_scripts/scheduler/cfdot/jobs
+
+set -o errexit -o nounset
+
+target="/var/vcap/all-releases/jobs-src/diego/cfdot/templates/pre-start.erb"
+sentinel="${target}.patch_sentinel"
+if [[ -f "${sentinel}" ]]; then
+  if sha256sum --check "${sentinel}" ; then
+    echo "Patch already applied. Skipping"
+    exit 0
+  fi
+  echo "Sentinel mismatch, re-patching"
+fi
+
+# Place the cfdot related things into a location shared by all the jobs.
+##
+# Implementation note: Given the small size of the pre-start script a
+# patch is likely as large, or even larger than just the replacement
+# script, we simply do the latter.
+cat > "${target}" <<'EOT'
+#!/bin/bash -e
+
+DEST=/var/vcap/data/cfdot/bin
+mkdir -p "${DEST}"
+
+cp /var/vcap/jobs/cfdot/bin/setup     "${DEST}/cfdot.sh"
+cp /var/vcap/packages/cfdot/bin/cfdot "${DEST}/cfdot"
+chown root:vcap "${DEST}/cfdot.sh"
+EOT
+
+sha256sum "${target}" > "${sentinel}"

--- a/bosh/releases/pre_render_scripts/diego-cell/cfdot/jobs/patch_setup.sh
+++ b/bosh/releases/pre_render_scripts/diego-cell/cfdot/jobs/patch_setup.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+##
+# ATTENTION: This is part of a set of six interconnected patches.
+#            Two files spread over three instance groups.
+# See
+# - bosh/releases/pre_render_scripts/diego-cell/cfdot/jobs
+# - bosh/releases/pre_render_scripts/diego-api/cfdot/jobs
+# - bosh/releases/pre_render_scripts/scheduler/cfdot/jobs
+
+set -o errexit -o nounset
+
+target="/var/vcap/all-releases/jobs-src/diego/cfdot/templates/setup.erb"
+sentinel="${target}.patch_sentinel"
+if [[ -f "${sentinel}" ]]; then
+  if sha256sum --check "${sentinel}" ; then
+    echo "Patch already applied. Skipping"
+    exit 0
+  fi
+  echo "Sentinel mismatch, re-patching"
+fi
+
+# Look for cfdot in the new, shared location.
+sed -i "s|PATH=/var/vcap/packages|PATH=/var/vcap/data|g" "${target}"
+
+sha256sum "${target}" > "${sentinel}"

--- a/bosh/releases/pre_render_scripts/scheduler/cfdot/jobs/patch_pre-start.sh
+++ b/bosh/releases/pre_render_scripts/scheduler/cfdot/jobs/patch_pre-start.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+##
+# ATTENTION: This is part of a set of six interconnected patches.
+#            Two files spread over three instance groups.
+# See
+# - bosh/releases/pre_render_scripts/diego-cell/cfdot/jobs
+# - bosh/releases/pre_render_scripts/diego-api/cfdot/jobs
+# - bosh/releases/pre_render_scripts/scheduler/cfdot/jobs
+
+set -o errexit -o nounset
+
+target="/var/vcap/all-releases/jobs-src/diego/cfdot/templates/pre-start.erb"
+sentinel="${target}.patch_sentinel"
+if [[ -f "${sentinel}" ]]; then
+  if sha256sum --check "${sentinel}" ; then
+    echo "Patch already applied. Skipping"
+    exit 0
+  fi
+  echo "Sentinel mismatch, re-patching"
+fi
+
+# Place the cfdot related things into a location shared by all the jobs.
+##
+# Implementation note: Given the small size of the pre-start script a
+# patch is likely as large, or even larger than just the replacement
+# script, we simply do the latter.
+cat > "${target}" <<'EOT'
+#!/bin/bash -e
+
+DEST=/var/vcap/data/cfdot/bin
+mkdir -p "${DEST}"
+
+cp /var/vcap/jobs/cfdot/bin/setup     "${DEST}/cfdot.sh"
+cp /var/vcap/packages/cfdot/bin/cfdot "${DEST}/cfdot"
+chown root:vcap "${DEST}/cfdot.sh"
+EOT
+
+sha256sum "${target}" > "${sentinel}"

--- a/bosh/releases/pre_render_scripts/scheduler/cfdot/jobs/patch_setup.sh
+++ b/bosh/releases/pre_render_scripts/scheduler/cfdot/jobs/patch_setup.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+##
+# ATTENTION: This is part of a set of six interconnected patches.
+#            Two files spread over three instance groups.
+# See
+# - bosh/releases/pre_render_scripts/diego-cell/cfdot/jobs
+# - bosh/releases/pre_render_scripts/diego-api/cfdot/jobs
+# - bosh/releases/pre_render_scripts/scheduler/cfdot/jobs
+
+set -o errexit -o nounset
+
+target="/var/vcap/all-releases/jobs-src/diego/cfdot/templates/setup.erb"
+sentinel="${target}.patch_sentinel"
+if [[ -f "${sentinel}" ]]; then
+  if sha256sum --check "${sentinel}" ; then
+    echo "Patch already applied. Skipping"
+    exit 0
+  fi
+  echo "Sentinel mismatch, re-patching"
+fi
+
+# Look for cfdot in the new, shared location.
+sed -i "s|PATH=/var/vcap/packages|PATH=/var/vcap/data|g" "${target}"
+
+sha256sum "${target}" > "${sentinel}"

--- a/deploy/helm/kubecf/assets/operations/instance_groups/diego-cell.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/diego-cell.yaml
@@ -225,10 +225,12 @@
   value: true
 
 {{- if .Values.features.suse_buildpacks.enabled }}
+# For SUSE buildpacks take all patches
 {{- range $bytes := .Files.Glob "assets/operations/pre_render_scripts/diego-cell_*" }}
 {{ $bytes | toString }}
 {{- end }}
 {{- else }}
+# Without SUSE buildpacks, exclude the SLE15 patch and rootfs
 {{- range $path, $bytes := .Files.Glob "assets/operations/pre_render_scripts/diego-cell_*" }}
 {{- if not (regexMatch "diego-cell_sle15-rootfs-setup" $path) }}
 {{ $bytes | toString }}


### PR DESCRIPTION
## Description

Patched cfdot job prestart to a shared location accessible in all the container of an instance group. The patches are all the same for the three affected instance groups. (As the job itself is the same).

Added comments to the diego-cell patch setup as a reminder to maintainers as to the intent of the complexity.

## Motivation and Context

See ticket #738 

## How Has This Been Tested?

Testing was done in a local minikube deployment. After the cluster became :heavy_check_mark: all affected instance groups were entered into via `kubectl exec`, the `cfdot.sh` was sourced from its new location and then a few `cfdot` commands invoked (`--help`, `locks`, `task`, `domains`, `cells`, `presences`.).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
