### PR TITLE
Fix shellcheck binary urls

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -81,13 +81,13 @@ binaries:
     version: 1.9.2
   shellcheck:
     sha256:
-      darwin: a5d77cbe4c3e92916bce712b959f6d54392f94bcf8ea84f80ba425a9e72e2afe
-      linux: c37d4f51e26ec8ab96b03d84af8c050548d7288a47f755ffb57706c6c458e027
-      windows: 8aafdeff31095613308e92ce6a13e3c41249b51e757fd4fcdfdfc7a81d29286a
+      darwin: c4edf1f04e53a35c39a7ef83598f2c50d36772e4cc942fb08a1114f9d48e5380
+      linux: 39c501aaca6aae3f3c7fc125b3c3af779ddbe4e67e4ebdc44c2ae5cba76c847f
+      windows: 02cfa14220c8154bb7c97909e80e74d3a7fe2cbb7d80ac32adcac7988a95e387
     url:
-      darwin: https://storage.googleapis.com/shellcheck/shellcheck-v{version}.darwin-x86_64
-      linux: https://storage.googleapis.com/shellcheck/shellcheck-v{version}.linux-x86_64
-      windows: https://storage.googleapis.com/shellcheck/shellcheck-v{version}.exe
+      darwin: https://github.com/koalaman/shellcheck/releases/download/v{version}/shellcheck-v{version}.darwin.x86_64.tar.xz
+      linux: https://github.com/koalaman/shellcheck/releases/download/v{version}/shellcheck-v{version}.linux.x86_64.tar.xz
+      windows: https://github.com/koalaman/shellcheck/releases/download/v{version}/shellcheck-v{version}.zip
     version: 0.7.0
   yq:
     sha256:


### PR DESCRIPTION
because linting now is broken in CI

Reason: https://github.com/koalaman/shellcheck/issues/1871

Urls from here: https://github.com/koalaman/shellcheck/releases/tag/v0.7.0

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- An important detail to include is the version of the used cf-operator -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
