### PR TITLE
Setup proper dns on gke

### DIFF
--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -236,8 +236,8 @@ deploy_args: &deploy_args
   make kubeconfig kubecf
 
   # Setup dns
-  tcp_router_ip=$(kubectl  get svc -n scf tcp-router-public -o json | jq -r .status.loadBalancer.ingress[].ip | head -n 1)
-  public_router_ip=$(kubectl  get svc -n scf router-public -o json | jq -r .status.loadBalancer.ingress[].ip | head -n 1)
+  tcp_router_ip=$(kubectl get svc -n scf tcp-router-public -o json | jq -r .status.loadBalancer.ingress[].ip | head -n 1)
+  public_router_ip=$(kubectl get svc -n scf router-public -o json | jq -r .status.loadBalancer.ingress[].ip | head -n 1)
 
   gcloud --quiet beta dns --project=suse-225215 record-sets transaction start --zone=kubecf-ci
   gcloud --quiet beta dns --project=suse-225215 record-sets transaction add --name=\*.${DOMAIN}. --ttl=300 --type=A --zone=kubecf-ci $public_router_ip
@@ -545,6 +545,9 @@ jobs:
                   gcloud compute disks delete ${ID} --zone=${GKE_CLUSTER_ZONE} \
                                                     --project="${GKE_PROJECT}" --quiet;
               done
+
+              tcp_router_ip=$(kubectl get svc -n scf tcp-router-public -o json | jq -r .status.loadBalancer.ingress[].ip | head -n 1)
+              public_router_ip=$(kubectl get svc -n scf router-public -o json | jq -r .status.loadBalancer.ingress[].ip | head -n 1)
 
               gcloud --quiet beta dns --project=suse-225215 record-sets transaction start --zone=kubecf-ci
               gcloud --quiet beta dns --project=suse-225215 record-sets transaction remove \

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -180,6 +180,7 @@ deploy_args: &deploy_args
   export GKE_PROJECT={{ if has . "gke_project" }}{{ .gke_project }}{{ else }}"suse-225215"{{ end }}
   export GKE_CLUSTER_ZONE={{ if has . "gke_zone" }}{{ .gke_zone }}{{ else }}"europe-west3-c"{{ end }}
   export GKE_CLUSTER_NAME="kubecf-ci-${BRANCH}-${CFSCHEDULER}-$(cat semver.gke-cluster/version | sed 's/\./-/g')"
+  export DOMAIN="${GKE_CLUSTER_NAME}.kubecf.ci"
 
   gcloud --quiet beta container \
     --project "${GKE_PROJECT}" clusters create "${GKE_CLUSTER_NAME}" \
@@ -232,6 +233,15 @@ deploy_args: &deploy_args
   # Bring up a k8s cluster and builds+deploy kubecf
   # https://github.com/SUSE/catapult/wiki/Build-and-run-SCF#build-and-run-kubecf
   make kubeconfig kubecf
+
+  # Setup dns
+  tcp_router_ip=$(kubectl  get svc -n scf tcp-router-public -o json | jq -r .status.loadBalancer.ingress[].ip | head -n 1)
+  public_router_ip=$(kubectl  get svc -n scf router-public -o json | jq -r .status.loadBalancer.ingress[].ip | head -n 1)
+
+  gcloud beta dns --project=suse-225215 record-sets transaction start --zone=kubecf-ci
+  gcloud beta dns --project=suse-225215 record-sets transaction add --name=\*.${DOMAIN}. --ttl=300 --type=A --zone=kubecf-ci $public_router_ip
+  gcloud beta dns --project=suse-225215 record-sets transaction add --name=tcp.${DOMAIN}. --ttl=300 --type=A --zone=kubecf-ci $tcp_router_ip
+  gcloud beta dns --project=suse-225215 record-sets transaction execute --zone=kubecf-ci
 
 test_args: &test_args
 - -ce
@@ -518,6 +528,8 @@ jobs:
               export GKE_PROJECT={{ if has . "gke_project" }}{{ .gke_project }}{{ else }}"suse-225215"{{ end }}
               export GKE_CLUSTER_ZONE={{ if has . "gke_zone" }}{{ .gke_zone }}{{ else }}"europe-west3-c"{{ end }}
               export GKE_CLUSTER_NAME="kubecf-ci-${BRANCH}-${CFSCHEDULER}-$(cat semver.gke-cluster/version | sed 's/\./-/g')"
+              export DOMAIN="${GKE_CLUSTER_NAME}.kubecf.ci"
+
               # Obtain pvc disks associated to the cluster
               IDS=$(gcloud compute disks list \
                     --filter="zone~${GKE_CLUSTER_ZONE}" \
@@ -532,6 +544,14 @@ jobs:
                   gcloud compute disks delete ${ID} --zone=${GKE_CLUSTER_ZONE} \
                                                     --project="${GKE_PROJECT}" --quiet;
               done
+
+              gcloud beta dns --project=suse-225215 record-sets transaction start --zone=kubecf-ci
+              gcloud beta dns --project=suse-225215 record-sets transaction remove \
+                --name=\*.${DOMAIN}. --ttl=300 --type=A --zone=kubecf-ci $public_router_ip
+              gcloud beta dns --project=suse-225215 record-sets transaction remove \
+                --name=tcp.${DOMAIN}. --ttl=300 --type=A --zone=kubecf-ci $tcp_router_ip
+              gcloud beta dns --project=suse-225215 record-sets transaction execute --zone=kubecf-ci
+
   on_abort:
     in_parallel:
     - try:
@@ -1186,6 +1206,7 @@ jobs:
   - task: upgrade
     params:
       BRANCH: {{ $branch }}
+      CFSCHEDULER: upgrade # hack to re-use the same cleanup code
     input_mapping:
       kubecf: kubecf-{{ $branch }}
       semver.gke-cluster: semver.gke-cluster-{{ $branch }}-upgrade

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -230,6 +230,7 @@ deploy_args: &deploy_args
   export CONFIG_OVERRIDE
 
   pushd catapult
+  export CLUSTER_PASSWORD=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)
   # Bring up a k8s cluster and builds+deploy kubecf
   # https://github.com/SUSE/catapult/wiki/Build-and-run-SCF#build-and-run-kubecf
   make kubeconfig kubecf

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -130,7 +130,7 @@ resources:
   source:
     uri: https://github.com/SUSE/catapult
   version:
-    ref: 76182e1e21f13b5143cfc275ee818a81570e8b32
+    ref: 6654aef2922f768df6e9f8a9e166af94f6ed9d48
 
 - name: s3.kubecf-ci
   type: s3

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -130,7 +130,7 @@ resources:
   source:
     uri: https://github.com/SUSE/catapult
   version:
-    ref: 6654aef2922f768df6e9f8a9e166af94f6ed9d48
+    ref: 9ae9c76829a302119c7be52fc0d41f624b093c04
 
 - name: s3.kubecf-ci
   type: s3
@@ -206,7 +206,7 @@ deploy_args: &deploy_args
     --no-enable-autoprovisioning
 
   # Get a kubeconfig
-  gcloud container clusters get-credentials ${GKE_CLUSTER_NAME} --zone ${GKE_CLUSTER_ZONE} --project "${GKE_PROJECT}"
+  gcloud --quiet container clusters get-credentials ${GKE_CLUSTER_NAME} --zone ${GKE_CLUSTER_ZONE} --project "${GKE_PROJECT}"
 
   export SCF_LOCAL="${PWD}/kubecf"
   export SCF_CHART="$(readlink -f s3.kubecf-ci/*.tgz)"
@@ -239,10 +239,10 @@ deploy_args: &deploy_args
   tcp_router_ip=$(kubectl  get svc -n scf tcp-router-public -o json | jq -r .status.loadBalancer.ingress[].ip | head -n 1)
   public_router_ip=$(kubectl  get svc -n scf router-public -o json | jq -r .status.loadBalancer.ingress[].ip | head -n 1)
 
-  gcloud beta dns --project=suse-225215 record-sets transaction start --zone=kubecf-ci
-  gcloud beta dns --project=suse-225215 record-sets transaction add --name=\*.${DOMAIN}. --ttl=300 --type=A --zone=kubecf-ci $public_router_ip
-  gcloud beta dns --project=suse-225215 record-sets transaction add --name=tcp.${DOMAIN}. --ttl=300 --type=A --zone=kubecf-ci $tcp_router_ip
-  gcloud beta dns --project=suse-225215 record-sets transaction execute --zone=kubecf-ci
+  gcloud --quiet beta dns --project=suse-225215 record-sets transaction start --zone=kubecf-ci
+  gcloud --quiet beta dns --project=suse-225215 record-sets transaction add --name=\*.${DOMAIN}. --ttl=300 --type=A --zone=kubecf-ci $public_router_ip
+  gcloud --quiet beta dns --project=suse-225215 record-sets transaction add --name=tcp.${DOMAIN}. --ttl=300 --type=A --zone=kubecf-ci $tcp_router_ip
+  gcloud --quiet beta dns --project=suse-225215 record-sets transaction execute --zone=kubecf-ci
 
 test_args: &test_args
 - -ce
@@ -546,12 +546,12 @@ jobs:
                                                     --project="${GKE_PROJECT}" --quiet;
               done
 
-              gcloud beta dns --project=suse-225215 record-sets transaction start --zone=kubecf-ci
-              gcloud beta dns --project=suse-225215 record-sets transaction remove \
+              gcloud --quiet beta dns --project=suse-225215 record-sets transaction start --zone=kubecf-ci
+              gcloud --quiet beta dns --project=suse-225215 record-sets transaction remove \
                 --name=\*.${DOMAIN}. --ttl=300 --type=A --zone=kubecf-ci $public_router_ip
-              gcloud beta dns --project=suse-225215 record-sets transaction remove \
+              gcloud --quiet beta dns --project=suse-225215 record-sets transaction remove \
                 --name=tcp.${DOMAIN}. --ttl=300 --type=A --zone=kubecf-ci $tcp_router_ip
-              gcloud beta dns --project=suse-225215 record-sets transaction execute --zone=kubecf-ci
+              gcloud --quiet beta dns --project=suse-225215 record-sets transaction execute --zone=kubecf-ci
 
   on_abort:
     in_parallel:

--- a/.concourse/tasks/upgrade.sh
+++ b/.concourse/tasks/upgrade.sh
@@ -74,10 +74,10 @@ make kubeconfig kubecf
 tcp_router_ip=$(kubectl  get svc -n scf tcp-router-public -o json | jq -r .status.loadBalancer.ingress[].ip | head -n 1)
 public_router_ip=$(kubectl  get svc -n scf router-public -o json | jq -r .status.loadBalancer.ingress[].ip | head -n 1)
 
-gcloud beta dns --project=suse-225215 record-sets transaction start --zone=kubecf-ci
-gcloud beta dns --project=suse-225215 record-sets transaction add --name="*.${DOMAIN}." --ttl=300 --type=A --zone=kubecf-ci "$public_router_ip"
-gcloud beta dns --project=suse-225215 record-sets transaction add --name="tcp.${DOMAIN}." --ttl=300 --type=A --zone=kubecf-ci "$tcp_router_ip"
-gcloud beta dns --project=suse-225215 record-sets transaction execute --zone=kubecf-ci
+gcloud --quiet beta dns --project=suse-225215 record-sets transaction start --zone=kubecf-ci
+gcloud --quiet beta dns --project=suse-225215 record-sets transaction add --name="*.${DOMAIN}." --ttl=300 --type=A --zone=kubecf-ci "$public_router_ip"
+gcloud --quiet beta dns --project=suse-225215 record-sets transaction add --name="tcp.${DOMAIN}." --ttl=300 --type=A --zone=kubecf-ci "$tcp_router_ip"
+gcloud --quiet beta dns --project=suse-225215 record-sets transaction execute --zone=kubecf-ci
 
 # Now upgrade to whatever chart we built for commit-to-test
 # The chart should be in s3.kubecf-ci directory

--- a/.concourse/tasks/upgrade.sh
+++ b/.concourse/tasks/upgrade.sh
@@ -27,7 +27,6 @@ gcloud auth activate-service-account --key-file "${PWD}/gke-key.json"
 export GKE_PROJECT='{{ .gke_project | default "suse-225215" }}'
 export GKE_ZONE='{{ .gke_zone | default "europe-west3-c"}}'
 
-# TODO: lint?
 export DOMAIN="${GKE_CLUSTER_NAME}.kubecf.ci"
 
 gcloud --quiet beta container \
@@ -70,11 +69,13 @@ pushd catapult
 # https://github.com/SUSE/catapult/wiki/Build-and-run-SCF#build-and-run-kubecf
 make kubeconfig kubecf
 
+# Setup dns
+tcp_router_ip=$(kubectl  get svc -n scf tcp-router-public -o json | jq -r .status.loadBalancer.ingress[].ip | head -n 1)
+public_router_ip=$(kubectl  get svc -n scf router-public -o json | jq -r .status.loadBalancer.ingress[].ip | head -n 1)
+
 gcloud beta dns --project=suse-225215 record-sets transaction start --zone=kubecf-ci
-gcloud beta dns --project=suse-225215 record-sets transaction remove \
-  --name=\*.${DOMAIN}. --ttl=300 --type=A --zone=kubecf-ci $public_router_ip
-gcloud beta dns --project=suse-225215 record-sets transaction remove \
-  --name=tcp.${DOMAIN}. --ttl=300 --type=A --zone=kubecf-ci $tcp_router_ip
+gcloud beta dns --project=suse-225215 record-sets transaction add --name="*.${DOMAIN}." --ttl=300 --type=A --zone=kubecf-ci "$public_router_ip"
+gcloud beta dns --project=suse-225215 record-sets transaction add --name="tcp.${DOMAIN}." --ttl=300 --type=A --zone=kubecf-ci "$tcp_router_ip"
 gcloud beta dns --project=suse-225215 record-sets transaction execute --zone=kubecf-ci
 
 # Now upgrade to whatever chart we built for commit-to-test

--- a/.concourse/tasks/upgrade.sh
+++ b/.concourse/tasks/upgrade.sh
@@ -65,6 +65,7 @@ EOF
 export CONFIG_OVERRIDE
 
 pushd catapult
+export CLUSTER_PASSWORD=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)
 # Bring up a k8s cluster and builds+deploy kubecf
 # https://github.com/SUSE/catapult/wiki/Build-and-run-SCF#build-and-run-kubecf
 make kubeconfig kubecf


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When a node is misbehaving in GKE it is sometimes removed or just changes Internal IP. We were using the internal IP with howdoi.website instead of a proper domain to run CATs. When the node IP changes our DOMAIN is no longer valid and tests fail.

This happens quite often leading in a lot of flakiness in the pipeline.

This PR is setting up a subdomain of `kubecf.ci` for each testing cluster and points that to the given public IP of the router service. It cleans up the dns records in the end.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- An important detail to include is the version of the used cf-operator -->
Deployed a copy of the pipeline, let it run and checked if cleanup happened in the end.


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
