### PR TITLE
Fix cleanup script by actually providing the needed env vars

### DIFF
--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -531,7 +531,11 @@ jobs:
               done
   on_abort:
     in_parallel:
-    - try: *cleanup-cluster
+    - try:
+        << : *cleanup-cluster
+        params:
+          BRANCH: {{ $branch }}
+          CFSCHEDULER: {{ $cfScheduler }}
 {{- if has $stable (printf "deploy-%s" $cfScheduler) }}
     - try:
         put: status-{{ $branch }}.src
@@ -541,7 +545,11 @@ jobs:
 {{- end }}
   on_error:
     in_parallel:
-    - try: *cleanup-cluster
+    - try:
+        << : *cleanup-cluster
+        params:
+          BRANCH: {{ $branch }}
+          CFSCHEDULER: {{ $cfScheduler }}
 {{- if has $stable (printf "deploy-%s" $cfScheduler) }}
     - try:
         put: status-{{ $branch }}.src
@@ -618,10 +626,18 @@ jobs:
           << : *smoke_{{ $cfScheduler }}_{{ $sanitized_branch_name }}_status
           state: failure
 {{- end }}
-    - try: *cleanup-cluster
+    - try:
+        << : *cleanup-cluster
+        params:
+          BRANCH: {{ $branch }}
+          CFSCHEDULER: {{ $cfScheduler }}
   on_abort:
     in_parallel:
-    - try: *cleanup-cluster
+    - try:
+        << : *cleanup-cluster
+        params:
+          BRANCH: {{ $branch }}
+          CFSCHEDULER: {{ $cfScheduler }}
 {{- if has $stable (printf "smoke-tests-%s" $cfScheduler) }}
     - try:
         put: status-{{ $branch }}.src
@@ -631,7 +647,11 @@ jobs:
 {{- end }}
   on_error:
     in_parallel:
-    - try: *cleanup-cluster
+    - try:
+        << : *cleanup-cluster
+        params:
+          BRANCH: {{ $branch }}
+          CFSCHEDULER: {{ $cfScheduler }}
 {{- if has $stable (printf "smoke-tests-%s" $cfScheduler) }}
     - try:
         put: status-{{ $branch }}.src
@@ -702,7 +722,11 @@ jobs:
 
   on_failure:
     in_parallel:
-    - try: *cleanup-cluster
+    - try:
+        << : *cleanup-cluster
+        params:
+          BRANCH: {{ $branch }}
+          CFSCHEDULER: {{ $cfScheduler }}
 {{- if has $stable (printf "cf-acceptance-tests-%s" $cfScheduler) }}
     - try:
         put: status-{{ $branch }}.src
@@ -712,7 +736,11 @@ jobs:
 {{- end }}
   on_abort:
     in_parallel:
-    - try: *cleanup-cluster
+    - try:
+        << : *cleanup-cluster
+        params:
+          BRANCH: {{ $branch }}
+          CFSCHEDULER: {{ $cfScheduler }}
 {{- if has $stable (printf "cf-acceptance-tests-%s" $cfScheduler) }}
     - try:
         put: status-{{ $branch }}.src
@@ -722,7 +750,11 @@ jobs:
 {{- end }}
   on_error:
     in_parallel:
-    - try: *cleanup-cluster
+    - try:
+        << : *cleanup-cluster
+        params:
+          BRANCH: {{ $branch }}
+          CFSCHEDULER: {{ $cfScheduler }}
 {{- if has $stable (printf "cf-acceptance-tests-%s" $cfScheduler) }}
     - try:
         put: status-{{ $branch }}.src
@@ -801,10 +833,18 @@ jobs:
           << : *sits_{{ $sanitized_branch_name }}_status
           state: failure
 {{- end }}
-    - try: *cleanup-cluster
+    - try:
+        << : *cleanup-cluster
+        params:
+          BRANCH: {{ $branch }}
+          CFSCHEDULER: {{ $cfScheduler }}
   on_abort:
     in_parallel:
-    - try: *cleanup-cluster
+    - try:
+        << : *cleanup-cluster
+        params:
+          BRANCH: {{ $branch }}
+          CFSCHEDULER: {{ $cfScheduler }}
 {{- if has $stable "sync-integration-tests" }}
     - try:
         put: status-{{ $branch }}.src
@@ -815,7 +855,11 @@ jobs:
 
   on_error:
     in_parallel:
-    - try: *cleanup-cluster
+    - try:
+        << : *cleanup-cluster
+        params:
+          BRANCH: {{ $branch }}
+          CFSCHEDULER: {{ $cfScheduler }}
 {{- if has $stable "sync-integration-tests" }}
     - try:
         put: status-{{ $branch }}.src
@@ -893,10 +937,18 @@ jobs:
           << : *rotate_{{ $cfScheduler }}_{{ $sanitized_branch_name }}_status
           state: failure
 {{- end }}
-    - try: *cleanup-cluster
+    - try:
+        << : *cleanup-cluster
+        params:
+          BRANCH: {{ $branch }}
+          CFSCHEDULER: {{ $cfScheduler }}
   on_abort:
     in_parallel:
-    - try: *cleanup-cluster
+    - try:
+        << : *cleanup-cluster
+        params:
+          BRANCH: {{ $branch }}
+          CFSCHEDULER: {{ $cfScheduler }}
 {{- if has $stable (printf "rotate-%s" $cfScheduler) }}
     - try:
         put: status-{{ $branch }}.src
@@ -906,7 +958,11 @@ jobs:
 {{- end }}
   on_error:
     in_parallel:
-    - try: *cleanup-cluster
+    - try:
+        << : *cleanup-cluster
+        params:
+          BRANCH: {{ $branch }}
+          CFSCHEDULER: {{ $cfScheduler }}
 {{- if has $stable (printf "rotate-%s" $cfScheduler) }}
     - try:
         put: status-{{ $branch }}.src
@@ -984,10 +1040,18 @@ jobs:
           << : *smoke_rotate_{{ $cfScheduler }}_{{ $sanitized_branch_name }}_status
           state: failure
 {{- end }}
-    - try: *cleanup-cluster
+    - try:
+        << : *cleanup-cluster
+        params:
+          BRANCH: {{ $branch }}
+          CFSCHEDULER: {{ $cfScheduler }}
   on_abort:
     in_parallel:
-    - try: *cleanup-cluster
+    - try:
+        << : *cleanup-cluster
+        params:
+          BRANCH: {{ $branch }}
+          CFSCHEDULER: {{ $cfScheduler }}
 {{- if has $stable (printf "smoke-rotated-{%s" $cfScheduler) }}
     - try:
         put: status-{{ $branch }}.src
@@ -997,7 +1061,11 @@ jobs:
 {{- end }}
   on_error:
     in_parallel:
-    - try: *cleanup-cluster
+    - try:
+        << : *cleanup-cluster
+        params:
+          BRANCH: {{ $branch }}
+          CFSCHEDULER: {{ $cfScheduler }}
 {{- if has $stable (printf "smoke-rotated-{%s" $cfScheduler) }}
     - try:
         put: status-{{ $branch }}.src
@@ -1087,7 +1155,10 @@ jobs:
     trigger: true
   ensure:
    do:
-    - *cleanup-cluster
+    - << : *cleanup-cluster
+      params:
+        BRANCH: {{ $branch }}
+        CFSCHEDULER: {{ $cfScheduler }}
 
 {{ end }} # of range cfScheduler
 
@@ -1119,7 +1190,10 @@ jobs:
     file: kubecf-{{ $branch }}/.concourse/tasks/upgrade.yaml
   ensure:
     do:
-      - *cleanup-cluster
+      - << : *cleanup-cluster
+        params:
+          BRANCH: {{ $branch }}
+          CFSCHEDULER: upgrade
 
 {{ if not ($branch | regexp.Match "^pr|fork-pr") }}
 - name: publish-{{ $branch }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Cleanup of clusters in the pipeline doesn't work:

```ERROR: (gcloud.container.clusters.delete) Some requests did not succeed:

 - args: [u"ResponseError: code=404, message=Not found: projects/suse-225215/zones/europe-west3-c/clusters/kubecf-ci---0-0-5.\nNo cluster named 'kubecf-ci---0-0-5' in suse-225215."]

   exit_code: 1

   message: ResponseError: code=404, message=Not found: projects/suse-225215/zones/europe-west3-c/clusters/kubecf-ci---0-0-5.

No cluster named 'kubecf-ci---0-0-5' in suse-225215.
```
the reason is that we call the cleanup script but the needed vars "$BRANCH" and "$CFSCHEDULER" are not set. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- An important detail to include is the version of the used cf-operator -->
TODO

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
