### PR TITLE
Remove version: "every" from publish step artifacts

### DIFF
--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -1203,12 +1203,10 @@ jobs:
     passed:
     - cf-acceptance-tests-diego-{{ $branch }}
     trigger: true
-    version: "every"
   - get: s3.kubecf-ci-bundle
     passed:
     - cf-acceptance-tests-diego-{{ $branch }}
     trigger: true
-    version: "every"
   - task: rename-artifacts
     config:
       platform: linux


### PR DESCRIPTION
because this together with `passed:` is confusing to Concourse and
doesn't let the step trigger when it should.

See also: https://github.com/concourse/concourse/issues/736#issuecomment-479557411

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- An important detail to include is the version of the used cf-operator -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
