### PR TITLE
feat: Add NOTES.txt to helm chart

### DIFF
--- a/deploy/helm/kubecf/templates/NOTES.txt
+++ b/deploy/helm/kubecf/templates/NOTES.txt
@@ -1,0 +1,20 @@
+    Welcome to your new deployment of KubeCF.
+
+    The endpoint for use by the `cf` client is
+        [1;36mhttps://api.{{ .Values.system_domain }}[0m
+
+    To target this endpoint and login, run
+        [1;36mcf login --skip-ssl-validation -a https://api.{{ .Values.system_domain }} -u admin[0m
+
+    Please remember, it may take some time for everything to come online.
+
+    You can use
+        [1;36mkubectl get pods --namespace {{ .Release.Namespace }}[0m
+
+    to spot-check if everything is up and running, or
+        [1;36mwatch -c 'kubectl get pods --namespace {{ .Release.Namespace }}'[0m
+
+    to monitor continuously.
+
+    The online documentation (release notes, deployment guide) can be found at
+        [1;36mhttps://kubecf.suse.dev/docs[0m


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->


## Description
<!--- Describe your changes in detail -->
Add a helm `templates/NOTES.txt` which gets shown on `helm install`.

The NOTES.txt points to https://kubecf.suse.dev/docs for documentation, which seems like a good starting point.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes https://github.com/cloudfoundry-incubator/kubecf/issues/855.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- An important detail to include is the version of the used cf-operator -->

Successfully tested by deploying the resulting chart and checking that the NOTES.txt are displayed correctly.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
