### PR TITLE
add notes.txt to release helmchart

### DIFF
--- a/rules/kubecf/release_chart.sh
+++ b/rules/kubecf/release_chart.sh
@@ -25,6 +25,37 @@ tar xf "${KUBECF_CHART}"
   < "${KUBECF_IMAGE_LIST_JSON_FILE}" \
   > "${KUBECF_IMAGE_LIST_TXT_FILE}"
 
+mkdir kubecf/templates
+cat <<EOF > kubecf/templates/NOTES.txt
+    Welcome to your new deployment of kubecf.
+
+    The endpoint for use by the `cf` client is
+        [1;36mhttps://api.{{ .Values.env.DOMAIN }}[0m
+
+    To target this endpoint and login, run
+        [1;36mcf login --skip-ssl-validation -a https://api.{{ .Values.env.DOMAIN }} -u admin[0m
+
+    Please remember, it may take some time for everything to come online.
+
+    You can use
+        [1;36mkubectl get pods --namespace {{ .Release.Namespace }}[0m
+
+    to spot-check if everything is up and running, or
+        [1;36mwatch -c 'kubectl get pods --namespace {{ .Release.Namespace }}'[0m
+
+    to monitor continuously.
+
+    The online documentation (release notes, deployment guide) can be found at
+        [1;36mhttps://www.suse.com/documentation/cloud-application-platform-1[0m
+{{- if and .Values.enable.eirini (ne (toString .Values.env.KUBE_CSR_AUTO_APPROVAL) "true") }}
+
+    [1;31mThe secret generator will create a certificate signing request that
+    must be approved by an administrator before deployment will continue.
+    To do so run the command[0m
+        [1;32mkubectl certificate approve {{ .Release.Namespace }}-bits-service-ssl-cert[0m
+{{- end }}
+EOF
+
 "${HELM}" package kubecf/
 
 mv kubecf-*.tgz "${OUTPUT}"


### PR DESCRIPTION
This PR adds a `NOTES.txt`  to the templates folder of the helmchart. 
It is output as soon as the cluster is set up and proviedes useful information about the cluster.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
