### PR TITLE
Switch embedded db from explicit bosh variables to implicit

### DIFF
--- a/deploy/helm/kubecf/assets/operations/instance_groups/database.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/database.yaml
@@ -16,28 +16,11 @@
 
 {{- if .Values.features.embedded_database.enabled }}
 
-# Add certificates for PXC.
-- type: replace
-  path: /variables/-
-  value:
-    name: pxc_ca
-    type: certificate
-    options:
-      common_name: pxc_ca
-      is_ca: true
-- type: replace
-  path: /variables/-
-  value:
-    name: pxc_tls
-    type: certificate
-    options:
-      ca: pxc_ca
-      common_name: &pxc-cluster-address {{ printf "database.%s" .Release.Namespace }}
-
 # Override the address and CA cert with the one from PXC.
+# See templates/database.yaml for the relevant quarks secrets.
 - type: replace
   path: /instance_groups/name=diego-api/jobs/name=bbs/properties/diego/bbs/sql/db_host?
-  value: *pxc-cluster-address
+  value: &pxc-cluster-address {{ printf "database.%s" .Release.Namespace }}
 - type: replace
   path: /instance_groups/name=diego-api/jobs/name=bbs/properties/diego/bbs/sql/ca_cert?
   value: &pxc-cluster-ca ((pxc_tls.ca))

--- a/deploy/helm/kubecf/templates/database.yaml
+++ b/deploy/helm/kubecf/templates/database.yaml
@@ -4,6 +4,54 @@
 apiVersion: quarks.cloudfoundry.org/v1alpha1
 kind: QuarksSecret
 metadata:
+  name: var-pxc-ca
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: {{ include "kubecf.fullname" . }}
+    app.kubernetes.io/version: {{ default .Chart.Version .Chart.AppVersion | quote }}
+    helm.sh/chart: {{ include "kubecf.chart" . }}
+spec:
+  request:
+    certificate:
+      commonName: pxc_ca
+      isCA: true
+      signerType: cluster
+  secretName: var-pxc-ca
+  type: certificate
+
+---
+apiVersion: quarks.cloudfoundry.org/v1alpha1
+kind: QuarksSecret
+metadata:
+  name: var-pxc-tls
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: {{ include "kubecf.fullname" . }}
+    app.kubernetes.io/version: {{ default .Chart.Version .Chart.AppVersion | quote }}
+    helm.sh/chart: {{ include "kubecf.chart" . }}
+spec:
+  request:
+    certificate:
+      CAKeyRef:
+        key: private_key
+        name: var-pcx-ca
+      CARef:
+        key: certificate
+        name: var-pcx-ca
+      commonName: {{ printf "database.%s" .Release.Namespace }}
+      isCA: false
+      signerType: cluster
+  secretName: var-pxc-tls
+  type: certificate
+
+---
+apiVersion: quarks.cloudfoundry.org/v1alpha1
+kind: QuarksSecret
+metadata:
   name: var-pxc-root-password
   namespace: {{ .Release.Namespace | quote }}
   labels:


### PR DESCRIPTION
## Description

Added quarks secrets for the embedded database, matching the BOSH variables.
Dropped the explicit variable definition for same.
The implicit variable ref `((pxc_tls.ca))` should now be resolved from
the quarks secret.

## Motivation and Context

See #772 

## How Has This Been Tested?

This is currently failing.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
