### PR TITLE
Clear resource requests from eirini bits service.

### DIFF
--- a/deploy/helm/kubecf/charts/bits/Chart.yaml
+++ b/deploy/helm/kubecf/charts/bits/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for CloudFoundry/bits-service
 name: bits
-version: 1.0.16
+version: 1.0.17

--- a/deploy/helm/kubecf/charts/bits/templates/bits.yaml
+++ b/deploy/helm/kubecf/charts/bits/templates/bits.yaml
@@ -65,10 +65,18 @@ spec:
         - name: bits-assets
           mountPath: /assets/
         {{ end }}
+        {{- with .Values.resources }}
+        {{- if or .cpu .memory }}
         resources:
           requests:
-            cpu: 800m
-            memory: 150Mi
+            {{- with .cpu }}
+            cpu: {{ . }}
+            {{ end }}
+            {{- with .memory }}
+            memory: {{ . }}
+            {{- end }}
+        {{- end }}
+        {{- end }}
       {{- if .Values.download_eirinifs }}
       initContainers:
       - name: "download-eirini-rootfs"

--- a/deploy/helm/kubecf/charts/bits/values.yaml
+++ b/deploy/helm/kubecf/charts/bits/values.yaml
@@ -19,6 +19,10 @@ global:
   labels: {}
   annotations: {}
 
+resources:
+  cpu: 800m
+  memory: 150Mi
+
 tls_secret_name: private-registry-cert
 # set to true if you wish to use a pre-populated
 # secret for TLS certs, such as that created by

--- a/deploy/helm/kubecf/requirements.lock
+++ b/deploy/helm/kubecf/requirements.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 1.0.5
 - name: bits
   repository: http://opensource.suse.com/bits-service-release/
-  version: 1.0.16
+  version: 1.0.17
 - name: eirini-extensions
   repository: https://opensource.suse.com/eirinix-helm-release/
   version: 0.0.0-10+g3df5bb4
-digest: sha256:a52b446b93a5facc654a8cbe3f4e38e862a8d3a905051bc5c77b7bcef3c7b136
-generated: "2020-05-19T11:32:33.36103155-07:00"
+digest: sha256:8e26d216ec80be5f053f3407625493530af58c7074cc6431d7c94cbd560d8596
+generated: "2020-06-12T13:24:55.27384381-07:00"

--- a/deploy/helm/kubecf/requirements.lock
+++ b/deploy/helm/kubecf/requirements.lock
@@ -8,5 +8,5 @@ dependencies:
 - name: eirini-extensions
   repository: https://opensource.suse.com/eirinix-helm-release/
   version: 0.0.0-10+g3df5bb4
-digest: sha256:8e26d216ec80be5f053f3407625493530af58c7074cc6431d7c94cbd560d8596
-generated: "2020-06-12T13:24:55.27384381-07:00"
+digest: sha256:ef3ea5ab17a55bb2cd371ea8e0f6a93bab6a0163be49f368304f6154b3bdab69
+generated: "2020-06-13T08:59:59.521728-07:00"

--- a/deploy/helm/kubecf/requirements.yaml
+++ b/deploy/helm/kubecf/requirements.yaml
@@ -4,7 +4,7 @@ dependencies:
   repository: http://opensource.suse.com/eirini-release/
   condition: features.eirini.enabled
 - name: bits
-  version: 1.0.16
+  version: 1.0.17
   repository: http://opensource.suse.com/bits-service-release/
   condition: features.eirini.enabled
 - name: eirini-extensions

--- a/deploy/helm/kubecf/values.yaml
+++ b/deploy/helm/kubecf/values.yaml
@@ -497,10 +497,10 @@ eirini:
 
 bits:
   download_eirinifs: false
+  resources:
+    cpu: ~
+    memory: ~
   global:
-    resources:
-      cpu: ~
-      memory: ~
     labels: {}
     annotations: {}
     images:

--- a/deploy/helm/kubecf/values.yaml
+++ b/deploy/helm/kubecf/values.yaml
@@ -498,6 +498,9 @@ eirini:
 bits:
   download_eirinifs: false
   global:
+    resources:
+      cpu: ~
+      memory: ~
     labels: {}
     annotations: {}
     images:


### PR DESCRIPTION

## Description

Subordinate PR at SUSE/bits-service-release#6
This PR sets the defaults to nil to disable resource requests.
Also bumped to the new bits release containing the ability to configure the resource requests. Version 1.0.17.

## Motivation and Context

See #861.

## How Has This Been Tested?

Tested locally in a minikube that changes to the defaults in the kubecf values.yaml are properly propagated into the bits pod.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
