### PR TITLE
Cleanup pods after tests

### DIFF
--- a/deploy/helm/kubecf/assets/operations/instance_groups/acceptance-tests.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/acceptance-tests.yaml
@@ -40,4 +40,9 @@
       serial: true
     vm_type: minimal
 
+
+- type: replace
+  path: /instance_groups/name=acceptance-tests/env?/bosh/agent/settings/labels/delete?
+  value: "pod"
+
 {{- end }}

--- a/deploy/helm/kubecf/assets/operations/instance_groups/acceptance-tests.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/acceptance-tests.yaml
@@ -41,8 +41,11 @@
     vm_type: minimal
 
 
+{{- if .Values.testing.cf_acceptance_tests.delete_pod }}
 - type: replace
   path: /instance_groups/name=acceptance-tests/env?/bosh/agent/settings/labels/delete?
   value: "pod"
+{{- end }}
+
 
 {{- end }}

--- a/deploy/helm/kubecf/assets/operations/instance_groups/acceptance-tests.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/acceptance-tests.yaml
@@ -43,7 +43,7 @@
 
 {{- if .Values.testing.cf_acceptance_tests.delete_pod }}
 - type: replace
-  path: /instance_groups/name=acceptance-tests/env?/bosh/agent/settings/labels/delete?
+  path: /instance_groups/name=acceptance-tests/env?/bosh/agent/settings/labels/delete
   value: "pod"
 {{- end }}
 

--- a/deploy/helm/kubecf/assets/operations/instance_groups/brain-tests.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/brain-tests.yaml
@@ -56,8 +56,10 @@
       serial: true
     vm_type: minimal
 
+{{- if .Values.testing.brain_tests.delete_pod }}
 - type: replace
   path: /instance_groups/name=brain-tests/env?/bosh/agent/settings/labels/delete?
   value: "pod"
+{{- end }}
 
 {{- end }}

--- a/deploy/helm/kubecf/assets/operations/instance_groups/brain-tests.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/brain-tests.yaml
@@ -58,7 +58,7 @@
 
 {{- if .Values.testing.brain_tests.delete_pod }}
 - type: replace
-  path: /instance_groups/name=brain-tests/env?/bosh/agent/settings/labels/delete?
+  path: /instance_groups/name=brain-tests/env?/bosh/agent/settings/labels/delete
   value: "pod"
 {{- end }}
 

--- a/deploy/helm/kubecf/assets/operations/instance_groups/brain-tests.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/brain-tests.yaml
@@ -56,4 +56,8 @@
       serial: true
     vm_type: minimal
 
+- type: replace
+  path: /instance_groups/name=brain-tests/env?/bosh/agent/settings/labels/delete?
+  value: "pod"
+
 {{- end }}

--- a/deploy/helm/kubecf/assets/operations/instance_groups/smoke-tests.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/smoke-tests.yaml
@@ -2,7 +2,7 @@
 
 {{- if .Values.testing.smoke_tests.delete_pod }}
 - type: replace
-  path: /instance_groups/name=smoke-tests/env?/bosh/agent/settings/labels/delete?
+  path: /instance_groups/name=smoke-tests/env?/bosh/agent/settings/labels/delete
   value: "pod"
 {{- end }}
 

--- a/deploy/helm/kubecf/assets/operations/instance_groups/smoke-tests.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/smoke-tests.yaml
@@ -1,8 +1,10 @@
 {{- if .Values.testing.smoke_tests.enabled }}
 
+{{- if .Values.testing.smoke_tests.delete_pod }}
 - type: replace
   path: /instance_groups/name=smoke-tests/env?/bosh/agent/settings/labels/delete?
   value: "pod"
+{{- end }}
 
 - type: replace
   path: /instance_groups/name=smoke-tests/jobs/name=cf-cli-6-linux/properties?/quarks/bpm/processes

--- a/deploy/helm/kubecf/assets/operations/instance_groups/smoke-tests.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/smoke-tests.yaml
@@ -1,6 +1,10 @@
 {{- if .Values.testing.smoke_tests.enabled }}
 
 - type: replace
+  path: /instance_groups/name=smoke-tests/env?/bosh/agent/settings/labels/delete?
+  value: "pod"
+
+- type: replace
   path: /instance_groups/name=smoke-tests/jobs/name=cf-cli-6-linux/properties?/quarks/bpm/processes
   value: []
 

--- a/deploy/helm/kubecf/assets/operations/instance_groups/sync-integration-tests.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/sync-integration-tests.yaml
@@ -49,4 +49,8 @@
       serial: true
     vm_type: minimal
 
+- type: replace
+  path: /instance_groups/name=sync-integration-tests/env?/bosh/agent/settings/labels/delete?
+  value: "pod"
+
 {{- end }}

--- a/deploy/helm/kubecf/assets/operations/instance_groups/sync-integration-tests.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/sync-integration-tests.yaml
@@ -51,7 +51,7 @@
 
 {{- if .Values.testing.sync_integration_tests.delete_pod }}
 - type: replace
-  path: /instance_groups/name=sync-integration-tests/env?/bosh/agent/settings/labels/delete?
+  path: /instance_groups/name=sync-integration-tests/env?/bosh/agent/settings/labels/delete
   value: "pod"
 {{- end }}
 

--- a/deploy/helm/kubecf/assets/operations/instance_groups/sync-integration-tests.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/sync-integration-tests.yaml
@@ -49,8 +49,10 @@
       serial: true
     vm_type: minimal
 
+{{- if .Values.testing.sync_integration_tests.delete_pod }}
 - type: replace
   path: /instance_groups/name=sync-integration-tests/env?/bosh/agent/settings/labels/delete?
   value: "pod"
+{{- end }}
 
 {{- end }}

--- a/deploy/helm/kubecf/values.yaml
+++ b/deploy/helm/kubecf/values.yaml
@@ -336,15 +336,19 @@ features:
 testing:
   brain_tests:
     enabled: false
+    # Delete the testing pod after completion (default: false)
     delete_pod: false
   cf_acceptance_tests:
     enabled: false
+    # Delete the testing pod after completion (default: false)
     delete_pod: false
   smoke_tests:
     enabled: true
+    # Delete the testing pod after completion (default: false)
     delete_pod: false
   sync_integration_tests:
     enabled: false
+    # Delete the testing pod after completion (default: false)
     delete_pod: false
 
 ccdb:

--- a/deploy/helm/kubecf/values.yaml
+++ b/deploy/helm/kubecf/values.yaml
@@ -336,12 +336,16 @@ features:
 testing:
   brain_tests:
     enabled: false
+    delete_pod: false
   cf_acceptance_tests:
     enabled: false
+    delete_pod: false
   smoke_tests:
     enabled: true
+    delete_pod: false
   sync_integration_tests:
     enabled: false
+    delete_pod: false
 
 ccdb:
   encryption:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When you delete a job with `kubectl` the created pods get deleted too. But when quarks-job deletes a job it doesn't delete the pod unless the `delete: pod` label is set on the job.

See also:
- https://github.com/cloudfoundry-incubator/quarks-job/blob/master/docs/quarksjob.md#job-controller
- https://github.com/cloudfoundry-incubator/quarks-job/blob/b16b2a026f867b8e4c8acc070735864dc5c3f6d8/pkg/kube/controllers/quarksjob/job_reconciler.go#L96

For the kubecf pipeline, we will cleanup the pod manually in catapult because we need the pod to be around for a while to be able to write the logs on a file. If quarks job deletes it, then we may not get the chance to do that (https://github.com/SUSE/catapult/pull/232).

I opened this PR in case it is useful for some other pipeline or use case. I know people had issues with testing pods that were left behind. The default is still to keep the pod around so this shouldn't break anything.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- An important detail to include is the version of the used cf-operator -->
Run smoke tests with this setting on and pod was deleted after completion.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
