### PR TITLE
Remove local nodePort registry in favor of changed bits service

### DIFF
--- a/deploy/helm/kubecf/values.yaml
+++ b/deploy/helm/kubecf/values.yaml
@@ -659,6 +659,7 @@ bits:
   kube:
     external_ips: []
   services:
+    # This setting is not configurable and must be HIDDEN from the user.
     nodePort: 31666
 
   # The blobstore configuration is part of kubecf and should be HIDDEN.

--- a/deploy/helm/kubecf/values.yaml
+++ b/deploy/helm/kubecf/values.yaml
@@ -517,7 +517,7 @@ eirini:
   env:
     # This setting is not configurable and must be HIDDEN from the user.
     # It's a workaround to replace the port eirini uses for the registry
-    DOMAIN: '127.0.0.1.nip.io:31666" #'
+    DOMAIN: '127.0.0.1.nip.io'
   services:
     loadbalanced: true
   opi:

--- a/deploy/helm/kubecf/values.yaml
+++ b/deploy/helm/kubecf/values.yaml
@@ -266,10 +266,6 @@ features:
   eirini:
     # When eirini is enabled, both suse_default_stack and suse_buildpacks must be enabled as well.
     enabled: false
-    registry:
-      service:
-        # This setting is not currently configurable and must be HIDDEN
-        nodePort: 31666
   # To support multi-clusters, deploy diego-cell separately please set control_plane is false  and cell_segment is true
   multiple_cluster_mode:
     control_plane:
@@ -663,7 +659,7 @@ bits:
   kube:
     external_ips: []
   services:
-    loadbalanced: true
+    nodePort: 31666
 
   # The blobstore configuration is part of kubecf and should be HIDDEN.
   blobstore:


### PR DESCRIPTION
## Description

Removed `loadbalanced` property.
Moved `nodePort` property from `kubecf` section to `bits` section.

:warning: TODO: Update the bits chart.

## Motivation and Context

See #792
See SUSE/bits-service-release/pull/7 for the bits release changes.

## How Has This Been Tested?

Local minikube, SA eirini. Smoke tests run manually.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
