### PR TITLE
Make internetless suite not public and fix triggering

### DIFF
--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -838,12 +838,12 @@ jobs:
 {{ $previousTest = (printf "cf-acceptance-tests-%s-%s" $cfScheduler $branch) }}
 
 - name: cats-internetless-{{ $cfScheduler }}-{{ $branch }}
-  public: true
   plan:
   - get: kubecf-{{ $branch }}
     passed:
     - {{ $previousTest | quote }}
     trigger: true
+    version: "every"
   - get: s3.kubecf-ci
     passed:
     - {{ $previousTest | quote }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
In some cases the internetless suite doesn't trigger although previous step is green. That leads to dangling clustets (since not job failed to trigger a cleanup).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- An important detail to include is the version of the used cf-operator -->
Deployed the pipeline and hoped for the best. Time will tell.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
