### PR TITLE
Remove unneeded vars in the upgrade task of the kubecf pipeline

### DIFF
--- a/.concourse/tasks/upgrade.sh
+++ b/.concourse/tasks/upgrade.sh
@@ -40,6 +40,7 @@ export GKE_CLUSTER_ZONE="$GKE_ZONE"
 KUBECF_LATEST_RELEASE="$(cat kubecf-github-release/version)"
 export KUBECF_LATEST_RELEASE
 export SCF_CHART="https://github.com/cloudfoundry-incubator/kubecf/releases/download/v${KUBECF_LATEST_RELEASE}/kubecf-bundle-v${KUBECF_LATEST_RELEASE}.tgz"
+export ENABLE_EIRINI=false
 
 export BACKEND=gke
 export DOWNLOAD_CATAPULT_DEPS=false

--- a/.concourse/tasks/upgrade.sh
+++ b/.concourse/tasks/upgrade.sh
@@ -16,12 +16,10 @@
 #
 #   - BACKEND
 #   - CONFIG_OVERRIDE
-#   - ENABLE_EIRINI
 #   - KUBECFG
 #   - DOWNLOAD_CATAPULT_DEPS=false
 #   - QUIET_OUTPUT
 #   - SCF_CHART
-#   - SCF_OPERATOR
 #
 # Variables used by kubectl, gcloud, ...
 #   - KUBECONFIG
@@ -43,10 +41,6 @@ KUBECF_LATEST_RELEASE="$(cat kubecf-github-release/version)"
 export KUBECF_LATEST_RELEASE
 export SCF_CHART="https://github.com/cloudfoundry-incubator/kubecf/releases/download/v${KUBECF_LATEST_RELEASE}/kubecf-bundle-v${KUBECF_LATEST_RELEASE}.tgz"
 
-export ENABLE_EIRINI=false
-export SCF_OPERATOR=true
-
-export HELM_VERSION="v3.1.1"
 export BACKEND=gke
 export DOWNLOAD_CATAPULT_DEPS=false
 export QUIET_OUTPUT=true

--- a/.concourse/tasks/upgrade.sh
+++ b/.concourse/tasks/upgrade.sh
@@ -100,7 +100,7 @@ export CLUSTER_PASSWORD
 # Bring up a k8s cluster and builds+deploy kubecf
 # https://github.com/SUSE/catapult/wiki/Build-and-run-SCF#build-and-run-kubecf
 make kubeconfig
-make kubecf
+make kubecf kubecf-login
 
 # Setup dns
 tcp_router_ip=$(kubectl  get svc -n scf tcp-router-public -o json | jq -r .status.loadBalancer.ingress[].ip | head -n 1)
@@ -121,4 +121,4 @@ SCF_CHART="$(readlink -f ../s3.kubecf-ci/*.tgz)"
 export SCF_CHART
 
 make kubecf-chart
-make kubecf-upgrade
+make kubecf-upgrade kubecf-login

--- a/.concourse/tasks/upgrade.sh
+++ b/.concourse/tasks/upgrade.sh
@@ -45,7 +45,6 @@ export SCF_CHART="https://github.com/cloudfoundry-incubator/kubecf/releases/down
 export ENABLE_EIRINI=false
 export SCF_OPERATOR=true
 
-export FORCE_DELETE=true
 export HELM_VERSION="v3.1.1"
 export BACKEND=gke
 export QUIET_OUTPUT=false

--- a/.concourse/tasks/upgrade.sh
+++ b/.concourse/tasks/upgrade.sh
@@ -18,6 +18,7 @@
 #   - CONFIG_OVERRIDE
 #   - ENABLE_EIRINI
 #   - KUBECFG
+#   - DOWNLOAD_CATAPULT_DEPS=false
 #   - QUIET_OUTPUT
 #   - SCF_CHART
 #   - SCF_OPERATOR
@@ -47,7 +48,8 @@ export SCF_OPERATOR=true
 
 export HELM_VERSION="v3.1.1"
 export BACKEND=gke
-export QUIET_OUTPUT=false
+export DOWNLOAD_CATAPULT_DEPS=false
+export QUIET_OUTPUT=true
 
 GKE_CLUSTER_NAME="kubecf-ci-${BRANCH}-upgrade-$(sed 'y/./-/' "semver.gke-cluster/version")"
 export GKE_CLUSTER_NAME

--- a/.concourse/tasks/upgrade.sh
+++ b/.concourse/tasks/upgrade.sh
@@ -97,9 +97,9 @@ export KUBECFG="${KUBECONFIG}"
 pushd catapult
 CLUSTER_PASSWORD=$(tr -dc 'a-zA-Z0-9' < /dev/random | fold -w 32 | head -n 1)
 export CLUSTER_PASSWORD
-# Bring up a k8s cluster and builds+deploy kubecf
-# https://github.com/SUSE/catapult/wiki/Build-and-run-SCF#build-and-run-kubecf
+# Import k8s cluster
 make kubeconfig
+# Deploy kubecf from public GH release
 make kubecf kubecf-login
 
 # Setup dns


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Remove unneeded vars in the upgrade pipeline task, use defaults already present.
Set Catapult vars to not download and install gcloud inline and provide plaintext input.
Perform `cf login` after `helm install` and afer `helm upgrade`, as sanity check.

## Motivation and Context
Speeds up the test because gcloud cli is not downloaded and installed, makes clearer what is happening.

## How Has This Been Tested?
Not tested. Because of line https://github.com/cloudfoundry-incubator/kubecf/blob/viccuad-upgrade-clobber/.concourse/pipeline.yaml.gomplate#L1401, one needs to deploy a pipeline that targets this `viccuad-upgrade-clobber` branch, and that is blocked by https://github.com/cloudfoundry-incubator/kubecf/issues/1032.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
