### PR TITLE
Login only after setting DNS

### DIFF
--- a/.concourse/tasks/upgrade.sh
+++ b/.concourse/tasks/upgrade.sh
@@ -101,7 +101,7 @@ export CLUSTER_PASSWORD
 # Import k8s cluster
 make kubeconfig
 # Deploy kubecf from public GH release
-make kubecf kubecf-login
+make kubecf
 
 # Setup dns
 tcp_router_ip=$(kubectl  get svc -n scf tcp-router-public -o json | jq -r .status.loadBalancer.ingress[].ip | head -n 1)
@@ -115,6 +115,9 @@ gcloud --quiet beta dns --project="${GKE_PROJECT}" record-sets transaction add \
   --name="tcp.${DOMAIN}." --ttl=300 --type=A --zone="${GKE_DNS_ZONE}" "$tcp_router_ip"
 gcloud --quiet beta dns --project="${GKE_PROJECT}" record-sets transaction execute \
   --zone="${GKE_DNS_ZONE}"
+
+# Do cf login as sanity check
+make kubecf-login
 
 # Now upgrade to whatever chart we built for commit-to-test
 # The chart should be in s3.kubecf-ci directory


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Login only after setting DNS, instead of before, which surely fails.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- An important detail to include is the version of the used cf-operator -->
Not tested. Because of line https://github.com/cloudfoundry-incubator/kubecf/blob/viccuad-upgrade-clobber/.concourse/pipeline.yaml.gomplate#L1401, one needs to deploy a pipeline that targets this viccuad-upgrade-clobber branch, and that is blocked by #1032.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
