### PR TITLE
Fix failing lint stage

### DIFF
--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -4,7 +4,7 @@
 # Variables
 {{ $availableCfSchedulers := slice "diego" "eirini" }} # Diego / Eirini
 {{ $pr_resources := slice "pr" "fork-pr" }}
-{{ $branches := slice "master" "release-2.2"}} # Repository branches to track
+{{ $branches := slice "jbuns-add-ubi-stack" }} # Repository branches to track
 
 # Split Concourse jobs in tabs (aka groups)
 # We split by "branch" and we also split the "experimental" jobs of each branch.

--- a/.concourse/tasks/upgrade.sh
+++ b/.concourse/tasks/upgrade.sh
@@ -110,7 +110,7 @@ public_router_ip=$(kubectl get svc -n scf router-public -o json | jq -r .status.
 
 gcloud --quiet beta dns --project="${GKE_PROJECT}" record-sets transaction start \
        --zone="${GKE_DNS_ZONE}"
-gcloud --quiet beta dns --project=${GKE_PROJECT} record-sets transaction add \
+gcloud --quiet beta dns --project="${GKE_PROJECT}" record-sets transaction add \
        --name="\*.${DOMAIN}." --ttl=300 --type=A --zone="${GKE_DNS_ZONE}" "$public_router_ip"
 gcloud --quiet beta dns --project="${GKE_PROJECT}" record-sets transaction add \
        --name=tcp."${DOMAIN}." --ttl=300 --type=A --zone="${GKE_DNS_ZONE}" "$tcp_router_ip"

--- a/.concourse/tasks/upgrade.sh
+++ b/.concourse/tasks/upgrade.sh
@@ -108,14 +108,14 @@ make kubecf
 tcp_router_ip=$(kubectl get svc -n scf tcp-router-public -o json | jq -r .status.loadBalancer.ingress[].ip | head -n 1)
 public_router_ip=$(kubectl get svc -n scf router-public -o json | jq -r .status.loadBalancer.ingress[].ip | head -n 1)
 
-gcloud --quiet beta dns --project=${GKE_PROJECT} record-sets transaction start \
-       --zone=${GKE_DNS_ZONE}
+gcloud --quiet beta dns --project="${GKE_PROJECT}" record-sets transaction start \
+       --zone="${GKE_DNS_ZONE}"
 gcloud --quiet beta dns --project=${GKE_PROJECT} record-sets transaction add \
-       --name=\*.${DOMAIN}. --ttl=300 --type=A --zone=${GKE_DNS_ZONE} $public_router_ip
-gcloud --quiet beta dns --project=${GKE_PROJECT} record-sets transaction add \
-       --name=tcp.${DOMAIN}. --ttl=300 --type=A --zone=${GKE_DNS_ZONE} $tcp_router_ip
-gcloud --quiet beta dns --project=${GKE_PROJECT} record-sets transaction execute \
-       --zone=${GKE_DNS_ZONE}
+       --name="\*.${DOMAIN}." --ttl=300 --type=A --zone="${GKE_DNS_ZONE}" "$public_router_ip"
+gcloud --quiet beta dns --project="${GKE_PROJECT}" record-sets transaction add \
+       --name=tcp."${DOMAIN}." --ttl=300 --type=A --zone="${GKE_DNS_ZONE}" "$tcp_router_ip"
+gcloud --quiet beta dns --project="${GKE_PROJECT}" record-sets transaction execute \
+       --zone="${GKE_DNS_ZONE}"
 
 # Do cf login as sanity check
 make kubecf-login


### PR DESCRIPTION
## Description
Added back double quotes variables in:
https://github.com/cloudfoundry-incubator/kubecf/blob/master/.concourse/tasks/upgrade.sh

## Motivation and Context
Removing the double quotes fails lint stage in pipelines:
https://concourse.suse.dev/teams/main/pipelines/kubecf/jobs/lint-master/builds/4

## How Has This Been Tested?
Implementing fix to pipeline and running against local concourse

## Screenshots (if appropriate):
Before:
<img width="1440" alt="Screenshot 2020-06-22 at 18 08 12" src="https://user-images.githubusercontent.com/47635090/85316191-3dabbe80-b4b4-11ea-92dd-892919fb396c.png">
After:
<img width="1440" alt="Screenshot 2020-06-22 at 18 08 37" src="https://user-images.githubusercontent.com/47635090/85316206-4a301700-b4b4-11ea-92c8-c96fc6b22efb.png">

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code has security implications.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
