### PR TITLE
Fix for failing update-test during lint stage

### DIFF
--- a/.concourse/tasks/upgrade.sh
+++ b/.concourse/tasks/upgrade.sh
@@ -108,14 +108,14 @@ make kubecf
 tcp_router_ip=$(kubectl get svc -n scf tcp-router-public -o json | jq -r .status.loadBalancer.ingress[].ip | head -n 1)
 public_router_ip=$(kubectl get svc -n scf router-public -o json | jq -r .status.loadBalancer.ingress[].ip | head -n 1)
 
-gcloud --quiet beta dns --project=${GKE_PROJECT} record-sets transaction start \
-       --zone=${GKE_DNS_ZONE}
-gcloud --quiet beta dns --project=${GKE_PROJECT} record-sets transaction add \
-       --name=\*.${DOMAIN}. --ttl=300 --type=A --zone=${GKE_DNS_ZONE} $public_router_ip
-gcloud --quiet beta dns --project=${GKE_PROJECT} record-sets transaction add \
-       --name=tcp.${DOMAIN}. --ttl=300 --type=A --zone=${GKE_DNS_ZONE} $tcp_router_ip
-gcloud --quiet beta dns --project=${GKE_PROJECT} record-sets transaction execute \
-       --zone=${GKE_DNS_ZONE}
+gcloud --quiet beta dns --project="${GKE_PROJECT}" record-sets transaction start \
+       --zone="${GKE_DNS_ZONE}"
+gcloud --quiet beta dns --project="${GKE_PROJECT}" record-sets transaction add \
+       --name="\*.${DOMAIN}." --ttl=300 --type=A --zone="${GKE_DNS_ZONE}" "$public_router_ip"
+gcloud --quiet beta dns --project="${GKE_PROJECT}" record-sets transaction add \
+       --name=tcp."${DOMAIN}." --ttl=300 --type=A --zone="${GKE_DNS_ZONE}" "$tcp_router_ip"
+gcloud --quiet beta dns --project="${GKE_PROJECT}" record-sets transaction execute \
+       --zone="${GKE_DNS_ZONE}"
 
 # Do cf login as sanity check
 make kubecf-login

--- a/.concourse/tasks/upgrade.sh
+++ b/.concourse/tasks/upgrade.sh
@@ -113,7 +113,7 @@ gcloud --quiet beta dns --project="${GKE_PROJECT}" record-sets transaction start
 gcloud --quiet beta dns --project="${GKE_PROJECT}" record-sets transaction add \
        --name="\*.${DOMAIN}." --ttl=300 --type=A --zone="${GKE_DNS_ZONE}" "$public_router_ip"
 gcloud --quiet beta dns --project="${GKE_PROJECT}" record-sets transaction add \
-       --name=tcp."${DOMAIN}." --ttl=300 --type=A --zone="${GKE_DNS_ZONE}" "$tcp_router_ip"
+       --name="tcp.${DOMAIN}." --ttl=300 --type=A --zone="${GKE_DNS_ZONE}" "${tcp_router_ip}"
 gcloud --quiet beta dns --project="${GKE_PROJECT}" record-sets transaction execute \
        --zone="${GKE_DNS_ZONE}"
 

--- a/.concourse/tasks/upgrade.sh
+++ b/.concourse/tasks/upgrade.sh
@@ -111,7 +111,7 @@ public_router_ip=$(kubectl get svc -n scf router-public -o json | jq -r .status.
 gcloud --quiet beta dns --project="${GKE_PROJECT}" record-sets transaction start \
        --zone="${GKE_DNS_ZONE}"
 gcloud --quiet beta dns --project="${GKE_PROJECT}" record-sets transaction add \
-       --name="\*.${DOMAIN}." --ttl=300 --type=A --zone="${GKE_DNS_ZONE}" "$public_router_ip"
+       --name="*.${DOMAIN}." --ttl=300 --type=A --zone="${GKE_DNS_ZONE}" "$public_router_ip"
 gcloud --quiet beta dns --project="${GKE_PROJECT}" record-sets transaction add \
        --name="tcp.${DOMAIN}." --ttl=300 --type=A --zone="${GKE_DNS_ZONE}" "${tcp_router_ip}"
 gcloud --quiet beta dns --project="${GKE_PROJECT}" record-sets transaction execute \


### PR DESCRIPTION
## Description
Added back double quotes variables in:
https://github.com/cloudfoundry-incubator/kubecf/blob/master/.concourse/tasks/upgrade.sh

## Motivation and Context
Removing the double quotes fails lint stage in pipelines:
https://concourse.suse.dev/teams/main/pipelines/kubecf/jobs/lint-master/builds/4

## How Has This Been Tested?
Implementing fix to pipeline and running against local concourse

## Screenshots (if appropriate):
Before:
<img width="1440" alt="Screenshot 2020-06-22 at 18 08 12" src="https://user-images.githubusercontent.com/47635090/85317601-895f6780-b4b6-11ea-9b88-cc2e9ef75eb8.png">

After:
<img width="1440" alt="Screenshot 2020-06-22 at 18 08 37" src="https://user-images.githubusercontent.com/47635090/85317620-92503900-b4b6-11ea-854e-ef0556e51765.png">

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code has security implications.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
