### PR TITLE
move variables from pipeline definition to config file

### DIFF
--- a/.concourse/kubecf.yaml
+++ b/.concourse/kubecf.yaml
@@ -20,3 +20,38 @@ gke_domain: kubecf.ci
 # the pipeline:
 trigger_publish: true
 github_status: true
+
+availableCfSchedulers: # Diego / Eirini
+- diego
+- eirini
+
+branches: # Repository branches to track
+- master
+- release-2.2
+- release-2.3
+pr_resources:
+- pr
+
+# Stable Jobs
+# TODO: Delete the special case here as soon as we get Eirini CATS green and we stabilize Eirini smoke (e.g. with a more large timeout)
+stable_jobs:
+- lint
+- build
+- deploy-diego
+- deploy-eirini
+- smoke-tests-diego
+- smoke-tests-eirini
+- cf-acceptance-tests-diego
+- cats-internetless-diego
+- sync-integration-tests
+- ccdb-rotate-diego
+- smoke-tests-post-rotate-diego
+- upgrade-test
+- cleanup-diego-cluster
+- cleanup-eirini-cluster
+
+experimental_jobs:
+- cf-acceptance-tests-eirini
+- cats-internetless-eirini
+- ccdb-rotate-eirini
+- smoke-tests-post-rotate-eirini

--- a/.concourse/kubecf.yaml
+++ b/.concourse/kubecf.yaml
@@ -33,7 +33,6 @@ pr_resources:
 - pr
 
 # Stable Jobs
-# TODO: Delete the special case here as soon as we get Eirini CATS green and we stabilize Eirini smoke (e.g. with a more large timeout)
 stable_jobs:
 - lint
 - build

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -1,24 +1,13 @@
 # load the config provided when evaluating the template
 {{ $config := (datasource "config") }}
 
-# Variables
-{{ $availableCfSchedulers := slice "diego" "eirini" }} # Diego / Eirini
-{{ $pr_resources := slice "pr" }}
-{{ $branches := slice "master" "release-2.2" "release-2.3"}} # Repository branches to track
-
 # Split Concourse jobs in tabs (aka groups)
 # We split by "branch" and we also split the "experimental" jobs of each branch.
-
-# Stable Jobs
-# TODO: Delete the special case here as soon as we get Eirini CATS green and we stabilize Eirini smoke (e.g. with a more large timeout)
-{{ $stable := slice "lint" "build" "deploy-diego" "deploy-eirini" "smoke-tests-diego" "smoke-tests-eirini" "cf-acceptance-tests-diego" "cats-internetless-diego" "sync-integration-tests" "ccdb-rotate-diego" "smoke-tests-post-rotate-diego" "upgrade-test" "cleanup-diego-cluster" "cleanup-eirini-cluster" }}
-{{ $experimental := slice "cf-acceptance-tests-eirini" "cats-internetless-eirini" "ccdb-rotate-eirini" "smoke-tests-post-rotate-eirini" }}
-
 groups:
-{{ range $_, $branch := (flatten (slice $branches $pr_resources) | uniq) }}
+{{ range $_, $branch := (flatten (slice $config.branches $config.pr_resources) | uniq) }}
 - name: {{ $branch }}
   jobs:
-  {{ range $_, $job := $stable }}
+  {{ range $_, $job := $config.stable_jobs }}
   - {{ $job }}-{{ $branch }}
   {{ end }}
   {{ if not ($branch | regexp.Match "^pr") }}
@@ -26,7 +15,7 @@ groups:
   {{ end }}
 - name: {{ $branch }}-experimental
   jobs:
-  {{ range $_, $job := $experimental }}
+  {{ range $_, $job := $config.experimental_jobs }}
   - {{ $job }}-{{ $branch }}
   {{ end }}
 {{ end }}
@@ -57,8 +46,8 @@ resources:
     repository: kubecf
     access_token: ((github-access-token))
 
-{{ range $_, $branch := (flatten (slice $branches $pr_resources) | uniq) }}
-{{- range $_, $cfScheduler := $availableCfSchedulers }}
+{{ range $_, $branch := (flatten (slice $config.branches $config.pr_resources) | uniq) }}
+{{- range $_, $cfScheduler := $config.availableCfSchedulers }}
 - name: semver.gke-cluster-{{ $branch }}-{{ $cfScheduler }}
   type: semver
   source:
@@ -84,7 +73,7 @@ resources:
 {{ end }} # prs and branches (flattened)
 
 
-{{- range $_, $branch := $branches }}
+{{- range $_, $branch := $config.branches }}
 - name: kubecf-{{ $branch }}
   type: git
   source:
@@ -107,7 +96,7 @@ resources:
     access_token: ((github-access-token))
     required_review_approvals: 1
 
-{{- range $_, $pr := $pr_resources }}
+{{- range $_, $pr := $config.pr_resources }}
 
 {{- if $config.github_status }}
 - name: status-{{$pr}}.src
@@ -300,7 +289,7 @@ rotate_args: &rotate_args
 jobs:
 
 {{ $path := "" }}
-{{- range $_, $branch := flatten (slice $branches $pr_resources)  }}
+{{- range $_, $branch := flatten (slice $config.branches $config.pr_resources)  }}
 
 {{ if ( eq $branch "pr" )}}
 {{ $path = ".git/resource/head_sha" }}
@@ -315,7 +304,7 @@ jobs:
   - get: kubecf-{{ $branch }}
     trigger: true
     version: "every"
-{{- if has $stable "lint" }}
+{{- if has $config.stable_jobs "lint" }}
   {{- if $config.github_status }}
   - put: status-{{ $branch }}.src
     params: &lint_{{ $sanitized_branch_name }}_status
@@ -346,7 +335,7 @@ jobs:
           ./dev/linters/helmlint.sh
           bazel test //rules/kubecf:create_sample_values_test
 
-{{- if has $stable "lint" }}
+{{- if has $config.stable_jobs "lint" }}
     {{- if $config.github_status }}
     on_success:
       put: status-{{ $branch }}.src
@@ -369,7 +358,7 @@ jobs:
     version: "every"
     passed:
     - lint-{{ $branch }}
-{{- if has $stable "build" }}
+{{- if has $config.stable_jobs "build" }}
   {{- if $config.github_status }}
   - put: status-{{ $branch }}.src
     params: &build_{{ $sanitized_branch_name }}_status
@@ -403,7 +392,7 @@ jobs:
               mv "$file" "${file%.tgz}-${timestamp}.tgz"
           done
 
-{{- if has $stable "build" }}
+{{- if has $config.stable_jobs "build" }}
     {{- if $config.github_status }}
     on_success:
       put: status-{{ $branch }}.src
@@ -426,7 +415,7 @@ jobs:
       file: output/kubecf-bundle-v*.tgz
       acl: public-read
 
-{{- range $_, $cfScheduler := $availableCfSchedulers }}
+{{- range $_, $cfScheduler := $config.availableCfSchedulers }}
 
 # prod-jobs
 - name: deploy-{{ $cfScheduler }}-{{ $branch }}
@@ -446,7 +435,7 @@ jobs:
     passed:
     - build-{{ $branch }}
   - get: catapult
-{{- if has $stable (printf "deploy-%s" $cfScheduler) }}
+{{- if has $config.stable_jobs (printf "deploy-%s" $cfScheduler) }}
   {{- if $config.github_status }}
   - put: status-{{ $branch }}.src
     params: &deploy_{{ $cfScheduler }}_{{ $sanitized_branch_name }}_status
@@ -484,7 +473,7 @@ jobs:
       run:
         path: "/bin/bash"
         args: *deploy_args
-{{- if has $stable (printf "deploy-%s" $cfScheduler) }}
+{{- if has $config.stable_jobs (printf "deploy-%s" $cfScheduler) }}
   {{- if $config.github_status }}
   on_success:
     do:
@@ -496,7 +485,7 @@ jobs:
 {{- end }}
   on_failure:
     in_parallel:
-{{- if has $stable (printf "deploy-%s" $cfScheduler) }}
+{{- if has $config.stable_jobs (printf "deploy-%s" $cfScheduler) }}
   {{- if $config.github_status }}
     - try:
         put: status-{{ $branch }}.src
@@ -581,7 +570,7 @@ jobs:
         params:
           BRANCH: {{ $branch }}
           CFSCHEDULER: {{ $cfScheduler }}
-{{- if has $stable (printf "deploy-%s" $cfScheduler) }}
+{{- if has $config.stable_jobs (printf "deploy-%s" $cfScheduler) }}
     {{- if $config.github_status }}
     - try:
         put: status-{{ $branch }}.src
@@ -597,7 +586,7 @@ jobs:
         params:
           BRANCH: {{ $branch }}
           CFSCHEDULER: {{ $cfScheduler }}
-{{- if has $stable (printf "deploy-%s" $cfScheduler) }}
+{{- if has $config.stable_jobs (printf "deploy-%s" $cfScheduler) }}
     {{- if $config.github_status }}
     - try:
         put: status-{{ $branch }}.src
@@ -627,7 +616,7 @@ jobs:
     - deploy-{{ $cfScheduler }}-{{ $branch }}
     trigger: true
   - get: catapult
-{{- if has $stable (printf "smoke-tests-%s" $cfScheduler) }}
+{{- if has $config.stable_jobs (printf "smoke-tests-%s" $cfScheduler) }}
   {{- if $config.github_status }}
   - put: status-{{ $branch }}.src
     params: &smoke_{{ $cfScheduler }}_{{ $sanitized_branch_name }}_status
@@ -659,7 +648,7 @@ jobs:
       run:
         path: "/bin/bash"
         args: *test_args
-{{- if has $stable (printf "smoke-tests-%s" $cfScheduler) }}
+{{- if has $config.stable_jobs (printf "smoke-tests-%s" $cfScheduler) }}
   {{- if $config.github_status }}
   on_success:
     put: status-{{ $branch }}.src
@@ -670,7 +659,7 @@ jobs:
 {{- end }}
   on_failure:
     in_parallel:
-{{- if has $stable (printf "smoke-tests-%s" $cfScheduler) }}
+{{- if has $config.stable_jobs (printf "smoke-tests-%s" $cfScheduler) }}
     {{- if $config.github_status }}
     - try:
         put: status-{{ $branch }}.src
@@ -691,7 +680,7 @@ jobs:
         params:
           BRANCH: {{ $branch }}
           CFSCHEDULER: {{ $cfScheduler }}
-{{- if has $stable (printf "smoke-tests-%s" $cfScheduler) }}
+{{- if has $config.stable_jobs (printf "smoke-tests-%s" $cfScheduler) }}
     {{- if $config.github_status }}
     - try:
         put: status-{{ $branch }}.src
@@ -707,7 +696,7 @@ jobs:
         params:
           BRANCH: {{ $branch }}
           CFSCHEDULER: {{ $cfScheduler }}
-{{- if has $stable (printf "smoke-tests-%s" $cfScheduler) }}
+{{- if has $config.stable_jobs (printf "smoke-tests-%s" $cfScheduler) }}
     {{- if $config.github_status }}
     - try:
         put: status-{{ $branch }}.src
@@ -736,7 +725,7 @@ jobs:
     - {{ $previousTest | quote }}
     trigger: true
   - get: catapult
-{{- if has $stable (printf "cf-acceptance-tests-%s" $cfScheduler) }}
+{{- if has $config.stable_jobs (printf "cf-acceptance-tests-%s" $cfScheduler) }}
   {{- if $config.github_status }}
   - put: status-{{ $branch }}.src
     params: &cats_{{ $cfScheduler }}_{{ $sanitized_branch_name }}_status
@@ -769,7 +758,7 @@ jobs:
         path: "/bin/bash"
         args: *test_args
 
-{{- if has $stable (printf "cf-acceptance-tests-%s" $cfScheduler) }}
+{{- if has $config.stable_jobs (printf "cf-acceptance-tests-%s" $cfScheduler) }}
   {{- if $config.github_status }}
   on_success:
     put: status-{{ $branch }}.src
@@ -786,7 +775,7 @@ jobs:
         params:
           BRANCH: {{ $branch }}
           CFSCHEDULER: {{ $cfScheduler }}
-{{- if has $stable (printf "cf-acceptance-tests-%s" $cfScheduler) }}
+{{- if has $config.stable_jobs (printf "cf-acceptance-tests-%s" $cfScheduler) }}
     {{- if $config.github_status }}
     - try:
         put: status-{{ $branch }}.src
@@ -802,7 +791,7 @@ jobs:
         params:
           BRANCH: {{ $branch }}
           CFSCHEDULER: {{ $cfScheduler }}
-{{- if has $stable (printf "cf-acceptance-tests-%s" $cfScheduler) }}
+{{- if has $config.stable_jobs (printf "cf-acceptance-tests-%s" $cfScheduler) }}
     {{- if $config.github_status }}
     - try:
         put: status-{{ $branch }}.src
@@ -818,7 +807,7 @@ jobs:
         params:
           BRANCH: {{ $branch }}
           CFSCHEDULER: {{ $cfScheduler }}
-{{- if has $stable (printf "cf-acceptance-tests-%s" $cfScheduler) }}
+{{- if has $config.stable_jobs (printf "cf-acceptance-tests-%s" $cfScheduler) }}
     {{- if $config.github_status }}
     - try:
         put: status-{{ $branch }}.src
@@ -847,7 +836,7 @@ jobs:
     - {{ $previousTest | quote }}
     trigger: true
   - get: catapult
-{{- if has $stable (printf "cats-internetless-%s" $cfScheduler) }}
+{{- if has $config.stable_jobs (printf "cats-internetless-%s" $cfScheduler) }}
   {{- if $config.github_status }}
   - put: status-{{ $branch }}.src
     params: &cats_internetless_{{ $cfScheduler }}_{{ $sanitized_branch_name }}_status
@@ -881,7 +870,7 @@ jobs:
         path: "/bin/bash"
         args: *test_args
 
-{{- if has $stable (printf "cats-internetless-%s" $cfScheduler) }}
+{{- if has $config.stable_jobs (printf "cats-internetless-%s" $cfScheduler) }}
   {{- if $config.github_status }}
   on_success:
     put: status-{{ $branch }}.src
@@ -897,7 +886,7 @@ jobs:
         params:
           BRANCH: {{ $branch }}
           CFSCHEDULER: {{ $cfScheduler }}
-{{- if has $stable (printf "cats-internetless-%s" $cfScheduler) }}
+{{- if has $config.stable_jobs (printf "cats-internetless-%s" $cfScheduler) }}
     {{- if $config.github_status }}
     - try:
         put: status-{{ $branch }}.src
@@ -913,7 +902,7 @@ jobs:
         params:
           BRANCH: {{ $branch }}
           CFSCHEDULER: {{ $cfScheduler }}
-{{- if has $stable (printf "cats-internetless-%s" $cfScheduler) }}
+{{- if has $config.stable_jobs (printf "cats-internetless-%s" $cfScheduler) }}
     {{- if $config.github_status }}
     - try:
         put: status-{{ $branch }}.src
@@ -929,7 +918,7 @@ jobs:
         params:
           BRANCH: {{ $branch }}
           CFSCHEDULER: {{ $cfScheduler }}
-{{- if has $stable (printf "cats-internetless-%s" $cfScheduler) }}
+{{- if has $config.stable_jobs (printf "cats-internetless-%s" $cfScheduler) }}
     {{- if $config.github_status }}
     - try:
         put: status-{{ $branch }}.src
@@ -961,7 +950,7 @@ jobs:
     - {{ $previousTest | quote }}
     trigger: true
   - get: catapult
-{{- if has $stable "sync-integration-tests" }}
+{{- if has $config.stable_jobs "sync-integration-tests" }}
   {{- if $config.github_status }}
   - put: status-{{ $branch }}.src
     params: &sits_{{ $sanitized_branch_name }}_status
@@ -993,7 +982,7 @@ jobs:
       run:
         path: "/bin/bash"
         args: *test_args
-{{- if has $stable "sync-integration-tests" }}
+{{- if has $config.stable_jobs "sync-integration-tests" }}
   {{- if $config.github_status }}
   on_success:
     put: status-{{ $branch }}.src
@@ -1004,7 +993,7 @@ jobs:
 {{- end }}
   on_failure:
     in_parallel:
-{{- if has $stable "sync-integration-tests" }}
+{{- if has $config.stable_jobs "sync-integration-tests" }}
     {{- if $config.github_status }}
     - try:
         put: status-{{ $branch }}.src
@@ -1025,7 +1014,7 @@ jobs:
         params:
           BRANCH: {{ $branch }}
           CFSCHEDULER: {{ $cfScheduler }}
-{{- if has $stable "sync-integration-tests" }}
+{{- if has $config.stable_jobs "sync-integration-tests" }}
     {{- if $config.github_status }}
     - try:
         put: status-{{ $branch }}.src
@@ -1042,7 +1031,7 @@ jobs:
         params:
           BRANCH: {{ $branch }}
           CFSCHEDULER: {{ $cfScheduler }}
-{{- if has $stable "sync-integration-tests" }}
+{{- if has $config.stable_jobs "sync-integration-tests" }}
     {{- if $config.github_status }}
     - try:
         put: status-{{ $branch }}.src
@@ -1072,7 +1061,7 @@ jobs:
     - {{ $previousTest | quote }}
     trigger: true
   - get: catapult
-{{- if has $stable (printf "rotate-%s" $cfScheduler) }}
+{{- if has $config.stable_jobs (printf "rotate-%s" $cfScheduler) }}
   {{- if $config.github_status }}
   - put: status-{{ $branch }}.src
     params: &rotate_{{ $cfScheduler }}_{{ $sanitized_branch_name }}_status
@@ -1104,7 +1093,7 @@ jobs:
         path: "/bin/bash"
         args: *rotate_args
 
-{{- if has $stable (printf "rotate-%s" $cfScheduler) }}
+{{- if has $config.stable_jobs (printf "rotate-%s" $cfScheduler) }}
   {{- if $config.github_status }}
   on_success:
     put: status-{{ $branch }}.src
@@ -1116,7 +1105,7 @@ jobs:
 
   on_failure:
     in_parallel:
-{{- if has $stable (printf "rotate-%s" $cfScheduler) }}
+{{- if has $config.stable_jobs (printf "rotate-%s" $cfScheduler) }}
     {{- if $config.github_status }}
     - try:
         put: status-{{ $branch }}.src
@@ -1137,7 +1126,7 @@ jobs:
         params:
           BRANCH: {{ $branch }}
           CFSCHEDULER: {{ $cfScheduler }}
-{{- if has $stable (printf "rotate-%s" $cfScheduler) }}
+{{- if has $config.stable_jobs (printf "rotate-%s" $cfScheduler) }}
     {{- if $config.github_status }}
     - try:
         put: status-{{ $branch }}.src
@@ -1153,7 +1142,7 @@ jobs:
         params:
           BRANCH: {{ $branch }}
           CFSCHEDULER: {{ $cfScheduler }}
-{{- if has $stable (printf "rotate-%s" $cfScheduler) }}
+{{- if has $config.stable_jobs (printf "rotate-%s" $cfScheduler) }}
     {{- if $config.github_status }}
     - try:
         put: status-{{ $branch }}.src
@@ -1182,7 +1171,7 @@ jobs:
     - {{ $previousTest | quote }}
     trigger: true
   - get: catapult
-{{- if has $stable (printf "smoke-rotated-{%s" $cfScheduler) }}
+{{- if has $config.stable_jobs (printf "smoke-rotated-{%s" $cfScheduler) }}
   {{- if $config.github_status }}
   - put: status-{{ $branch }}.src
     params: &smoke_rotate_{{ $cfScheduler }}_{{ $sanitized_branch_name }}_status
@@ -1215,7 +1204,7 @@ jobs:
         path: "/bin/bash"
         args: *test_args
 
-{{- if has $stable (printf "smoke-rotated-{%s" $cfScheduler) }}
+{{- if has $config.stable_jobs (printf "smoke-rotated-{%s" $cfScheduler) }}
   {{- if $config.github_status }}
   on_success:
     put: status-{{ $branch }}.src
@@ -1227,7 +1216,7 @@ jobs:
 
   on_failure:
     in_parallel:
-{{- if has $stable (printf "smoke-rotated-{%s" $cfScheduler) }}
+{{- if has $config.stable_jobs (printf "smoke-rotated-{%s" $cfScheduler) }}
     {{- if $config.github_status }}
     - try:
         put: status-{{ $branch }}.src
@@ -1248,7 +1237,7 @@ jobs:
         params:
           BRANCH: {{ $branch }}
           CFSCHEDULER: {{ $cfScheduler }}
-{{- if has $stable (printf "smoke-rotated-{%s" $cfScheduler) }}
+{{- if has $config.stable_jobs (printf "smoke-rotated-{%s" $cfScheduler) }}
     {{- if $config.github_status }}
     - try:
         put: status-{{ $branch }}.src
@@ -1264,7 +1253,7 @@ jobs:
         params:
           BRANCH: {{ $branch }}
           CFSCHEDULER: {{ $cfScheduler }}
-{{- if has $stable (printf "smoke-rotated-{%s" $cfScheduler) }}
+{{- if has $config.stable_jobs (printf "smoke-rotated-{%s" $cfScheduler) }}
     {{- if $config.github_status }}
     - try:
         put: status-{{ $branch }}.src


### PR DESCRIPTION
move variables from pipeline definition to config file - https://github.com/cloudfoundry-incubator/kubecf/issues/1084


## Description

- Moved variables from pipeline definition to config file: kubecf.yaml

- Renamed `stable ` and `experimental` to `stable_jobs` and `experimental_jobs`, respectively 

## How Has This Been Tested?
https://concourse.suse.dev/teams/main/pipelines/prabal-kubecf?group=pr

When kubecf CI will be updated with this kubecf.yaml, there will be `no changes to apply` to the CI.

