### PR TITLE
CI: Move green jobs to the production tab

### DIFF
--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -1415,11 +1415,11 @@ jobs:
   plan:
   - get: s3.kubecf-ci
     passed:
-    - cf-acceptance-tests-diego-{{ $branch }}
+    - smoke-tests-post-rotate-diego-{{ $branch }}
     trigger: {{ $config.trigger_publish }}
   - get: s3.kubecf-ci-bundle
     passed:
-    - cf-acceptance-tests-diego-{{ $branch }}
+    - smoke-tests-post-rotate-diego-{{ $branch }}
     trigger: {{ $config.trigger_publish }}
   - task: rename-artifacts
     config:

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -11,8 +11,8 @@
 
 # Stable Jobs
 # TODO: Delete the special case here as soon as we get Eirini CATS green and we stabilize Eirini smoke (e.g. with a more large timeout)
-{{ $stable := slice "lint" "build" "deploy-diego" "deploy-eirini" "smoke-tests-diego" "smoke-tests-eirini" "cf-acceptance-tests-diego" "cleanup-diego-cluster" "cleanup-eirini-cluster" }}
-{{ $experimental := slice "cf-acceptance-tests-eirini" "cats-internetless-diego" "cats-internetless-eirini" "sync-integration-tests" "ccdb-rotate-diego" "ccdb-rotate-eirini" "smoke-tests-post-rotate-diego" "smoke-tests-post-rotate-eirini" "upgrade-test" }}
+{{ $stable := slice "lint" "build" "deploy-diego" "deploy-eirini" "smoke-tests-diego" "smoke-tests-eirini" "cf-acceptance-tests-diego" "cats-internetless-diego" "sync-integration-tests" "ccdb-rotate-diego" "smoke-tests-post-rotate-diego" "upgrade-test" "cleanup-diego-cluster" "cleanup-eirini-cluster" }}
+{{ $experimental := slice "cf-acceptance-tests-eirini" "cats-internetless-eirini" "ccdb-rotate-eirini" "smoke-tests-post-rotate-eirini" }}
 
 groups:
 {{ range $_, $branch := (flatten (slice $branches $pr_resources) | uniq) }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Move green jobs to the production tab. A full CI run seems will take ~2 1/2 hours.

Once this is merged, the GH status check for them need to be [enabled](https://help.github.com/en/github/administering-a-repository/enabling-required-status-checks).


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

To gate PRs by the green jobs and not introduce regressions.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- An important detail to include is the version of the used cf-operator -->
Deployed https://concourse.suse.dev/teams/main/pipelines/kubecf-viccuad
That pipeline is deployed with the changes on the `viccuad-mv-prod-jobs`, plus _also_ tracking this branch:
```patch
-{{ $branches := slice "master" "release-2.2" "release-2.3"}} # Repository branches to track
+{{ $branches := slice "viccuad-mv-prod-jobs" }} # Repository branches to track
```

Currently, jobs and pipeline are paused. To test this PR:
1. Approve PR. this will put it in the queue
2. Pin this PR number in https://concourse.suse.dev/teams/main/pipelines/kubecf-viccuad/resources/kubecf-pr
3. Unpause the [lint-pr job](https://concourse.suse.dev/teams/main/pipelines/kubecf-viccuad/jobs/lint-pr) and the full pipeline.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
