### PR TITLE
Add comment on why we cannot upstream the routing-api bpm patch

### DIFF
--- a/bosh/releases/pre_render_scripts/routing-api/routing-api/bpm/patch_bpm.sh
+++ b/bosh/releases/pre_render_scripts/routing-api/routing-api/bpm/patch_bpm.sh
@@ -3,7 +3,7 @@
 # This patch changes the BPM command to not use spec.ip because the
 # quarks-operator implements process management very differently from
 # BOSH: BPM is rendered from a completely different container (and
-# therefore has no chance of having a valid spec.ip.
+# therefore has no chance of having a valid spec.ip).
 #
 # We have no idea how we can implement the change in an upstream-
 # compatible way: we hack around things by changing the POD_IP

--- a/bosh/releases/pre_render_scripts/routing-api/routing-api/bpm/patch_bpm.sh
+++ b/bosh/releases/pre_render_scripts/routing-api/routing-api/bpm/patch_bpm.sh
@@ -7,8 +7,10 @@
 #
 # We have no idea how we can implement the change in an upstream-
 # compatible way: we hack around things by changing the POD_IP
-# environment variable via an ops file, which wouldn't make any sense
-# in the BOSH VM world.
+# environment variable via an ops file [1], which wouldn't make any
+# sense in the BOSH VM world.
+#
+# [1] deploy/helm/kubecf/assets/operations/instance_groups/routing-api.yaml
 #
 # Result: The patch is extremely specific to kubecf, and cannot be
 # upstreamed.

--- a/bosh/releases/pre_render_scripts/routing-api/routing-api/bpm/patch_bpm.sh
+++ b/bosh/releases/pre_render_scripts/routing-api/routing-api/bpm/patch_bpm.sh
@@ -1,5 +1,18 @@
 #!/usr/bin/env bash
 
+# This patch changes the BPM command to not use spec.ip because the
+# quarks-operator implements process management very differently from
+# BOSH: BPM is rendered from a completely different container (and
+# therefore has no chance of having a valid spec.ip.
+#
+# We have no idea how we can implement the change in an upstream-
+# compatible way: we hack around things by changing the POD_IP
+# environment variable via an ops file, which wouldn't make any sense
+# in the BOSH VM world.
+#
+# Result: The patch is extremely specific to kubecf, and cannot be
+# upstreamed.
+
 set -o errexit -o nounset
 
 target="/var/vcap/all-releases/jobs-src/routing/routing-api/templates/bpm.yml.erb"


### PR DESCRIPTION

## Description

Just added comments to the patch script explaining why we cannot upstream.

## Motivation and Context

See #521 for the discussion.

## How Has This Been Tested?

No testing was done, pure comment changes.

## Types of changes

- [x] Comments. No functional change.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code has security implications.
- [x] My code/comment follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
