### PR TITLE
CI: Add GH status reporting to upgrade when it is on stable jobs

### DIFF
--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -1366,6 +1366,16 @@ jobs:
     - get: catapult
     - put: semver.gke-cluster-{{ $branch }}-upgrade
       params: {bump: patch}
+{{- if has $stable (printf "upgrade-test") }}
+  {{- if $config.github_status }}
+  - put: status-{{ $branch }}.src
+    params: &upgrade-test_{{ $sanitized_branch_name }}_status
+        context: "upgrade-test"
+        description: "Upgrade from latest GH available release"
+        path: kubecf-{{ $branch }}/{{ $path }}
+        state: pending
+  {{- end }}
+{{- end }}
   - task: upgrade
     params:
       BRANCH: {{ $branch }}
@@ -1380,6 +1390,48 @@ jobs:
       semver.gke-cluster: semver.gke-cluster-{{ $branch }}-upgrade
     timeout: 4h
     file: kubecf-{{ $branch }}/.concourse/tasks/upgrade.yaml
+{{- if has $stable (printf "upgrade-test") }}
+  {{- if $config.github_status }}
+  on_success:
+    put: status-{{ $branch }}.src
+    params:
+      << : *upgrade-test_{{ $sanitized_branch_name }}_status
+      state: success
+  {{- end }}
+{{- end }}
+  on_failure:
+    in_parallel:
+{{- if has $stable (printf "upgrade-test") }}
+    {{- if $config.github_status }}
+    - try:
+        put: status-{{ $branch }}.src
+        params:
+          << : *upgrade-test_{{ $sanitized_branch_name }}_status
+          state: failure
+    {{- end }}
+{{- end }}
+  on_abort:
+    in_parallel:
+{{- if has $stable (printf "upgrade-test") }}
+    {{- if $config.github_status }}
+    - try:
+        put: status-{{ $branch }}.src
+        params:
+          << : *upgrade-test_{{ $sanitized_branch_name }}_status
+          state: failure
+    {{- end }}
+{{- end }}
+  on_error:
+    in_parallel:
+{{- if has $stable (printf "upgrade-test") }}
+    {{- if $config.github_status }}
+    - try:
+        put: status-{{ $branch }}.src
+        params:
+          << : *upgrade-test_{{ $sanitized_branch_name }}_status
+          state: failure
+    {{- end }}
+{{- end }}
   ensure:
     do:
       - << : *cleanup-cluster

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -1366,15 +1366,14 @@ jobs:
     - get: catapult
     - put: semver.gke-cluster-{{ $branch }}-upgrade
       params: {bump: patch}
-{{- if has $stable (printf "upgrade-test") }}
-  {{- if $config.github_status }}
+
+{{- if (has $config.stable_jobs "upgrade-test") and $config.github_status }}
   - put: status-{{ $branch }}.src
     params: &upgrade-test_{{ $sanitized_branch_name }}_status
         context: "upgrade-test"
         description: "Upgrade from latest GH available release"
         path: kubecf-{{ $branch }}/{{ $path }}
         state: pending
-  {{- end }}
 {{- end }}
   - task: upgrade
     params:
@@ -1390,7 +1389,7 @@ jobs:
       semver.gke-cluster: semver.gke-cluster-{{ $branch }}-upgrade
     timeout: 4h
     file: kubecf-{{ $branch }}/.concourse/tasks/upgrade.yaml
-{{- if (has $stable (printf "upgrade-test")) and $config.github_status }}
+{{- if (has $config.stable_jobs "upgrade-test") and $config.github_status }}
   on_success:
     put: status-{{ $branch }}.src
     params:

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -1390,47 +1390,33 @@ jobs:
       semver.gke-cluster: semver.gke-cluster-{{ $branch }}-upgrade
     timeout: 4h
     file: kubecf-{{ $branch }}/.concourse/tasks/upgrade.yaml
-{{- if has $stable (printf "upgrade-test") }}
-  {{- if $config.github_status }}
+{{- if (has $stable (printf "upgrade-test")) and $config.github_status }}
   on_success:
     put: status-{{ $branch }}.src
     params:
       << : *upgrade-test_{{ $sanitized_branch_name }}_status
       state: success
-  {{- end }}
-{{- end }}
   on_failure:
     in_parallel:
-{{- if has $stable (printf "upgrade-test") }}
-    {{- if $config.github_status }}
     - try:
         put: status-{{ $branch }}.src
         params:
           << : *upgrade-test_{{ $sanitized_branch_name }}_status
           state: failure
-    {{- end }}
-{{- end }}
   on_abort:
     in_parallel:
-{{- if has $stable (printf "upgrade-test") }}
-    {{- if $config.github_status }}
     - try:
         put: status-{{ $branch }}.src
         params:
           << : *upgrade-test_{{ $sanitized_branch_name }}_status
           state: failure
-    {{- end }}
-{{- end }}
   on_error:
     in_parallel:
-{{- if has $stable (printf "upgrade-test") }}
-    {{- if $config.github_status }}
     - try:
         put: status-{{ $branch }}.src
         params:
           << : *upgrade-test_{{ $sanitized_branch_name }}_status
           state: failure
-    {{- end }}
 {{- end }}
   ensure:
     do:


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail -->

Add GH status reporting to upgrade when it is on stable jobs.
Reporting copied from smoke-tests after rotation:
- pending
- success
- failure (on abort, on error, on pipeline failure)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

To gate PRs with the upgrade job.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- An important detail to include is the version of the used cf-operator -->

Deployed pipeline with this changes here: https://concourse.suse.dev/teams/main/pipelines/kubecf-viccuad/jobs/upgrade-test-master


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
