### PR TITLE
Remove `v` from kubecf's version string, and consume correctly

### DIFF
--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -466,7 +466,7 @@ jobs:
     - {{ . -}}{{ end }}
     {{- end }}
     params:
-      file: output/kubecf-*.tgz
+      file: output/kubecf-[0-9]*.tgz
       acl: public-read
   - put: s3.kubecf-ci-bundle
     {{- if $config.workertags }}
@@ -2037,7 +2037,7 @@ jobs:
     - {{ . -}}{{ end }}
     {{- end }}
     params:
-      file: output/kubecf-*.tgz
+      file: output/kubecf-[0-9]*.tgz
   - put: s3.kubecf-bundle
     {{- if $config.workertags }}
     tags: {{ range $config.workertags }}

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -129,7 +129,7 @@ resources:
     region_name: {{ $config.s3_bucket_region }}
     # adapted from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
     # with 1 capturing group for the whole semver, as the s3 resource expects
-    regexp: kubecf-[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+)?.tgz
+    regexp: kubecf-([0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+)?).tgz
 
 - name: s3.kubecf-ci-bundle
   type: s3
@@ -140,7 +140,7 @@ resources:
     region_name: {{ $config.s3_bucket_region }}
     # adapted from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
     # with 1 capturing group for the whole semver, as the s3 resource expects
-    regexp: kubecf-bundle-[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+)?.tgz
+    regexp: kubecf-bundle-([0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+)?).tgz
 
 - name: s3.kubecf
   type: s3
@@ -149,7 +149,7 @@ resources:
     access_key_id: ((aws-access-key))
     secret_access_key: ((aws-secret-key))
     region_name: {{ $config.s3_final_bucket_region }}
-    regexp: kubecf-(.*).tgz
+    regexp: kubecf-([0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+)?).tgz
 
 - name: s3.kubecf-bundle
   type: s3
@@ -158,7 +158,7 @@ resources:
     access_key_id: ((aws-access-key))
     secret_access_key: ((aws-secret-key))
     region_name: {{ $config.s3_final_bucket_region }}
-    regexp: kubecf-bundle-(.*).tgz
+    regexp: kubecf-bundle-([0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+)?).tgz
 
 deploy_args: &deploy_args
 - -ce

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -127,7 +127,7 @@ resources:
     access_key_id: ((aws-access-key))
     secret_access_key: ((aws-secret-key))
     region_name: {{ $config.s3_bucket_region }}
-    regexp: kubecf-v(.*).tgz
+    regexp: kubecf-(.*).tgz
 
 - name: s3.kubecf-ci-bundle
   type: s3
@@ -136,7 +136,7 @@ resources:
     access_key_id: ((aws-access-key))
     secret_access_key: ((aws-secret-key))
     region_name: {{ $config.s3_bucket_region }}
-    regexp: kubecf-bundle-v(.*).tgz
+    regexp: kubecf-bundle-(.*).tgz
 
 - name: s3.kubecf
   type: s3
@@ -145,7 +145,7 @@ resources:
     access_key_id: ((aws-access-key))
     secret_access_key: ((aws-secret-key))
     region_name: {{ $config.s3_final_bucket_region }}
-    regexp: kubecf-v(.*).tgz
+    regexp: kubecf-(.*).tgz
 
 - name: s3.kubecf-bundle
   type: s3
@@ -154,7 +154,7 @@ resources:
     access_key_id: ((aws-access-key))
     secret_access_key: ((aws-secret-key))
     region_name: {{ $config.s3_final_bucket_region }}
-    regexp: kubecf-bundle-v(.*).tgz
+    regexp: kubecf-bundle-(.*).tgz
 
 deploy_args: &deploy_args
 - -ce
@@ -464,7 +464,7 @@ jobs:
     - {{ . -}}{{ end }}
     {{- end }}
     params:
-      file: output/kubecf-v*.tgz
+      file: output/kubecf-*.tgz
       acl: public-read
   - put: s3.kubecf-ci-bundle
     {{- if $config.workertags }}
@@ -472,7 +472,7 @@ jobs:
     - {{ . -}}{{ end }}
     {{- end }}
     params:
-      file: output/kubecf-bundle-v*.tgz
+      file: output/kubecf-bundle-*.tgz
       acl: public-read
 
 {{- range $_, $cfScheduler := $config.availableCfSchedulers }}
@@ -2035,13 +2035,13 @@ jobs:
     - {{ . -}}{{ end }}
     {{- end }}
     params:
-      file: output/kubecf-v*.tgz
+      file: output/kubecf-*.tgz
   - put: s3.kubecf-bundle
     {{- if $config.workertags }}
     tags: {{ range $config.workertags }}
     - {{ . -}}{{ end }}
     {{- end }}
     params:
-      file: output/kubecf-bundle-v*.tgz
+      file: output/kubecf-bundle-*.tgz
 {{ end }} # of publish
 {{ end }} # of branch

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -128,7 +128,8 @@ resources:
     secret_access_key: ((aws-secret-key))
     region_name: {{ $config.s3_bucket_region }}
     # adapted from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
-    regexp: kubecf-(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?.tgz
+    # with 1 capturing group for the whole semver, as the s3 resource expects
+    regexp: kubecf-[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+)?.tgz
 
 - name: s3.kubecf-ci-bundle
   type: s3
@@ -138,7 +139,8 @@ resources:
     secret_access_key: ((aws-secret-key))
     region_name: {{ $config.s3_bucket_region }}
     # adapted from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
-    regexp: kubecf-bundle-(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?.tgz
+    # with 1 capturing group for the whole semver, as the s3 resource expects
+    regexp: kubecf-bundle-[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+)?.tgz
 
 - name: s3.kubecf
   type: s3

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -127,7 +127,8 @@ resources:
     access_key_id: ((aws-access-key))
     secret_access_key: ((aws-secret-key))
     region_name: {{ $config.s3_bucket_region }}
-    regexp: kubecf-(.*).tgz
+    # adapted from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+    regexp: kubecf-(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?.tgz
 
 - name: s3.kubecf-ci-bundle
   type: s3
@@ -136,7 +137,8 @@ resources:
     access_key_id: ((aws-access-key))
     secret_access_key: ((aws-secret-key))
     region_name: {{ $config.s3_bucket_region }}
-    regexp: kubecf-bundle-(.*).tgz
+    # adapted from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+    regexp: kubecf-bundle-(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?.tgz
 
 - name: s3.kubecf
   type: s3

--- a/doc/release/release-guidelines.md
+++ b/doc/release/release-guidelines.md
@@ -30,7 +30,7 @@ Check [here](https://github.com/cloudfoundry-incubator/kubecf/branches) if the r
 ## Files to Change
 
 Add the version to the KubeCF helm chart target in _deploy/helm/kubecf/BUILD.bazel_:
-> ```version = "v2.0.0"```
+> ```version = "2.0.0"```
 
 As an example:
 ```

--- a/rules/helm/package.tmpl.rb
+++ b/rules/helm/package.tmpl.rb
@@ -59,10 +59,10 @@ begin
 
   # A semver that matches what Helm uses.
   # https://github.com/Masterminds/semver/blob/910aa146bd66780c2815d652b92a7fc5331e533c/version.go#L41-L43
-  semver_regex = /^v?([0-9]+)(\.[0-9]+)?(\.[0-9]+)?(-([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?(\+([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?$/
+  semver_regex = /^([0-9]+)(\.[0-9]+)?(\.[0-9]+)?(-([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?(\+([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?$/
 
   # Handle chart versioning based on git state if version doesn't match semver.
-  version = "v0.0.0-#{git_commit_short}" unless version.match(semver_regex)
+  version = "0.0.0-#{git_commit_short}" unless version.match(semver_regex)
 
   # Package and return the output path.
   package_cmd = <<-EOS

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -3,4 +3,4 @@ source scripts/include/setup.sh
 
 require_tools git
 
-echo "v${KUBECF_VERSION}-$(git rev-parse --short HEAD)"
+echo "${KUBECF_VERSION}-$(git rev-parse --short HEAD)"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Remove `v` char from the semver string, to be fully compliant with semver, both in bazel and shell based build systems.

This changes the resulting artifact name from the build; adjust regexps and shell expansion in pipeline
to consume them. 

If merged, this would surely trigger changes downstream for consuming the tars and version string.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Another implementation could be to not change the artifact name, and only the yaml value in `Chart.yaml`. This seems hackish, and given that the call to building with helm is `helm package  --version "${VERSION}" …`, seems foolish.

Closes https://github.com/cloudfoundry-incubator/kubecf/issues/927.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- An important detail to include is the version of the used cf-operator -->

Deployed pipeline from this branch at https://concourse.suse.dev/teams/main/pipelines/kubecf-viccuad?group=viccuad-semver-full.

Tested also by rebasing this branch against release-2.3, setting `version := 2.3.0`, and running up until smokes-diego. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
