### PR TITLE
fix: concourse: update catapult for operator 5.x

### DIFF
--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -113,7 +113,7 @@ resources:
   source:
     uri: https://github.com/SUSE/catapult
   version:
-    ref: 0e470c97aac9c656201946f47576772a91ab68e5
+    ref: 782c1af643fa6d03337a26434ddcd7613441774a
 
 - name: s3.kubecf-ci
   type: s3


### PR DESCRIPTION
## Description
Update the pinned catapult version to support using quarks-operator 5.x.

## Motivation and Context
We're having issues landing #1049 because the catapult we have doesn't support quarks-operator 5.x, and we don't want to land that until CI passes (because that's always bad).

## How Has This Been Tested?
Used the relevant catapult locally.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
