### PR TITLE
CI: Don't try to `cf login` in .concourse/tasks/upgrade.sh

### DIFF
--- a/.concourse/tasks/upgrade.sh
+++ b/.concourse/tasks/upgrade.sh
@@ -117,9 +117,6 @@ gcloud --quiet beta dns --project="${GKE_PROJECT}" record-sets transaction add \
 gcloud --quiet beta dns --project="${GKE_PROJECT}" record-sets transaction execute \
        --zone="${GKE_DNS_ZONE}"
 
-# Do cf login as sanity check
-make kubecf-login
-
 # Now upgrade to whatever chart we built for commit-to-test
 # The chart should be in s3.kubecf-ci directory
 SCF_CHART="$(readlink -f ../s3.kubecf-ci/*.tgz)"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This backports a fix from master for the upgrade task in CI.

Testing for `cf login` will never work, `make kubecf-login` tries to `cf login` outside of the cluster,
and the DNS is set as private.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- An important detail to include is the version of the used cf-operator -->

We saw the same behaviour on master CI.


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
