### PR TITLE
CI: Add pr_base_branch option to filter PRs by which branch(es) they target

### DIFF
--- a/.concourse/README.md
+++ b/.concourse/README.md
@@ -30,8 +30,8 @@ If you wish to deploy a custom pipeline:
    `<your-pipeline-name>.yaml`
 2. Edit the yaml and disable production options as said by the NOTEs (publishing
    artifacts, updating github status, s3 buckets to consume, etc)
-3. If needed, change the branches to track in the `$branches` var at the
-   beginning of pipeline.yaml.gomplate
+3. If needed, change the branches to track in the `branches` map in
+   `<your-pipeline-name>`.yaml
 4. Deploy as usual with `$ ./create_pipeline.sh <concourse-target> <your-pipeline-name>`
 
 

--- a/.concourse/kubecf.yaml
+++ b/.concourse/kubecf.yaml
@@ -31,6 +31,7 @@ branches: # Repository branches to track
 - release-2.3
 pr_resources:
 - pr
+pr_base_branch: ~ # filter PRs depending on the branch they target. `~` for all branches
 
 # Stable Jobs
 stable_jobs:

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -95,6 +95,11 @@ resources:
     repository: {{ $config.kubecf_repository }}
     access_token: ((github-access-token))
     required_review_approvals: 1
+    {{- if not $config.pr_base_branch }}
+    # base_branch must not be defined to catch all PRs, null value is not enough.
+    {{ else }}
+    base_branch: {{ $config.pr_base_branch }}
+    {{- end }}
 
 {{- range $_, $pr := $config.pr_resources }}
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add pr_base_branch option to filter PRs by which branch(es) they target.

The resource either allows for the parameter to be set to 1 branch, or not set,
for all branches.
See: https://github.com/telia-oss/github-pr-resource#source-configuration

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Needed for https://github.com/cloudfoundry-incubator/kubecf/issues/1095.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- An important detail to include is the version of the used cf-operator -->

Manually set the new option `pr_base_branch` to `~`, `release-2.3`, `foo` and verified the gomplate works as intended. Deployed kubecf-viccuad pipeline with those options and verified that the kubecf-pr resource lists the correct PRs to test.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
