### PR TITLE
move definitions from pipeline-definition to a scripts folder

### DIFF
--- a/.concourse/create-pipeline.sh
+++ b/.concourse/create-pipeline.sh
@@ -54,10 +54,14 @@ fly_args=(
     "--pipeline=${PIPELINE}"
 )
 
+# space-separated paths to template files and directories which contain template files
+template_paths="scripts"
+templates=$(find ${template_paths} -type f -exec echo "--template="{} \;)
+
 if [[ "$2" =~ "reconciler" ]]; then
     fly "${fly_args[@]}" --config \
         <(gomplate -V --datasource config="$PIPELINE".yaml --file kubecf-pool-reconciler.yaml.gomplate)
 else # kubecf pipeline
     fly "${fly_args[@]}" --config \
-        <(gomplate -V --datasource config="$PIPELINE".yaml --file pipeline.yaml.gomplate)
+        <(gomplate -V --datasource config="$PIPELINE".yaml ${templates} --file pipeline.yaml.gomplate)
 fi

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -156,147 +156,6 @@ resources:
     region_name: {{ $config.s3_final_bucket_region }}
     regexp: kubecf-bundle-v(.*).tgz
 
-deploy_args: &deploy_args
-- -ce
-- |
-
-  # Login to gcloud
-  printf "%s" '((gke-suse-cap-json))' > $PWD/gke-key.json
-  export GKE_CRED_JSON=$PWD/gke-key.json
-  gcloud auth activate-service-account --key-file $PWD/gke-key.json
-
-  export GKE_PROJECT="{{ $config.gke_project }}"
-  export GKE_CLUSTER_ZONE="{{ $config.gke_zone }}"
-  export GKE_CLUSTER_NAME="{{ $config.resource_prefix | strings.Trunc 12 }}-${BRANCH//./-}-${CFSCHEDULER//./-}-$(cat semver.gke-cluster/version | sed 's/\./-/g')"
-  export GKE_DNS_ZONE="{{ $config.gke_dns_zone }}"
-  export GKE_DOMAIN="{{ $config.gke_domain }}"
-  export DOMAIN="${GKE_CLUSTER_NAME}.${GKE_DOMAIN}"
-
-  gcloud --quiet beta container \
-    --project "${GKE_PROJECT}" clusters create "${GKE_CLUSTER_NAME}" \
-    --enable-network-policy \
-    --zone "${GKE_CLUSTER_ZONE}" \
-    --no-enable-basic-auth \
-    --machine-type "n1-highcpu-16" \
-    --image-type "UBUNTU" \
-    --disk-type "pd-ssd" \
-    --disk-size "100" \
-    --metadata disable-legacy-endpoints=true \
-    --scopes "https://www.googleapis.com/auth/devstorage.read_only","https://www.googleapis.com/auth/logging.write","https://www.googleapis.com/auth/monitoring","https://www.googleapis.com/auth/servicecontrol","https://www.googleapis.com/auth/service.management.readonly","https://www.googleapis.com/auth/trace.append" \
-    --preemptible \
-    --num-nodes "1" \
-    --enable-stackdriver-kubernetes \
-    --enable-ip-alias \
-    --network "projects/${GKE_PROJECT}/global/networks/default" \
-    --subnetwork "projects/${GKE_PROJECT}/regions/$(echo ${GKE_CLUSTER_ZONE} | sed 's/-.$//')/subnetworks/default" \
-    --default-max-pods-per-node "110" \
-    --no-enable-master-authorized-networks \
-    --addons HorizontalPodAutoscaling,HttpLoadBalancing \
-    --no-enable-autorepair \
-    --no-enable-autoupgrade \
-    --no-enable-autoprovisioning
-
-  # Get a kubeconfig
-  gcloud --quiet container clusters get-credentials ${GKE_CLUSTER_NAME} --zone ${GKE_CLUSTER_ZONE} --project "${GKE_PROJECT}"
-
-  export SCF_CHART="$(readlink -f s3.kubecf-ci/*.tgz)"
-  export BACKEND=gke
-  export DOCKER_ORG=cap-staging
-  export QUIET_OUTPUT=true
-  export DOWNLOAD_CATAPULT_DEPS=false
-  export KUBECFG="$(readlink -f ~/.kube/config)"
-
-  # https://unix.stackexchange.com/a/265151
-  read -r -d '' CONFIG_OVERRIDE <<'EOF' || true
-  sizing:
-    diego_cell:
-      ephemeral_disk:
-        size: 300000
-  EOF
-  export CONFIG_OVERRIDE
-
-  pushd catapult
-  export CLUSTER_PASSWORD=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)
-  # Bring up a k8s cluster and builds+deploy kubecf
-  # https://github.com/SUSE/catapult/wiki/Build-and-run-SCF#build-and-run-kubecf
-  make kubeconfig kubecf
-
-  # Setup dns
-  tcp_router_ip=$(kubectl get svc -n scf tcp-router-public -o json | jq -r .status.loadBalancer.ingress[].ip | head -n 1)
-  public_router_ip=$(kubectl get svc -n scf router-public -o json | jq -r .status.loadBalancer.ingress[].ip | head -n 1)
-
-  gcloud --quiet beta dns --project=${GKE_PROJECT} record-sets transaction start \
-    --zone=${GKE_DNS_ZONE}
-  gcloud --quiet beta dns --project=${GKE_PROJECT} record-sets transaction add \
-    --name=\*.${DOMAIN}. --ttl=300 --type=A --zone=${GKE_DNS_ZONE} $public_router_ip
-  gcloud --quiet beta dns --project=${GKE_PROJECT} record-sets transaction add \
-    --name=tcp.${DOMAIN}. --ttl=300 --type=A --zone=${GKE_DNS_ZONE} $tcp_router_ip
-  gcloud --quiet beta dns --project=${GKE_PROJECT} record-sets transaction execute \
-    --zone=${GKE_DNS_ZONE}
-
-test_args: &test_args
-- -ce
-- |
-
-  # Login to gcloud
-  printf "%s" '((gke-suse-cap-json))' > $PWD/gke-key.json
-  export GKE_CRED_JSON=$PWD/gke-key.json
-  gcloud auth activate-service-account --key-file $PWD/gke-key.json
-
-  export GKE_PROJECT="{{ $config.gke_project }}"
-  export GKE_CLUSTER_ZONE="{{ $config.gke_zone }}"
-  export GKE_CLUSTER_NAME="{{ $config.resource_prefix | strings.Trunc 12 }}-${BRANCH//./-}-${CFSCHEDULER//./-}-$(cat semver.gke-cluster/version | sed 's/\./-/g')"
-
-  # Get a kubeconfig
-  gcloud container clusters get-credentials ${GKE_CLUSTER_NAME} --zone ${GKE_CLUSTER_ZONE} --project "${GKE_PROJECT}"
-
-  export BACKEND=gke
-  export KUBECF_NAMESPACE="scf"
-  export QUIET_OUTPUT=true
-  export DOWNLOAD_CATAPULT_DEPS=false
-  export KUBECFG="$(readlink -f ~/.kube/config)"
-  pushd catapult
-  # Grabs back a deployed cluster and runs test suites on it
-  # See: https://github.com/SUSE/catapult/wiki/Running-SCF-tests#kubecf
-  make kubeconfig tests-kubecf
-
-rotate_args: &rotate_args
-- -ce
-- |
-
-  # Login to gcloud
-  printf "%s" '((gke-suse-cap-json))' > $PWD/gke-key.json
-  export GKE_CRED_JSON=$PWD/gke-key.json
-  export GKE_PROJECT="{{ $config.gke_project }}"
-  export GKE_CLUSTER_ZONE="{{ $config.gke_zone }}"
-  export GKE_CLUSTER_NAME="{{ $config.resource_prefix | strings.Trunc 12 }}-${BRANCH//./-}-${CFSCHEDULER//./-}-$(cat semver.gke-cluster/version | sed 's/\./-/g')"
-
-  gcloud auth activate-service-account --key-file $PWD/gke-key.json
-  # Get a kubeconfig
-  gcloud container clusters get-credentials ${GKE_CLUSTER_NAME} --zone ${GKE_CLUSTER_ZONE} --project "${GKE_PROJECT}"
-
-  export BACKEND=gke
-  export QUIET_OUTPUT=true
-  export DOWNLOAD_CATAPULT_DEPS=false
-  export KUBECFG="$(readlink -f ~/.kube/config)"
-
-  pushd catapult
-  make kubeconfig
-  source build*/.envrc
-  popd
-
-  export KUBECF_INSTALL_NAME="susecf-scf"
-  export KUBECF_NAMESPACE="scf"
-
-  pushd kubecf
-  testing/ccdb_key_rotation/rotate-ccdb-keys-test.sh
-
-  echo "Waiting for all pods to be back"
-  while ! ( kubectl get pods --namespace "${KUBECF_NAMESPACE}" | gawk '{ if ((match($2, /^([0-9]+)\/([0-9]+)$/, c) && c[1] != c[2] && !match($3, /Completed/)) || !match($3, /STATUS|Completed|Running/)) { print ; exit 1 } }' )
-  do
-      sleep 10
-  done
-
 jobs:
 
 {{ $path := "" }}
@@ -560,7 +419,10 @@ jobs:
         CFSCHEDULER: {{ $cfScheduler }}
       run:
         path: "/bin/bash"
-        args: *deploy_args
+        args:
+        - -ce
+        - |
+          {{ tmpl.Exec "scripts_deploy_args" $config | indent 10 | trimSpace }}
 {{- if has $config.stable_jobs (printf "deploy-%s" $cfScheduler) }}
   {{- if $config.github_status }}
   on_success:
@@ -614,55 +476,7 @@ jobs:
             args:
             - -ce
             - |
-
-              # Login to gcloud
-              printf "%s" '((gke-suse-cap-json))' > $PWD/gke-key.json
-              gcloud auth activate-service-account --key-file $PWD/gke-key.json
-              export GKE_PROJECT="{{ $config.gke_project }}"
-              export GKE_CLUSTER_ZONE="{{ $config.gke_zone }}"
-              export GKE_DNS_ZONE="{{ $config.gke_dns_zone }}"
-              export GKE_CLUSTER_NAME="{{ $config.resource_prefix | strings.Trunc 12 }}-${BRANCH//./-}-${CFSCHEDULER//./-}-$(cat semver.gke-cluster/version | sed 's/\./-/g')"
-              export GKE_DOMAIN="{{ $config.gke_domain }}"
-              export DOMAIN="${GKE_CLUSTER_NAME}.${GKE_DOMAIN}"
-
-              # Get a kubeconfig
-              gcloud container clusters get-credentials ${GKE_CLUSTER_NAME} --zone ${GKE_CLUSTER_ZONE} --project "${GKE_PROJECT}"
-
-              pvcs=$(kubectl get pvc -n scf -o json | jq -r .items[].spec.volumeName | paste -sd "|")
-              tcp_router_ip=$(kubectl get svc -n scf tcp-router-public -o json | jq -r .status.loadBalancer.ingress[].ip | head -n 1)
-              public_router_ip=$(kubectl get svc -n scf router-public -o json | jq -r .status.loadBalancer.ingress[].ip | head -n 1)
-
-              # Delete cluster
-              gcloud --quiet container --project "${GKE_PROJECT}" clusters delete "${GKE_CLUSTER_NAME}" \
-                    --zone "${GKE_CLUSTER_ZONE}"
-
-              # Delete leftover disks assigned to (now deleted) pvcs.
-              # https://cloud.google.com/compute/docs/instances/preemptible#understanding_the_preemption_process
-              # https://groups.google.com/d/msg/gce-discussion/RLrwOx8fazo/9ve7lIdsBQAJ
-              DISK_IDS=$(gcloud compute disks list \
-                    --filter="zone~${GKE_CLUSTER_ZONE}" \
-                    --filter="name~${pvcs}" \
-                    --filter="-users:*" \
-                    --format="value(id)" \
-                    --project=${GKE_PROJECT})
-
-              # Delete pvc disks associated to the cluster, now that they are free
-              for ID in ${DISK_IDS}; do
-                  gcloud compute disks delete ${ID} --zone=${GKE_CLUSTER_ZONE} \
-                                                    --project="${GKE_PROJECT}" --quiet;
-              done
-
-              gcloud --quiet beta dns --project=${GKE_PROJECT} record-sets \
-                transaction start --zone=${GKE_DNS_ZONE}
-              gcloud --quiet beta dns --project=${GKE_PROJECT} record-sets \
-                transaction remove --name=\*.${DOMAIN}. --ttl=300 --type=A \
-                --zone=${GKE_DNS_ZONE} $public_router_ip
-              gcloud --quiet beta dns --project=${GKE_PROJECT} record-sets \
-                transaction remove --name=tcp.${DOMAIN}. --ttl=300 --type=A \
-                --zone=${GKE_DNS_ZONE} $tcp_router_ip
-              gcloud --quiet beta dns --project=${GKE_PROJECT} record-sets \
-                transaction execute --zone=${GKE_DNS_ZONE}
-
+              {{ tmpl.Exec "scripts_destroy_gke" $config | indent 14 | trimSpace }}
   on_abort:
     in_parallel:
     - try:
@@ -791,7 +605,10 @@ jobs:
         CFSCHEDULER: {{ $cfScheduler }}
       run:
         path: "/bin/bash"
-        args: *test_args
+        args:
+        - -ce
+        - |
+          {{ tmpl.Exec "scripts_test_args" $config | indent 10 | trimSpace }}
 {{- if has $config.stable_jobs (printf "smoke-tests-%s" $cfScheduler) }}
   {{- if $config.github_status }}
   on_success:
@@ -968,7 +785,10 @@ jobs:
         CFSCHEDULER: {{ $cfScheduler }}
       run:
         path: "/bin/bash"
-        args: *test_args
+        args:
+        - -ce
+        - |
+          {{ tmpl.Exec "scripts_test_args" $config | indent 10 | trimSpace }}
 
 {{- if has $config.stable_jobs (printf "cf-acceptance-tests-%s" $cfScheduler) }}
   {{- if $config.github_status }}
@@ -1136,7 +956,10 @@ jobs:
         CFSCHEDULER: {{ $cfScheduler }}
       run:
         path: "/bin/bash"
-        args: *test_args
+        args:
+        - -ce
+        - |
+          {{ tmpl.Exec "scripts_test_args" $config | indent 10 | trimSpace }}
 
 {{- if has $config.stable_jobs (printf "cats-internetless-%s" $cfScheduler) }}
   {{- if $config.github_status }}
@@ -1305,7 +1128,10 @@ jobs:
         CFSCHEDULER: {{ $cfScheduler }}
       run:
         path: "/bin/bash"
-        args: *test_args
+        args:
+        - -ce
+        - |
+          {{ tmpl.Exec "scripts_test_args" $config | indent 10 | trimSpace }}
 {{- if has $config.stable_jobs "sync-integration-tests" }}
   {{- if $config.github_status }}
   on_success:
@@ -1472,8 +1298,10 @@ jobs:
         CFSCHEDULER: {{ $cfScheduler }}
       run:
         path: "/bin/bash"
-        args: *rotate_args
-
+        args:
+        - -ce
+        - |
+          {{ tmpl.Exec "scripts_rotate_args" $config | indent 10 | trimSpace }}
 {{- if has $config.stable_jobs (printf "rotate-%s" $cfScheduler) }}
   {{- if $config.github_status }}
   on_success:
@@ -1639,7 +1467,10 @@ jobs:
         CFSCHEDULER: {{ $cfScheduler }}
       run:
         path: "/bin/bash"
-        args: *test_args
+        args:
+        - -ce
+        - |
+          {{ tmpl.Exec "scripts_test_args" $config | indent 10 | trimSpace }}
 
 {{- if has $config.stable_jobs (printf "smoke-rotated-{%s" $cfScheduler) }}
   {{- if $config.github_status }}
@@ -1728,70 +1559,6 @@ jobs:
     {{- end }}
 {{- end }}
 {{ $previousTest = (printf "smoke-tests-post-rotate-%s-%s" $cfScheduler $branch) }}
-
-# TODO: re-enable and re-adapt once BRAIN tests are fixed.
-# - name: brain-tests-{{ $cfScheduler }}
-#   plan:
-#   - get: commit-to-test
-#     passed:
-#     - sync-integration-tests-{{ $cfScheduler }}
-#     trigger: true
-#     version: "every"
-#   - get: s3.kubecf-ci
-#     passed:
-#     - sync-integration-tests-{{ $cfScheduler }}
-#   - get: s3.kubecf-ci-bundle
-#     passed:
-#     - sync-integration-tests-{{ $cfScheduler }}
-#   - get: catapult
-#   - task: test-{{ $cfScheduler }}
-#     timeout: 1h30m
-#     config:
-#       platform: linux
-#       image_resource:
-#         type: registry-image
-#         source:
-#           repository: splatform/catapult
-#       inputs:
-#       - name: catapult
-#       - name: commit-to-test
-#       outputs:
-#       - name: output
-#       params:
-#         EKCP_HOST: ((ekcp-host))
-#         KUBECF_TEST_SUITE: brain
-#       run:
-#         path: "/bin/bash"
-#         args: *test_args
-#     on_success:
-#       put: commit-to-test
-#       params:
-#         description: "Brain tests on {{ $cfScheduler }} succeeded"
-#         state: "success"
-#         contexts: "brain-tests-{{ $cfScheduler }}"
-#         commit_path: "commit-to-test/.git/resource/ref"
-#         version_path: "commit-to-test/.git/resource/version"
-#     on_failure:
-#       do:
-#       - put: commit-to-test
-#         params:
-#           description: "Brain tests on {{ $cfScheduler }} failed"
-#           state: "failure"
-#           commit_path: "commit-to-test/.git/resource/ref"
-#           version_path: "commit-to-test/.git/resource/version"
-#           contexts: "brain-tests-{{ $cfScheduler }}"
-#       - task: cleanup-cluster
-#         config:
-#           <<: *cleanup-cluster
-#           params:
-#             EKCP_HOST: ((ekcp-host))
-#     on_abort:
-#       task: cleanup-cluster
-#       config:
-#         <<: *cleanup-cluster
-#         params:
-#           EKCP_HOST: ((ekcp-host))
-
 
 - name: cleanup-{{ $cfScheduler }}-cluster-{{ $branch }}
   plan:

--- a/.concourse/scripts/deploy_args.tmpl
+++ b/.concourse/scripts/deploy_args.tmpl
@@ -7,7 +7,7 @@ gcloud auth activate-service-account --key-file $PWD/gke-key.json
 
 export GKE_PROJECT="{{ .gke_project }}"
 export GKE_CLUSTER_ZONE="{{ .gke_zone }}"
-export GKE_CLUSTER_NAME="kubecf-ci-${BRANCH//./-}-${CFSCHEDULER//./-}-$(cat semver.gke-cluster/version | sed 's/\./-/g')"
+export GKE_CLUSTER_NAME="{{ .resource_prefix | strings.Trunc 12 }}-${BRANCH//./-}-${CFSCHEDULER//./-}-$(cat semver.gke-cluster/version | sed 's/\./-/g')"
 export GKE_DNS_ZONE="{{ .gke_dns_zone }}"
 export GKE_DOMAIN="{{ .gke_domain }}"
 export DOMAIN="${GKE_CLUSTER_NAME}.${GKE_DOMAIN}"

--- a/.concourse/scripts/deploy_args.tmpl
+++ b/.concourse/scripts/deploy_args.tmpl
@@ -1,0 +1,77 @@
+{{ define "scripts_deploy_args" }}
+
+# Login to gcloud
+printf "%s" '((gke-suse-cap-json))' > $PWD/gke-key.json
+export GKE_CRED_JSON=$PWD/gke-key.json
+gcloud auth activate-service-account --key-file $PWD/gke-key.json
+
+export GKE_PROJECT="{{ .gke_project }}"
+export GKE_CLUSTER_ZONE="{{ .gke_zone }}"
+export GKE_CLUSTER_NAME="kubecf-ci-${BRANCH//./-}-${CFSCHEDULER//./-}-$(cat semver.gke-cluster/version | sed 's/\./-/g')"
+export GKE_DNS_ZONE="{{ .gke_dns_zone }}"
+export GKE_DOMAIN="{{ .gke_domain }}"
+export DOMAIN="${GKE_CLUSTER_NAME}.${GKE_DOMAIN}"
+
+gcloud --quiet beta container \
+  --project "${GKE_PROJECT}" clusters create "${GKE_CLUSTER_NAME}" \
+  --enable-network-policy \
+  --zone "${GKE_CLUSTER_ZONE}" \
+  --no-enable-basic-auth \
+  --machine-type "n1-highcpu-16" \
+  --image-type "UBUNTU" \
+  --disk-type "pd-ssd" \
+  --disk-size "100" \
+  --metadata disable-legacy-endpoints=true \
+  --scopes "https://www.googleapis.com/auth/devstorage.read_only","https://www.googleapis.com/auth/logging.write","https://www.googleapis.com/auth/monitoring","https://www.googleapis.com/auth/servicecontrol","https://www.googleapis.com/auth/service.management.readonly","https://www.googleapis.com/auth/trace.append" \
+  --preemptible \
+  --num-nodes "1" \
+  --enable-stackdriver-kubernetes \
+  --enable-ip-alias \
+  --network "projects/${GKE_PROJECT}/global/networks/default" \
+  --subnetwork "projects/${GKE_PROJECT}/regions/$(echo ${GKE_CLUSTER_ZONE} | sed 's/-.$//')/subnetworks/default" \
+  --default-max-pods-per-node "110" \
+  --no-enable-master-authorized-networks \
+  --addons HorizontalPodAutoscaling,HttpLoadBalancing \
+  --no-enable-autorepair \
+  --no-enable-autoupgrade \
+  --no-enable-autoprovisioning
+
+# Get a kubeconfig
+gcloud --quiet container clusters get-credentials ${GKE_CLUSTER_NAME} --zone ${GKE_CLUSTER_ZONE} --project "${GKE_PROJECT}"
+
+export SCF_CHART="$(readlink -f s3.kubecf-ci/*.tgz)"
+export BACKEND=gke
+export DOCKER_ORG=cap-staging
+export QUIET_OUTPUT=true
+export DOWNLOAD_CATAPULT_DEPS=false
+export KUBECFG="$(readlink -f ~/.kube/config)"
+
+# https://unix.stackexchange.com/a/265151
+read -r -d '' CONFIG_OVERRIDE <<'EOF' || true
+sizing:
+  diego_cell:
+    ephemeral_disk:
+      size: 300000
+EOF
+export CONFIG_OVERRIDE
+
+pushd catapult
+export CLUSTER_PASSWORD=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)
+# Bring up a k8s cluster and builds+deploy kubecf
+# https://github.com/SUSE/catapult/wiki/Build-and-run-SCF#build-and-run-kubecf
+make kubeconfig kubecf
+
+# Setup dns
+tcp_router_ip=$(kubectl get svc -n scf tcp-router-public -o json | jq -r .status.loadBalancer.ingress[].ip | head -n 1)
+public_router_ip=$(kubectl get svc -n scf router-public -o json | jq -r .status.loadBalancer.ingress[].ip | head -n 1)
+
+gcloud --quiet beta dns --project=${GKE_PROJECT} record-sets transaction start \
+  --zone=${GKE_DNS_ZONE}
+gcloud --quiet beta dns --project=${GKE_PROJECT} record-sets transaction add \
+  --name=\*.${DOMAIN}. --ttl=300 --type=A --zone=${GKE_DNS_ZONE} $public_router_ip
+gcloud --quiet beta dns --project=${GKE_PROJECT} record-sets transaction add \
+  --name=tcp.${DOMAIN}. --ttl=300 --type=A --zone=${GKE_DNS_ZONE} $tcp_router_ip
+gcloud --quiet beta dns --project=${GKE_PROJECT} record-sets transaction execute \
+  --zone=${GKE_DNS_ZONE}
+
+{{ end }}

--- a/.concourse/scripts/destroy_gke.tmpl
+++ b/.concourse/scripts/destroy_gke.tmpl
@@ -1,0 +1,52 @@
+{{ define "scripts_destroy_gke" }}
+{{- /* destroy gke cluster and pvc */}}
+
+# Login to gcloud
+printf "%s" '((gke-suse-cap-json))' > $PWD/gke-key.json
+gcloud auth activate-service-account --key-file $PWD/gke-key.json
+export GKE_PROJECT="{{ .gke_project }}"
+export GKE_CLUSTER_ZONE="{{ .gke_zone }}"
+export GKE_DNS_ZONE="{{ .gke_dns_zone }}"
+export GKE_CLUSTER_NAME="kubecf-ci-${BRANCH//./-}-${CFSCHEDULER//./-}-$(cat semver.gke-cluster/version | sed 's/\./-/g')"
+export GKE_DOMAIN="{{ .gke_domain }}"
+export DOMAIN="${GKE_CLUSTER_NAME}.${GKE_DOMAIN}"
+
+# Get a kubeconfig
+gcloud container clusters get-credentials ${GKE_CLUSTER_NAME} --zone ${GKE_CLUSTER_ZONE} --project "${GKE_PROJECT}"
+
+pvcs=$(kubectl get pvc -n scf -o json | jq -r .items[].spec.volumeName | paste -sd "|")
+tcp_router_ip=$(kubectl get svc -n scf tcp-router-public -o json | jq -r .status.loadBalancer.ingress[].ip | head -n 1)
+public_router_ip=$(kubectl get svc -n scf router-public -o json | jq -r .status.loadBalancer.ingress[].ip | head -n 1)
+
+# Delete cluster
+gcloud --quiet container --project "${GKE_PROJECT}" clusters delete "${GKE_CLUSTER_NAME}" \
+      --zone "${GKE_CLUSTER_ZONE}"
+
+# Delete leftover disks assigned to (now deleted) pvcs.
+# https://cloud.google.com/compute/docs/instances/preemptible#understanding_the_preemption_process
+# https://groups.google.com/d/msg/gce-discussion/RLrwOx8fazo/9ve7lIdsBQAJ
+DISK_IDS=$(gcloud compute disks list \
+      --filter="zone~${GKE_CLUSTER_ZONE}" \
+      --filter="name~${pvcs}" \
+      --filter="-users:*" \
+      --format="value(id)" \
+      --project=${GKE_PROJECT})
+
+# Delete pvc disks associated to the cluster, now that they are free
+for ID in ${DISK_IDS}; do
+    gcloud compute disks delete ${ID} --zone=${GKE_CLUSTER_ZONE} \
+                                      --project="${GKE_PROJECT}" --quiet;
+done
+
+gcloud --quiet beta dns --project=${GKE_PROJECT} record-sets \
+  transaction start --zone=${GKE_DNS_ZONE}
+gcloud --quiet beta dns --project=${GKE_PROJECT} record-sets \
+  transaction remove --name=\*.${DOMAIN}. --ttl=300 --type=A \
+  --zone=${GKE_DNS_ZONE} $public_router_ip
+gcloud --quiet beta dns --project=${GKE_PROJECT} record-sets \
+  transaction remove --name=tcp.${DOMAIN}. --ttl=300 --type=A \
+  --zone=${GKE_DNS_ZONE} $tcp_router_ip
+gcloud --quiet beta dns --project=${GKE_PROJECT} record-sets \
+  transaction execute --zone=${GKE_DNS_ZONE}
+
+{{ end }}

--- a/.concourse/scripts/destroy_gke.tmpl
+++ b/.concourse/scripts/destroy_gke.tmpl
@@ -7,7 +7,7 @@ gcloud auth activate-service-account --key-file $PWD/gke-key.json
 export GKE_PROJECT="{{ .gke_project }}"
 export GKE_CLUSTER_ZONE="{{ .gke_zone }}"
 export GKE_DNS_ZONE="{{ .gke_dns_zone }}"
-export GKE_CLUSTER_NAME="kubecf-ci-${BRANCH//./-}-${CFSCHEDULER//./-}-$(cat semver.gke-cluster/version | sed 's/\./-/g')"
+export GKE_CLUSTER_NAME="{{ .resource_prefix | strings.Trunc 12 }}-${BRANCH//./-}-${CFSCHEDULER//./-}-$(cat semver.gke-cluster/version | sed 's/\./-/g')"
 export GKE_DOMAIN="{{ .gke_domain }}"
 export DOMAIN="${GKE_CLUSTER_NAME}.${GKE_DOMAIN}"
 

--- a/.concourse/scripts/rotate_args.tmpl
+++ b/.concourse/scripts/rotate_args.tmpl
@@ -5,7 +5,7 @@ printf "%s" '((gke-suse-cap-json))' > $PWD/gke-key.json
 export GKE_CRED_JSON=$PWD/gke-key.json
 export GKE_PROJECT="{{ .gke_project }}"
 export GKE_CLUSTER_ZONE="{{ .gke_zone }}"
-export GKE_CLUSTER_NAME="kubecf-ci-${BRANCH//./-}-${CFSCHEDULER//./-}-$(cat semver.gke-cluster/version | sed 's/\./-/g')"
+export GKE_CLUSTER_NAME="{{ .resource_prefix | strings.Trunc 12 }}-${BRANCH//./-}-${CFSCHEDULER//./-}-$(cat semver.gke-cluster/version | sed 's/\./-/g')"
 
 gcloud auth activate-service-account --key-file $PWD/gke-key.json
 # Get a kubeconfig

--- a/.concourse/scripts/rotate_args.tmpl
+++ b/.concourse/scripts/rotate_args.tmpl
@@ -1,0 +1,36 @@
+{{ define "scripts_rotate_args" }}
+
+# Login to gcloud
+printf "%s" '((gke-suse-cap-json))' > $PWD/gke-key.json
+export GKE_CRED_JSON=$PWD/gke-key.json
+export GKE_PROJECT="{{ .gke_project }}"
+export GKE_CLUSTER_ZONE="{{ .gke_zone }}"
+export GKE_CLUSTER_NAME="kubecf-ci-${BRANCH//./-}-${CFSCHEDULER//./-}-$(cat semver.gke-cluster/version | sed 's/\./-/g')"
+
+gcloud auth activate-service-account --key-file $PWD/gke-key.json
+# Get a kubeconfig
+gcloud container clusters get-credentials ${GKE_CLUSTER_NAME} --zone ${GKE_CLUSTER_ZONE} --project "${GKE_PROJECT}"
+
+export BACKEND=gke
+export QUIET_OUTPUT=true
+export DOWNLOAD_CATAPULT_DEPS=false
+export KUBECFG="$(readlink -f ~/.kube/config)"
+
+pushd catapult
+make kubeconfig
+source build*/.envrc
+popd
+
+export KUBECF_INSTALL_NAME="susecf-scf"
+export KUBECF_NAMESPACE="scf"
+
+pushd kubecf
+testing/ccdb_key_rotation/rotate-ccdb-keys-test.sh
+
+echo "Waiting for all pods to be back"
+while ! ( kubectl get pods --namespace "${KUBECF_NAMESPACE}" | gawk '{ if ((match($2, /^([0-9]+)\/([0-9]+)$/, c) && c[1] != c[2] && !match($3, /Completed/)) || !match($3, /STATUS|Completed|Running/)) { print ; exit 1 } }' )
+do
+  sleep 10
+done
+
+{{ end }}

--- a/.concourse/scripts/test_args.tmpl
+++ b/.concourse/scripts/test_args.tmpl
@@ -1,0 +1,25 @@
+{{ define "scripts_test_args" }}
+
+# Login to gcloud
+printf "%s" '((gke-suse-cap-json))' > $PWD/gke-key.json
+export GKE_CRED_JSON=$PWD/gke-key.json
+gcloud auth activate-service-account --key-file $PWD/gke-key.json
+
+export GKE_PROJECT="{{ .gke_project }}"
+export GKE_CLUSTER_ZONE="{{ .gke_zone }}"
+export GKE_CLUSTER_NAME="kubecf-ci-${BRANCH//./-}-${CFSCHEDULER//./-}-$(cat semver.gke-cluster/version | sed 's/\./-/g')"
+
+# Get a kubeconfig
+gcloud container clusters get-credentials ${GKE_CLUSTER_NAME} --zone ${GKE_CLUSTER_ZONE} --project "${GKE_PROJECT}"
+
+export BACKEND=gke
+export KUBECF_NAMESPACE="scf"
+export QUIET_OUTPUT=true
+export DOWNLOAD_CATAPULT_DEPS=false
+export KUBECFG="$(readlink -f ~/.kube/config)"
+pushd catapult
+# Grabs back a deployed cluster and runs test suites on it
+# See: https://github.com/SUSE/catapult/wiki/Running-SCF-tests#kubecf
+make kubeconfig tests-kubecf
+
+{{ end }}

--- a/.concourse/scripts/test_args.tmpl
+++ b/.concourse/scripts/test_args.tmpl
@@ -7,7 +7,7 @@ gcloud auth activate-service-account --key-file $PWD/gke-key.json
 
 export GKE_PROJECT="{{ .gke_project }}"
 export GKE_CLUSTER_ZONE="{{ .gke_zone }}"
-export GKE_CLUSTER_NAME="kubecf-ci-${BRANCH//./-}-${CFSCHEDULER//./-}-$(cat semver.gke-cluster/version | sed 's/\./-/g')"
+export GKE_CLUSTER_NAME="{{ .resource_prefix | strings.Trunc 12 }}-${BRANCH//./-}-${CFSCHEDULER//./-}-$(cat semver.gke-cluster/version | sed 's/\./-/g')"
 
 # Get a kubeconfig
 gcloud container clusters get-credentials ${GKE_CLUSTER_NAME} --zone ${GKE_CLUSTER_ZONE} --project "${GKE_PROJECT}"


### PR DESCRIPTION
https://github.com/cloudfoundry-incubator/kubecf/issues/1090
Right now our pipeline definition itself contains script/ definitions to perform sub tasks in a job. This makes the pipeline definition difficult to understand and iterate.
We must move these definition / code / scripts outside of our pipeline definition (just like our variables are kept in config file).
We should take this route even if we iterate slowly towards `task` workflow.

Test: https://concourse.suse.dev/teams/main/pipelines/prabal-kubecf?group=pr