### PR TITLE
Backport needed CI code to release-2.3 branch

### DIFF
--- a/.concourse/README.md
+++ b/.concourse/README.md
@@ -26,9 +26,13 @@ All the required config options are in `<pipeline-name>.yaml`.
 ### Developing the pipeline
 
 If you wish to deploy a custom pipeline:
-1. copy either `kubecf.yaml` or `kubecf-pool-reconciler.yaml` into `<your-pipeline-name>.yaml`
-2. Edit the yaml and disable production options (publishing artifacts, updating github status, etc)
-3. Deploy as usual with `$ ./create_pipeline.sh <concourse-target> <your-pipeline-name>`
+1. copy either `kubecf.yaml` or `kubecf-pool-reconciler.yaml` into
+   `<your-pipeline-name>.yaml`
+2. Edit the yaml and disable production options as said by the NOTEs (publishing
+   artifacts, updating github status, s3 buckets to consume, etc)
+3. If needed, change the branches to track in the `branches` map in
+   `<your-pipeline-name>`.yaml
+4. Deploy as usual with `$ ./create_pipeline.sh <concourse-target> <your-pipeline-name>`
 
 
 

--- a/.concourse/kubecf-release-2.3.yaml
+++ b/.concourse/kubecf-release-2.3.yaml
@@ -1,0 +1,53 @@
+---
+
+s3_bucket: kubecf-ci
+s3_bucket_region: eu-central-1
+s3_final_bucket: kubecf
+s3_final_bucket_region: us-west-2
+kubecf_repository: cloudfoundry-incubator/kubecf
+
+# for preemptible gke clusters
+gke_project: suse-225215
+gke_zone: europe-west3-c
+gke_dns_zone: kubecf-ci
+gke_domain: kubecf.ci
+
+# NOTE please disable the following if you are developing or deploying a copy of
+# the pipeline:
+trigger_publish: true
+github_status: true
+
+availableCfSchedulers: # Diego / Eirini
+- diego
+- eirini
+
+branches: # Repository branches to track
+- master
+- release-2.2
+- release-2.3
+pr_resources:
+- pr
+pr_base_branch: ~ # filter PRs depending on the branch they target. `~` for all branches
+
+# Stable Jobs
+stable_jobs:
+- lint
+- build
+- deploy-diego
+- deploy-eirini
+- smoke-tests-diego
+- smoke-tests-eirini
+- cf-acceptance-tests-diego
+- cats-internetless-diego
+- sync-integration-tests
+- ccdb-rotate-diego
+- smoke-tests-post-rotate-diego
+- upgrade-test
+- cleanup-diego-cluster
+- cleanup-eirini-cluster
+
+experimental_jobs:
+- cf-acceptance-tests-eirini
+- cats-internetless-eirini
+- ccdb-rotate-eirini
+- smoke-tests-post-rotate-eirini

--- a/.concourse/kubecf-release-2.3.yaml
+++ b/.concourse/kubecf-release-2.3.yaml
@@ -22,12 +22,10 @@ availableCfSchedulers: # Diego / Eirini
 - eirini
 
 branches: # Repository branches to track
-- master
-- release-2.2
 - release-2.3
 pr_resources:
 - pr
-pr_base_branch: ~ # filter PRs depending on the branch they target. `~` for all branches
+pr_base_branch: release-2.3 # filter PRs depending on the branch they target. `~` for all branches
 
 # Stable Jobs
 stable_jobs:

--- a/.concourse/kubecf.yaml
+++ b/.concourse/kubecf.yaml
@@ -27,6 +27,7 @@ branches: # Repository branches to track
 - release-2.3
 pr_resources:
 - pr
+pr_base_branch: ~ # filter PRs depending on the branch they target. `~` for all branches
 
 # Stable Jobs
 stable_jobs:

--- a/.concourse/kubecf.yaml
+++ b/.concourse/kubecf.yaml
@@ -16,3 +16,38 @@ gke_domain: kubecf.ci
 # the pipeline:
 trigger_publish: true
 github_status: true
+
+availableCfSchedulers: # Diego / Eirini
+- diego
+- eirini
+
+branches: # Repository branches to track
+- master
+- release-2.2
+- release-2.3
+pr_resources:
+- pr
+
+# Stable Jobs
+# TODO: Delete the special case here as soon as we get Eirini CATS green and we stabilize Eirini smoke (e.g. with a more large timeout)
+stable_jobs:
+- lint
+- build
+- deploy-diego
+- deploy-eirini
+- smoke-tests-diego
+- smoke-tests-eirini
+- cf-acceptance-tests-diego
+- cats-internetless-diego
+- sync-integration-tests
+- ccdb-rotate-diego
+- smoke-tests-post-rotate-diego
+- upgrade-test
+- cleanup-diego-cluster
+- cleanup-eirini-cluster
+
+experimental_jobs:
+- cf-acceptance-tests-eirini
+- cats-internetless-eirini
+- ccdb-rotate-eirini
+- smoke-tests-post-rotate-eirini

--- a/.concourse/kubecf.yaml
+++ b/.concourse/kubecf.yaml
@@ -29,7 +29,6 @@ pr_resources:
 - pr
 
 # Stable Jobs
-# TODO: Delete the special case here as soon as we get Eirini CATS green and we stabilize Eirini smoke (e.g. with a more large timeout)
 stable_jobs:
 - lint
 - build

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -1391,47 +1391,33 @@ jobs:
       semver.gke-cluster: semver.gke-cluster-{{ $branch }}-upgrade
     timeout: 4h
     file: kubecf-{{ $branch }}/.concourse/tasks/upgrade.yaml
-{{- if has $stable (printf "upgrade-test") }}
-  {{- if $config.github_status }}
+{{- if (has $stable (printf "upgrade-test")) and $config.github_status }}
   on_success:
     put: status-{{ $branch }}.src
     params:
       << : *upgrade-test_{{ $sanitized_branch_name }}_status
       state: success
-  {{- end }}
-{{- end }}
   on_failure:
     in_parallel:
-{{- if has $stable (printf "upgrade-test") }}
-    {{- if $config.github_status }}
     - try:
         put: status-{{ $branch }}.src
         params:
           << : *upgrade-test_{{ $sanitized_branch_name }}_status
           state: failure
-    {{- end }}
-{{- end }}
   on_abort:
     in_parallel:
-{{- if has $stable (printf "upgrade-test") }}
-    {{- if $config.github_status }}
     - try:
         put: status-{{ $branch }}.src
         params:
           << : *upgrade-test_{{ $sanitized_branch_name }}_status
           state: failure
-    {{- end }}
-{{- end }}
   on_error:
     in_parallel:
-{{- if has $stable (printf "upgrade-test") }}
-    {{- if $config.github_status }}
     - try:
         put: status-{{ $branch }}.src
         params:
           << : *upgrade-test_{{ $sanitized_branch_name }}_status
           state: failure
-    {{- end }}
 {{- end }}
   ensure:
     do:

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -1395,11 +1395,11 @@ jobs:
   plan:
   - get: s3.kubecf-ci
     passed:
-    - cf-acceptance-tests-diego-{{ $branch }}
+    - smoke-tests-post-rotate-diego-{{ $branch }}
     trigger: {{ $config.trigger_publish }}
   - get: s3.kubecf-ci-bundle
     passed:
-    - cf-acceptance-tests-diego-{{ $branch }}
+    - smoke-tests-post-rotate-diego-{{ $branch }}
     trigger: {{ $config.trigger_publish }}
   - task: rename-artifacts
     config:

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -96,6 +96,11 @@ resources:
     access_token: ((github-access-token))
     disable_forks: true # Trigger on kubecf branches only
     required_review_approvals: 1
+    {{- if not $config.pr_base_branch }}
+    # base_branch must not be defined to catch all PRs, null value is not enough.
+    {{ else }}
+    base_branch: {{ $config.pr_base_branch }}
+    {{- end }}
 
 {{- range $_, $pr := $config.pr_resources }}
 

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -287,6 +287,12 @@ rotate_args: &rotate_args
   pushd kubecf
   testing/ccdb_key_rotation/rotate-ccdb-keys-test.sh
 
+  echo "Waiting for all pods to be back"
+  while ! ( kubectl get pods --namespace "${KUBECF_NAMESPACE}" | gawk '{ if ((match($2, /^([0-9]+)\/([0-9]+)$/, c) && c[1] != c[2] && !match($3, /Completed/)) || !match($3, /STATUS|Completed|Running/)) { print ; exit 1 } }' )
+  do
+      sleep 10
+  done
+
 jobs:
 
 {{ $path := "" }}

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -1367,15 +1367,14 @@ jobs:
     - get: catapult
     - put: semver.gke-cluster-{{ $branch }}-upgrade
       params: {bump: patch}
-{{- if has $stable (printf "upgrade-test") }}
-  {{- if $config.github_status }}
+
+{{- if (has $config.stable_jobs "upgrade-test") and $config.github_status }}
   - put: status-{{ $branch }}.src
     params: &upgrade-test_{{ $sanitized_branch_name }}_status
         context: "upgrade-test"
         description: "Upgrade from latest GH available release"
         path: kubecf-{{ $branch }}/{{ $path }}
         state: pending
-  {{- end }}
 {{- end }}
   - task: upgrade
     params:
@@ -1391,7 +1390,7 @@ jobs:
       semver.gke-cluster: semver.gke-cluster-{{ $branch }}-upgrade
     timeout: 4h
     file: kubecf-{{ $branch }}/.concourse/tasks/upgrade.yaml
-{{- if (has $stable (printf "upgrade-test")) and $config.github_status }}
+{{- if (has $config.stable_jobs "upgrade-test") and $config.github_status }}
   on_success:
     put: status-{{ $branch }}.src
     params:

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -1,24 +1,13 @@
 # load the config provided when evaluating the template
 {{ $config := (datasource "config") }}
 
-# Variables
-{{ $availableCfSchedulers := slice "diego" "eirini" }} # Diego / Eirini
-{{ $pr_resources := slice "pr" "fork-pr" }}
-{{ $branches := slice "master" "release-2.2"}} # Repository branches to track
-
 # Split Concourse jobs in tabs (aka groups)
 # We split by "branch" and we also split the "experimental" jobs of each branch.
-
-# Stable Jobs
-# TODO: Delete the special case here as soon as we get Eirini CATS green and we stabilize Eirini smoke (e.g. with a more large timeout)
-{{ $stable := slice "lint" "build" "deploy-diego" "deploy-eirini" "smoke-tests-diego" "smoke-tests-eirini" "cf-acceptance-tests-diego" "cleanup-diego-cluster" "cleanup-eirini-cluster" }}
-{{ $experimental := slice "cf-acceptance-tests-eirini" "cats-internetless-diego" "cats-internetless-eirini" "sync-integration-tests" "ccdb-rotate-diego" "ccdb-rotate-eirini" "smoke-tests-post-rotate-diego" "smoke-tests-post-rotate-eirini" "upgrade-test" }}
-
 groups:
-{{ range $_, $branch := (flatten (slice $branches $pr_resources) | uniq) }}
+{{ range $_, $branch := (flatten (slice $config.branches $config.pr_resources) | uniq) }}
 - name: {{ $branch }}
   jobs:
-  {{ range $_, $job := $stable }}
+  {{ range $_, $job := $config.stable_jobs }}
   - {{ $job }}-{{ $branch }}
   {{ end }}
   {{ if not ($branch | regexp.Match "^pr|fork-pr") }}
@@ -26,7 +15,7 @@ groups:
   {{ end }}
 - name: {{ $branch }}-experimental
   jobs:
-  {{ range $_, $job := $experimental }}
+  {{ range $_, $job := $config.experimental_jobs }}
   - {{ $job }}-{{ $branch }}
   {{ end }}
 {{ end }}
@@ -57,8 +46,8 @@ resources:
     repository: kubecf
     access_token: ((github-access-token))
 
-{{ range $_, $branch := (flatten (slice $branches $pr_resources) | uniq) }}
-{{- range $_, $cfScheduler := $availableCfSchedulers }}
+{{ range $_, $branch := (flatten (slice $config.branches $config.pr_resources) | uniq) }}
+{{- range $_, $cfScheduler := $config.availableCfSchedulers }}
 - name: semver.gke-cluster-{{ $branch }}-{{ $cfScheduler }}
   type: semver
   source:
@@ -84,7 +73,7 @@ resources:
 {{ end }} # prs and branches (flattened)
 
 
-{{- range $_, $branch := $branches }}
+{{- range $_, $branch := $config.branches }}
 - name: kubecf-{{ $branch }}
   type: git
   source:
@@ -108,16 +97,7 @@ resources:
     disable_forks: true # Trigger on kubecf branches only
     required_review_approvals: 1
 
-- name: kubecf-fork-pr
-  type: pull-request
-  check_every: 10m
-  source:
-    repository: {{ $config.kubecf_repository }}
-    access_token: ((github-access-token))
-    disable_forks: false # Trigger on kubecf branches only
-    required_review_approvals: 1
-
-{{- range $_, $pr := $pr_resources }}
+{{- range $_, $pr := $config.pr_resources }}
 
 {{- if $config.github_status }}
 - name: status-{{$pr}}.src
@@ -310,7 +290,7 @@ rotate_args: &rotate_args
 jobs:
 
 {{ $path := "" }}
-{{- range $_, $branch := flatten (slice $branches $pr_resources)  }}
+{{- range $_, $branch := flatten (slice $config.branches $config.pr_resources)  }}
 
 {{ if or (eq $branch "fork-pr") (eq $branch "pr" )}}
 {{ $path = ".git/resource/head_sha" }}
@@ -325,7 +305,7 @@ jobs:
   - get: kubecf-{{ $branch }}
     trigger: true
     version: "every"
-{{- if has $stable "lint" }}
+{{- if has $config.stable_jobs "lint" }}
   {{- if $config.github_status }}
   - put: status-{{ $branch }}.src
     params: &lint_{{ $sanitized_branch_name }}_status
@@ -356,7 +336,7 @@ jobs:
           ./dev/linters/helmlint.sh
           bazel test //rules/kubecf:create_sample_values_test
 
-{{- if has $stable "lint" }}
+{{- if has $config.stable_jobs "lint" }}
     {{- if $config.github_status }}
     on_success:
       put: status-{{ $branch }}.src
@@ -379,7 +359,7 @@ jobs:
     version: "every"
     passed:
     - lint-{{ $branch }}
-{{- if has $stable "build" }}
+{{- if has $config.stable_jobs "build" }}
   {{- if $config.github_status }}
   - put: status-{{ $branch }}.src
     params: &build_{{ $sanitized_branch_name }}_status
@@ -413,7 +393,7 @@ jobs:
               mv "$file" "${file%.tgz}-${timestamp}.tgz"
           done
 
-{{- if has $stable "build" }}
+{{- if has $config.stable_jobs "build" }}
     {{- if $config.github_status }}
     on_success:
       put: status-{{ $branch }}.src
@@ -436,7 +416,7 @@ jobs:
       file: output/kubecf-bundle-v*.tgz
       acl: public-read
 
-{{- range $_, $cfScheduler := $availableCfSchedulers }}
+{{- range $_, $cfScheduler := $config.availableCfSchedulers }}
 
 # prod-jobs
 - name: deploy-{{ $cfScheduler }}-{{ $branch }}
@@ -456,7 +436,7 @@ jobs:
     passed:
     - build-{{ $branch }}
   - get: catapult
-{{- if has $stable (printf "deploy-%s" $cfScheduler) }}
+{{- if has $config.stable_jobs (printf "deploy-%s" $cfScheduler) }}
   {{- if $config.github_status }}
   - put: status-{{ $branch }}.src
     params: &deploy_{{ $cfScheduler }}_{{ $sanitized_branch_name }}_status
@@ -494,7 +474,7 @@ jobs:
       run:
         path: "/bin/bash"
         args: *deploy_args
-{{- if has $stable (printf "deploy-%s" $cfScheduler) }}
+{{- if has $config.stable_jobs (printf "deploy-%s" $cfScheduler) }}
   {{- if $config.github_status }}
   on_success:
     do:
@@ -506,7 +486,7 @@ jobs:
 {{- end }}
   on_failure:
     in_parallel:
-{{- if has $stable (printf "deploy-%s" $cfScheduler) }}
+{{- if has $config.stable_jobs (printf "deploy-%s" $cfScheduler) }}
   {{- if $config.github_status }}
     - try:
         put: status-{{ $branch }}.src
@@ -591,7 +571,7 @@ jobs:
         params:
           BRANCH: {{ $branch }}
           CFSCHEDULER: {{ $cfScheduler }}
-{{- if has $stable (printf "deploy-%s" $cfScheduler) }}
+{{- if has $config.stable_jobs (printf "deploy-%s" $cfScheduler) }}
     {{- if $config.github_status }}
     - try:
         put: status-{{ $branch }}.src
@@ -607,7 +587,7 @@ jobs:
         params:
           BRANCH: {{ $branch }}
           CFSCHEDULER: {{ $cfScheduler }}
-{{- if has $stable (printf "deploy-%s" $cfScheduler) }}
+{{- if has $config.stable_jobs (printf "deploy-%s" $cfScheduler) }}
     {{- if $config.github_status }}
     - try:
         put: status-{{ $branch }}.src
@@ -637,7 +617,7 @@ jobs:
     - deploy-{{ $cfScheduler }}-{{ $branch }}
     trigger: true
   - get: catapult
-{{- if has $stable (printf "smoke-tests-%s" $cfScheduler) }}
+{{- if has $config.stable_jobs (printf "smoke-tests-%s" $cfScheduler) }}
   {{- if $config.github_status }}
   - put: status-{{ $branch }}.src
     params: &smoke_{{ $cfScheduler }}_{{ $sanitized_branch_name }}_status
@@ -669,7 +649,7 @@ jobs:
       run:
         path: "/bin/bash"
         args: *test_args
-{{- if has $stable (printf "smoke-tests-%s" $cfScheduler) }}
+{{- if has $config.stable_jobs (printf "smoke-tests-%s" $cfScheduler) }}
   {{- if $config.github_status }}
   on_success:
     put: status-{{ $branch }}.src
@@ -680,7 +660,7 @@ jobs:
 {{- end }}
   on_failure:
     in_parallel:
-{{- if has $stable (printf "smoke-tests-%s" $cfScheduler) }}
+{{- if has $config.stable_jobs (printf "smoke-tests-%s" $cfScheduler) }}
     {{- if $config.github_status }}
     - try:
         put: status-{{ $branch }}.src
@@ -701,7 +681,7 @@ jobs:
         params:
           BRANCH: {{ $branch }}
           CFSCHEDULER: {{ $cfScheduler }}
-{{- if has $stable (printf "smoke-tests-%s" $cfScheduler) }}
+{{- if has $config.stable_jobs (printf "smoke-tests-%s" $cfScheduler) }}
     {{- if $config.github_status }}
     - try:
         put: status-{{ $branch }}.src
@@ -717,7 +697,7 @@ jobs:
         params:
           BRANCH: {{ $branch }}
           CFSCHEDULER: {{ $cfScheduler }}
-{{- if has $stable (printf "smoke-tests-%s" $cfScheduler) }}
+{{- if has $config.stable_jobs (printf "smoke-tests-%s" $cfScheduler) }}
     {{- if $config.github_status }}
     - try:
         put: status-{{ $branch }}.src
@@ -746,7 +726,7 @@ jobs:
     - {{ $previousTest | quote }}
     trigger: true
   - get: catapult
-{{- if has $stable (printf "cf-acceptance-tests-%s" $cfScheduler) }}
+{{- if has $config.stable_jobs (printf "cf-acceptance-tests-%s" $cfScheduler) }}
   {{- if $config.github_status }}
   - put: status-{{ $branch }}.src
     params: &cats_{{ $cfScheduler }}_{{ $sanitized_branch_name }}_status
@@ -779,7 +759,7 @@ jobs:
         path: "/bin/bash"
         args: *test_args
 
-{{- if has $stable (printf "cf-acceptance-tests-%s" $cfScheduler) }}
+{{- if has $config.stable_jobs (printf "cf-acceptance-tests-%s" $cfScheduler) }}
   {{- if $config.github_status }}
   on_success:
     put: status-{{ $branch }}.src
@@ -796,7 +776,7 @@ jobs:
         params:
           BRANCH: {{ $branch }}
           CFSCHEDULER: {{ $cfScheduler }}
-{{- if has $stable (printf "cf-acceptance-tests-%s" $cfScheduler) }}
+{{- if has $config.stable_jobs (printf "cf-acceptance-tests-%s" $cfScheduler) }}
     {{- if $config.github_status }}
     - try:
         put: status-{{ $branch }}.src
@@ -812,7 +792,7 @@ jobs:
         params:
           BRANCH: {{ $branch }}
           CFSCHEDULER: {{ $cfScheduler }}
-{{- if has $stable (printf "cf-acceptance-tests-%s" $cfScheduler) }}
+{{- if has $config.stable_jobs (printf "cf-acceptance-tests-%s" $cfScheduler) }}
     {{- if $config.github_status }}
     - try:
         put: status-{{ $branch }}.src
@@ -828,7 +808,7 @@ jobs:
         params:
           BRANCH: {{ $branch }}
           CFSCHEDULER: {{ $cfScheduler }}
-{{- if has $stable (printf "cf-acceptance-tests-%s" $cfScheduler) }}
+{{- if has $config.stable_jobs (printf "cf-acceptance-tests-%s" $cfScheduler) }}
     {{- if $config.github_status }}
     - try:
         put: status-{{ $branch }}.src
@@ -857,7 +837,7 @@ jobs:
     - {{ $previousTest | quote }}
     trigger: true
   - get: catapult
-{{- if has $stable (printf "cats-internetless-%s" $cfScheduler) }}
+{{- if has $config.stable_jobs (printf "cats-internetless-%s" $cfScheduler) }}
   {{- if $config.github_status }}
   - put: status-{{ $branch }}.src
     params: &cats_internetless_{{ $cfScheduler }}_{{ $sanitized_branch_name }}_status
@@ -891,7 +871,7 @@ jobs:
         path: "/bin/bash"
         args: *test_args
 
-{{- if has $stable (printf "cats-internetless-%s" $cfScheduler) }}
+{{- if has $config.stable_jobs (printf "cats-internetless-%s" $cfScheduler) }}
   {{- if $config.github_status }}
   on_success:
     put: status-{{ $branch }}.src
@@ -907,7 +887,7 @@ jobs:
         params:
           BRANCH: {{ $branch }}
           CFSCHEDULER: {{ $cfScheduler }}
-{{- if has $stable (printf "cats-internetless-%s" $cfScheduler) }}
+{{- if has $config.stable_jobs (printf "cats-internetless-%s" $cfScheduler) }}
     {{- if $config.github_status }}
     - try:
         put: status-{{ $branch }}.src
@@ -923,7 +903,7 @@ jobs:
         params:
           BRANCH: {{ $branch }}
           CFSCHEDULER: {{ $cfScheduler }}
-{{- if has $stable (printf "cats-internetless-%s" $cfScheduler) }}
+{{- if has $config.stable_jobs (printf "cats-internetless-%s" $cfScheduler) }}
     {{- if $config.github_status }}
     - try:
         put: status-{{ $branch }}.src
@@ -939,7 +919,7 @@ jobs:
         params:
           BRANCH: {{ $branch }}
           CFSCHEDULER: {{ $cfScheduler }}
-{{- if has $stable (printf "cats-internetless-%s" $cfScheduler) }}
+{{- if has $config.stable_jobs (printf "cats-internetless-%s" $cfScheduler) }}
     {{- if $config.github_status }}
     - try:
         put: status-{{ $branch }}.src
@@ -971,7 +951,7 @@ jobs:
     - {{ $previousTest | quote }}
     trigger: true
   - get: catapult
-{{- if has $stable "sync-integration-tests" }}
+{{- if has $config.stable_jobs "sync-integration-tests" }}
   {{- if $config.github_status }}
   - put: status-{{ $branch }}.src
     params: &sits_{{ $sanitized_branch_name }}_status
@@ -1003,7 +983,7 @@ jobs:
       run:
         path: "/bin/bash"
         args: *test_args
-{{- if has $stable "sync-integration-tests" }}
+{{- if has $config.stable_jobs "sync-integration-tests" }}
   {{- if $config.github_status }}
   on_success:
     put: status-{{ $branch }}.src
@@ -1014,7 +994,7 @@ jobs:
 {{- end }}
   on_failure:
     in_parallel:
-{{- if has $stable "sync-integration-tests" }}
+{{- if has $config.stable_jobs "sync-integration-tests" }}
     {{- if $config.github_status }}
     - try:
         put: status-{{ $branch }}.src
@@ -1035,7 +1015,7 @@ jobs:
         params:
           BRANCH: {{ $branch }}
           CFSCHEDULER: {{ $cfScheduler }}
-{{- if has $stable "sync-integration-tests" }}
+{{- if has $config.stable_jobs "sync-integration-tests" }}
     {{- if $config.github_status }}
     - try:
         put: status-{{ $branch }}.src
@@ -1052,7 +1032,7 @@ jobs:
         params:
           BRANCH: {{ $branch }}
           CFSCHEDULER: {{ $cfScheduler }}
-{{- if has $stable "sync-integration-tests" }}
+{{- if has $config.stable_jobs "sync-integration-tests" }}
     {{- if $config.github_status }}
     - try:
         put: status-{{ $branch }}.src
@@ -1082,7 +1062,7 @@ jobs:
     - {{ $previousTest | quote }}
     trigger: true
   - get: catapult
-{{- if has $stable (printf "rotate-%s" $cfScheduler) }}
+{{- if has $config.stable_jobs (printf "rotate-%s" $cfScheduler) }}
   {{- if $config.github_status }}
   - put: status-{{ $branch }}.src
     params: &rotate_{{ $cfScheduler }}_{{ $sanitized_branch_name }}_status
@@ -1114,7 +1094,7 @@ jobs:
         path: "/bin/bash"
         args: *rotate_args
 
-{{- if has $stable (printf "rotate-%s" $cfScheduler) }}
+{{- if has $config.stable_jobs (printf "rotate-%s" $cfScheduler) }}
   {{- if $config.github_status }}
   on_success:
     put: status-{{ $branch }}.src
@@ -1126,7 +1106,7 @@ jobs:
 
   on_failure:
     in_parallel:
-{{- if has $stable (printf "rotate-%s" $cfScheduler) }}
+{{- if has $config.stable_jobs (printf "rotate-%s" $cfScheduler) }}
     {{- if $config.github_status }}
     - try:
         put: status-{{ $branch }}.src
@@ -1147,7 +1127,7 @@ jobs:
         params:
           BRANCH: {{ $branch }}
           CFSCHEDULER: {{ $cfScheduler }}
-{{- if has $stable (printf "rotate-%s" $cfScheduler) }}
+{{- if has $config.stable_jobs (printf "rotate-%s" $cfScheduler) }}
     {{- if $config.github_status }}
     - try:
         put: status-{{ $branch }}.src
@@ -1163,7 +1143,7 @@ jobs:
         params:
           BRANCH: {{ $branch }}
           CFSCHEDULER: {{ $cfScheduler }}
-{{- if has $stable (printf "rotate-%s" $cfScheduler) }}
+{{- if has $config.stable_jobs (printf "rotate-%s" $cfScheduler) }}
     {{- if $config.github_status }}
     - try:
         put: status-{{ $branch }}.src
@@ -1192,7 +1172,7 @@ jobs:
     - {{ $previousTest | quote }}
     trigger: true
   - get: catapult
-{{- if has $stable (printf "smoke-rotated-{%s" $cfScheduler) }}
+{{- if has $config.stable_jobs (printf "smoke-rotated-{%s" $cfScheduler) }}
   {{- if $config.github_status }}
   - put: status-{{ $branch }}.src
     params: &smoke_rotate_{{ $cfScheduler }}_{{ $sanitized_branch_name }}_status
@@ -1225,7 +1205,7 @@ jobs:
         path: "/bin/bash"
         args: *test_args
 
-{{- if has $stable (printf "smoke-rotated-{%s" $cfScheduler) }}
+{{- if has $config.stable_jobs (printf "smoke-rotated-{%s" $cfScheduler) }}
   {{- if $config.github_status }}
   on_success:
     put: status-{{ $branch }}.src
@@ -1237,7 +1217,7 @@ jobs:
 
   on_failure:
     in_parallel:
-{{- if has $stable (printf "smoke-rotated-{%s" $cfScheduler) }}
+{{- if has $config.stable_jobs (printf "smoke-rotated-{%s" $cfScheduler) }}
     {{- if $config.github_status }}
     - try:
         put: status-{{ $branch }}.src
@@ -1258,7 +1238,7 @@ jobs:
         params:
           BRANCH: {{ $branch }}
           CFSCHEDULER: {{ $cfScheduler }}
-{{- if has $stable (printf "smoke-rotated-{%s" $cfScheduler) }}
+{{- if has $config.stable_jobs (printf "smoke-rotated-{%s" $cfScheduler) }}
     {{- if $config.github_status }}
     - try:
         put: status-{{ $branch }}.src
@@ -1274,7 +1254,7 @@ jobs:
         params:
           BRANCH: {{ $branch }}
           CFSCHEDULER: {{ $cfScheduler }}
-{{- if has $stable (printf "smoke-rotated-{%s" $cfScheduler) }}
+{{- if has $config.stable_jobs (printf "smoke-rotated-{%s" $cfScheduler) }}
     {{- if $config.github_status }}
     - try:
         put: status-{{ $branch }}.src

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -1367,6 +1367,16 @@ jobs:
     - get: catapult
     - put: semver.gke-cluster-{{ $branch }}-upgrade
       params: {bump: patch}
+{{- if has $stable (printf "upgrade-test") }}
+  {{- if $config.github_status }}
+  - put: status-{{ $branch }}.src
+    params: &upgrade-test_{{ $sanitized_branch_name }}_status
+        context: "upgrade-test"
+        description: "Upgrade from latest GH available release"
+        path: kubecf-{{ $branch }}/{{ $path }}
+        state: pending
+  {{- end }}
+{{- end }}
   - task: upgrade
     params:
       BRANCH: {{ $branch }}
@@ -1381,6 +1391,48 @@ jobs:
       semver.gke-cluster: semver.gke-cluster-{{ $branch }}-upgrade
     timeout: 4h
     file: kubecf-{{ $branch }}/.concourse/tasks/upgrade.yaml
+{{- if has $stable (printf "upgrade-test") }}
+  {{- if $config.github_status }}
+  on_success:
+    put: status-{{ $branch }}.src
+    params:
+      << : *upgrade-test_{{ $sanitized_branch_name }}_status
+      state: success
+  {{- end }}
+{{- end }}
+  on_failure:
+    in_parallel:
+{{- if has $stable (printf "upgrade-test") }}
+    {{- if $config.github_status }}
+    - try:
+        put: status-{{ $branch }}.src
+        params:
+          << : *upgrade-test_{{ $sanitized_branch_name }}_status
+          state: failure
+    {{- end }}
+{{- end }}
+  on_abort:
+    in_parallel:
+{{- if has $stable (printf "upgrade-test") }}
+    {{- if $config.github_status }}
+    - try:
+        put: status-{{ $branch }}.src
+        params:
+          << : *upgrade-test_{{ $sanitized_branch_name }}_status
+          state: failure
+    {{- end }}
+{{- end }}
+  on_error:
+    in_parallel:
+{{- if has $stable (printf "upgrade-test") }}
+    {{- if $config.github_status }}
+    - try:
+        put: status-{{ $branch }}.src
+        params:
+          << : *upgrade-test_{{ $sanitized_branch_name }}_status
+          state: failure
+    {{- end }}
+{{- end }}
   ensure:
     do:
       - << : *cleanup-cluster


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PRs backports as less code as possible and allows to deploy a pipeline for `release-2.3` branch:
- Backport:
  - move pipeline vars to config file
  - add github_status for upgrade
  - fix rotate_credentials job by adding a wait afterwards
  -  add `pr_base_branch` pipeline option
- Create new `./concourse/kubecf-release2.3.yaml` configuration file with sane options, for the new `kubecf-release-2.3` pipeline.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Implements https://github.com/cloudfoundry-incubator/kubecf/issues/1095 for `release-2.3` branch.

Decided to cherry-pick individual commits (`git cherry-pick -x <sha>`, fix minimal conflicts), and not merge commits.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- An important detail to include is the version of the used cf-operator -->

Deployed pipeline https://concourse.suse.dev/teams/main/pipelines/kubecf-release-2.3. Note that the pipeline is production ready and should stay, and the PR tab tests only PRs open against `release-2.3` (such as this very one you are reading) instead of all possible PRs.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
