### PR TITLE
CI: Update release-2.3 pipeline config to consume new options

### DIFF
--- a/.concourse/kubecf-release-2.3.yaml
+++ b/.concourse/kubecf-release-2.3.yaml
@@ -1,9 +1,21 @@
 ---
 
+# NOTE: unique prefix for resource names. This way they don't collide among
+# different pipelines. Use your own when developing. Must not start with a
+# number as it breaks gcloud clusters.
+resource_prefix: release-2-3
+
+workertags: # list of worker tags, to run the pipeline on specific (tagged) workers
+  # - yourtag
+
+# NOTE use your own bucket when developing
 s3_bucket: kubecf-ci
 s3_bucket_region: eu-central-1
+
+# NOTE use your own bucket when developing
 s3_final_bucket: kubecf
 s3_final_bucket_region: us-west-2
+
 kubecf_repository: cloudfoundry-incubator/kubecf
 
 # for preemptible gke clusters
@@ -12,7 +24,7 @@ gke_zone: europe-west3-c
 gke_dns_zone: kubecf-ci
 gke_domain: kubecf.ci
 
-# NOTE please disable the following if you are developing or deploying a copy of
+# NOTE please disable the following when developing or deploying a copy of
 # the pipeline:
 trigger_publish: true
 github_status: true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Update release-2.3 pipeline config to consume new options. After fast-forwarding, there are new options to set in the pipeline config, and the pipeline needs to be reflown.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fails to deploy clusters if not, because we name the clusters to make them unique per branch and copy of the pipeline.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- An important detail to include is the version of the used cf-operator -->

Redeployed release-2.3 pipeline, upgrade job is working now: https://concourse.suse.dev/teams/main/pipelines/kubecf-release-2.3/jobs/upgrade-test-release-2.3/builds/4
The other deploy jobs work the same, but I haven't triggered them; they will get triggered automatically when there's a new commit, such as this PR.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
