### PR TITLE
feat: Add wait targets for make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,12 +57,18 @@ cf-login:
 cf-operator-apply:
 	@./scripts/cf-operator-apply.sh
 
+cf-operator-wait:
+	@./scripts/cf-operator-wait.sh
+
 kubecf-apply:
 	@./scripts/kubecf-build.sh
 	@./scripts/kubecf-apply.sh
 
 kubecf-delete:
 	@./scripts/kubecf-delete.sh
+
+kubecf-wait:
+	@./scripts/kubecf-wait.sh
 
 ########################################################################
 # Test

--- a/scripts/cf-operator-wait.sh
+++ b/scripts/cf-operator-wait.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# This script waits untils the operator is ready
+
+source scripts/include/setup.sh
+
+require_tools kubectl retry
+
+# Wait for CRDs to show up
+crds=(
+    boshdeployments.quarks.cloudfoundry.org
+    quarksjobs.quarks.cloudfoundry.org
+    quarkssecrets.quarks.cloudfoundry.org
+    quarksstatefulsets.quarks.cloudfoundry.org
+)
+for crd in "${crds[@]}" ; do
+    RETRIES=60 DELAY=5 retry kubectl wait --for=condition=Established \
+        "customresourcedefinition.apiextensions.k8s.io/${crd}"
+done
+
+# Wait for the operator deployments to be ready
+deployments=( cf-operator cf-operator-quarks-job )
+for deployment in "${deployments[@]}" ; do
+    RETRIES=60 DELAY=5 retry kubectl wait --for=condition=Available \
+        --namespace=cf-operator --timeout=600s "deployment/${deployment}"
+done

--- a/scripts/kubecf-wait.sh
+++ b/scripts/kubecf-wait.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+# This script waits untils the KubeCF deployment is ready
+
+source scripts/include/setup.sh
+
+require_tools kubectl retry
+
+get_resource() {
+    kubectl get --output=name --namespace=kubecf "${@}"
+}
+
+check_resource_count() {
+    local resource="${1}"
+    test -n "$(get_resource "${resource}")"
+}
+
+green "Waiting for the BOSHDeployment to exist"
+RETRIES=30 DELAY=5 retry get_resource BOSHDeployment/kubecf
+
+green "Waiting for the quarks jobs to be done"
+check_qjob_ready() {
+    local qjob="QuarksJob/${1}"
+    local output='--output=jsonpath={.status.completed}'
+    test true == "$(get_resource "${qjob}" "${output}")"
+}
+RETRIES=180 DELAY=10 retry check_qjob_ready dm
+RETRIES=180 DELAY=10 retry check_qjob_ready ig
+
+green "Waiting for things to exist"
+resources=(
+    Service/uaa Service/api Service/router-public
+    StatefulSet/uaa StatefulSet/api StatefulSet/router
+)
+for resource in "${resources[@]}" ; do
+    RETRIES=30 DELAY=5 retry get_resource "${resource}"
+done
+
+RETRIES=60 DELAY=5 retry check_resource_count pods
+
+green "Waiting for all deployments to be available"
+wait_for_condition() {
+    local condition="${1}"
+    shift
+    local resource
+    for resource in "${@}" ; do
+        retry kubectl wait --for="${condition}" --namespace=kubecf --timeout=600s "${resource}"
+    done
+}
+
+RETRIES=60 DELAY=5 retry check_resource_count deployments
+mapfile -t deployments < <(get_resource deployments)
+RETRIES=60 DELAY=5 wait_for_condition condition=Available "${deployments[@]}"
+
+green "Waiting for all endpoints to be available"
+wait_for_endpoint() {
+    local endpoint="${1}"
+    local output='--output=jsonpath={.subsets.*.addresses.*.ip}'
+    test -n "$(get_resource "${endpoint}" "${output}")"
+}
+
+RETRIES=60 DELAY=5 retry check_resource_count endpoints
+mapfile -t endpoints < <(get_resource endpoints)
+for endpoint in "${endpoints[@]}" ; do
+    RETRIES=180 DELAY=10 retry wait_for_endpoint "${endpoint}"
+done

--- a/scripts/tools/retry.sh
+++ b/scripts/tools/retry.sh
@@ -1,0 +1,21 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034
+
+TOOLS+=(retry)
+
+function retry {
+    # Usage: [RETRIES=3] [DELAY=5] retry [command...]
+    local max="${RETRIES:-3}"
+    local delay="${DELAY:-5}"
+    local i=0
+
+    while test "${i}" -lt "${max}" ; do
+        printf "%s/%s: %s\\n" "$(( i + 1 ))" "${max}" "$*"
+        if "$@" ; then
+            return
+        fi
+        sleep "${delay}"
+        i="$(( i + 1 ))"
+    done
+    return 1
+}


### PR DESCRIPTION
## Description
This adds two new targets for the make-based build system, which can be used to wait for cf-operator & kubecf to finish deploying.  This is useful in CI where we may want to let things settle before running the consequent steps (e.g. to run tests).

## Motivation and Context
Wanted to use this in CI (spiking on using GitHub actions, but this is useful elsewhere).

## How Has This Been Tested?
Ran a lot.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

This change is for development only, this has no effect on the shipped code.  It is also currently not used anywhere.