### PR TITLE
CI: Add logic to pause jobs if pushed pipeline is new

### DIFF
--- a/.concourse/create-pipeline.sh
+++ b/.concourse/create-pipeline.sh
@@ -48,16 +48,38 @@ else
     fi
 fi
 
+# Determine if the pipeline being pushed is a new pipeline
+existing_pipeline_job_count=$(
+  fly --target ${target} get-pipeline --pipeline ${PIPELINE} --json | jq '.jobs | length' || true
+)
+if [[ ${existing_pipeline_job_count} -gt 0 ]]; then
+  pipeline_already_existed=true
+else
+  pipeline_already_existed=false
+fi
+
+# Push a new pipeline, or update an existing one
 fly_args=(
     "--target=${target}"
     "set-pipeline"
     "--pipeline=${PIPELINE}"
 )
-
 if [[ "$2" =~ "reconciler" ]]; then
     fly "${fly_args[@]}" --config \
         <(gomplate -V --datasource config="$PIPELINE".yaml --file kubecf-pool-reconciler.yaml.gomplate)
 else # kubecf pipeline
     fly "${fly_args[@]}" --config \
         <(gomplate -V --datasource config="$PIPELINE".yaml --file pipeline.yaml.gomplate)
+fi
+
+# If the pipeline being pushed was a *new* pipeline, pause all the 'initial' jobs (jobs without 'passed:' dependencies)
+# Important caveat: If a pipeline is updated to add new targets, the new initial jobs will *not* be paused
+if ! ${pipeline_already_existed}; then
+    jobs_without_dependencies_names=$(
+        fly ${target:+"--target=${target}"} get-pipeline --json -p "${PIPELINE}" | jq -r '.jobs - [.jobs[] | select(.plan[] | .passed)] | .[].name'
+                                   )
+    for job_name in ${jobs_without_dependencies_names}; do
+        fly ${target:+"--target=${target}"} pause-job -j "${PIPELINE}/${job_name}"
+    done
+    fly ${target:+"--target=${target}"} unpause-pipeline --pipeline="${PIPELINE}"
 fi

--- a/.concourse/create-pipeline.sh
+++ b/.concourse/create-pipeline.sh
@@ -50,7 +50,7 @@ fi
 
 # Determine if the pipeline being pushed is a new pipeline
 existing_pipeline_job_count=$(
-  fly --target ${target} get-pipeline --pipeline ${PIPELINE} --json | jq '.jobs | length' || true
+  fly --target "${target}" get-pipeline --pipeline "${PIPELINE}" --json | jq '.jobs | length' || true
 )
 if [[ ${existing_pipeline_job_count} -gt 0 ]]; then
   pipeline_already_existed=true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add logic to pause jobs if pushed pipeline is new. Lifted from github.com/SUSE/cap.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes: https://github.com/cloudfoundry-incubator/kubecf/issues/1032

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- An important detail to include is the version of the used cf-operator -->

Tested successfully all possible combinations, by deploying a new pipeline (and seeing starting jobs paused), deleting the pipeline, redeploying again, redeploying with changes seeing that starting jobs are not paused, and redeploying with no changes. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
