### PR TITLE
feat: Improve wait scripts for interactive usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,12 @@ minikube-delete:
 ########################################################################
 # Run
 
-all: cf-operator-apply cf-operator-wait kubecf-apply kubecf-wait cf-login
+all:
+	./scripts/cf-operator-apply
+	./scripts/cf-operator-wait
+	./scripts/kubecf-apply
+	./scripts/kubecf-wait
+	./scripts/cf-login
 
 cf-login:
 	@./scripts/cf-login.sh

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,8 @@ minikube-delete:
 ########################################################################
 # Run
 
+all: cf-operator-apply cf-operator-wait kubecf-apply kubecf-wait cf-login
+
 cf-login:
 	@./scripts/cf-login.sh
 

--- a/scripts/tools/retry.sh
+++ b/scripts/tools/retry.sh
@@ -9,13 +9,33 @@ function retry {
     local delay="${DELAY:-5}"
     local i=0
 
+    local cr
+    local nl
+    if [ -t 1 ]; then
+        # Output is to a TTY; don't scroll display while waiting.
+        cr="\r"
+        # Display a trailing space between the last character and the cursor.
+        # Also overwrites trailing character when number of seconds shrink from
+        # two to one digit, e.g. "1m 58s" → "2m 3s".
+        nl=" "
+    else
+        # Output is to a file; don't overwrite lines.
+        cr=""
+        nl="\n"
+    fi
+
     while test "${i}" -lt "${max}" ; do
-        printf "%s/%s: %s\\n" "$(( i + 1 ))" "${max}" "$*"
-        if "$@" ; then
+        printf "${cr}[%dm %ds] %s/%s: %s${nl}" \
+               "$(( SECONDS / 60 ))" "$(( SECONDS % 60))"\
+               "$(( i + 1 ))" "${max}" \
+               "$*"
+        if "$@" &> /dev/null ; then
+            [ -n "${cr}" ] && printf "\n"
             return
         fi
         sleep "${delay}"
         i="$(( i + 1 ))"
     done
+    [ -n "${cr}" ] && printf "\n"
     return 1
 }


### PR DESCRIPTION
* Don't display errors from the command checking status; it is expected to fail while the status is not yet ready.

* Display time since the start of the script for each wait check, in addition to the retry/max counts.

* Overwrite status output for a single check when writing to a tty to avoid massive scrolling.

Also add an `all` target to deploy cf-operator and kubecf, and then log in when everything is ready, e.g. `FEATURE_EIRINI=1 make all` to run kubecf with Eirini on the cluster specified by the current `KUBECONFIG`.