### PR TITLE
Add params.submodules true if using the pr resource on kubecf-pr

### DIFF
--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -321,6 +321,10 @@ jobs:
     tags: {{ range $config.workertags }}
     - {{ . -}}{{ end }}
     {{- end }}
+    {{- if ( eq $branch "pr" )}}
+    params:
+      submodules: true
+    {{- end }}
     trigger: true
     version: "every"
 {{- if has $config.stable_jobs "lint" }}

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -393,6 +393,10 @@ jobs:
     tags: {{ range $config.workertags }}
     - {{ . -}}{{ end }}
     {{- end }}
+    {{- if ( eq $branch "pr" )}}
+    params:
+      submodules: true
+    {{- end }}
     trigger: true
     version: "every"
     passed:
@@ -485,6 +489,10 @@ jobs:
     {{- if $config.workertags }}
     tags: {{ range $config.workertags }}
     - {{ . -}}{{ end }}
+    {{- end }}
+    {{- if ( eq $branch "pr" )}}
+    params:
+      submodules: true
     {{- end }}
     trigger: true
     version: "every"
@@ -715,6 +723,10 @@ jobs:
     tags: {{ range $config.workertags }}
     - {{ . -}}{{ end }}
     {{- end }}
+    {{- if ( eq $branch "pr" )}}
+    params:
+      submodules: true
+    {{- end }}
     trigger: true
     version: "every"
     passed:
@@ -890,6 +902,10 @@ jobs:
     tags: {{ range $config.workertags }}
     - {{ . -}}{{ end }}
     {{- end }}
+    {{- if ( eq $branch "pr" )}}
+    params:
+      submodules: true
+    {{- end }}
     passed:
     - {{ $previousTest | quote }}
     trigger: true
@@ -1054,6 +1070,10 @@ jobs:
     {{- if $config.workertags }}
     tags: {{ range $config.workertags }}
     - {{ . -}}{{ end }}
+    {{- end }}
+    {{- if ( eq $branch "pr" )}}
+    params:
+      submodules: true
     {{- end }}
     passed:
     - {{ $previousTest | quote }}
@@ -1223,6 +1243,10 @@ jobs:
     tags: {{ range $config.workertags }}
     - {{ . -}}{{ end }}
     {{- end }}
+    {{- if ( eq $branch "pr" )}}
+    params:
+      submodules: true
+    {{- end }}
     passed:
     - {{ $previousTest | quote }}
     trigger: true
@@ -1389,6 +1413,10 @@ jobs:
     tags: {{ range $config.workertags }}
     - {{ . -}}{{ end }}
     {{- end }}
+    {{- if ( eq $branch "pr" )}}
+    params:
+      submodules: true
+    {{- end }}
     passed:
     - {{ $previousTest | quote }}
     trigger: true
@@ -1552,6 +1580,10 @@ jobs:
     {{- if $config.workertags }}
     tags: {{ range $config.workertags }}
     - {{ . -}}{{ end }}
+    {{- end }}
+    {{- if ( eq $branch "pr" )}}
+    params:
+      submodules: true
     {{- end }}
     passed:
     - {{ $previousTest | quote }}
@@ -1779,6 +1811,10 @@ jobs:
     {{- if $config.workertags }}
     tags: {{ range $config.workertags }}
     - {{ . -}}{{ end }}
+    {{- end }}
+    {{- if ( eq $branch "pr" )}}
+    params:
+      submodules: true
     {{- end }}
     passed:
     - {{ $previousTest | quote }}


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This should clone submodules and fix PR testing.

The get step uses the resource `kubecf-{{ $branch }}`, and depending on the
range, it will either be:
- kubecf-{master, release-2.3, etc}, which is the git resource
- kubecf-pr, which is the SUSE/github-pr-resource

Each has a different behaviour for the `submodules` param, the former defaults
to all, the later accepts a boolean and defaults to false. Hence, the `if`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- An important detail to include is the version of the used cf-operator -->

Fix flown already, https://concourse.suse.dev/teams/main/pipelines/kubecf/jobs/lint-pr/builds/110 doesn't fail because of submodule not initialized, as https://concourse.suse.dev/teams/main/pipelines/kubecf/jobs/lint-pr/builds/109 used to do.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
