### PR TITLE
Fix 'all' Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ minikube-delete:
 all:
 	./scripts/cf-operator-apply.sh
 	./scripts/cf-operator-wait.sh
+	./scripts/kubecf-build.sh
 	./scripts/kubecf-apply.sh
 	./scripts/kubecf-wait.sh
 	./scripts/cf-login.sh
@@ -67,8 +68,10 @@ cf-operator-apply:
 cf-operator-wait:
 	@./scripts/cf-operator-wait.sh
 
-kubecf-apply:
+kubecf-build:
 	@./scripts/kubecf-build.sh
+
+kubecf-apply:
 	@./scripts/kubecf-apply.sh
 
 kubecf-delete:

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,6 @@ minikube-delete:
 all:
 	./scripts/cf-operator-apply.sh
 	./scripts/cf-operator-wait.sh
-	./scripts/kubecf-build.sh
 	./scripts/kubecf-apply.sh
 	./scripts/kubecf-wait.sh
 	./scripts/cf-login.sh

--- a/Makefile
+++ b/Makefile
@@ -52,11 +52,11 @@ minikube-delete:
 # Run
 
 all:
-	./scripts/cf-operator-apply
-	./scripts/cf-operator-wait
-	./scripts/kubecf-apply
-	./scripts/kubecf-wait
-	./scripts/cf-login
+	./scripts/cf-operator-apply.sh
+	./scripts/cf-operator-wait.sh
+	./scripts/kubecf-apply.sh
+	./scripts/kubecf-wait.sh
+	./scripts/cf-login.sh
 
 cf-login:
 	@./scripts/cf-login.sh

--- a/Makefile
+++ b/Makefile
@@ -67,9 +67,6 @@ cf-operator-apply:
 cf-operator-wait:
 	@./scripts/cf-operator-wait.sh
 
-kubecf-build:
-	@./scripts/kubecf-build.sh
-
 kubecf-apply:
 	@./scripts/kubecf-apply.sh
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -154,12 +154,9 @@ are running before deploying the `kubecf` chart.
 
 #### ./scripts/kubecf-apply.sh
 
-Deploys the `kubecf` chart. This script assumes that the `kubecf-build.sh`
-script has just been run. The `make kubecf-apply` target ensures this.
+Deploys the `kubecf` chart. If the `CHART` environment variable is not set then this script will first run `./scripts/kubecf-build.sh` to make certain that the chart is up-to-date with regard to the current state of the working directory. Otherwise it will deploy the chart specified by `CHART`.
 
-Alternatively, the `CHART` environment variable can be used to specify a
-the KubeCF chart to be deployed. Helm configuration variables can be set
-in a YAML file pointed to by `VALUES`.
+Helm configuration variables can be set in a YAML file pointed to by `VALUES`.
 
 Some common features can be enabled by setting their configuration variable
 to a non-empty value: `FEATURE_AUTOSCALER`, `FEATURE_EIRINI`, and

--- a/scripts/kubecf-apply.sh
+++ b/scripts/kubecf-apply.sh
@@ -49,6 +49,9 @@ fi
 
 if [ -z "${CHART:-}" ]; then
     CHART="output/kubecf-$(./scripts/version.sh).tgz"
+    export TARGET_FILE="${CHART}"
+    ./scripts/kubecf-build.sh
+
 fi
 
 helm upgrade kubecf "${CHART}" \

--- a/scripts/kubecf-build.sh
+++ b/scripts/kubecf-build.sh
@@ -70,7 +70,8 @@ helm package "${HELM_DIR}" --version "${VERSION}" --app-version "${VERSION}" --d
 
 rm -rf "${HELM_DIR}"
 
-if [ -n "${TARGET_FILE:-}" ]; then
+HELM_CHART="output/kubecf-${VERSION}.tgz"
+if [[ -n "${TARGET_FILE:-}" && "${TARGET_FILE}" != "${HELM_CHART}" ]]; then
     mkdir -p "$(dirname "${TARGET_FILE}")"
-    cp "output/kubecf-${VERSION}.tgz" "${TARGET_FILE}"
+    cp "${HELM_CHART}" "${TARGET_FILE}"
 fi


### PR DESCRIPTION
It got broken in cac7e60; all scripts are missing the .sh file extension.
