### PR TITLE
fix: scripts: Fix minikube ISO download URL

### DIFF
--- a/scripts/minikube-start.sh
+++ b/scripts/minikube-start.sh
@@ -7,7 +7,8 @@ require_tools minikube
 : "${VM_MEMORY:=16384}"
 : "${VM_DISK_SIZE:=120g}"
 
-: "${MINIKUBE_ISO_URL:=https://github.com/f0rmiga/opensuse-minikube-image/releases/download/v0.1.6/minikube-openSUSE.x86_64-0.1.8.iso}"
+: "${MINIKUBE_ISO_VERSION:=0.1.8}"
+: "${MINIKUBE_ISO_URL:=https://github.com/f0rmiga/opensuse-minikube-image/releases/download/v${MINIKUBE_ISO_VERSION}/minikube-openSUSE.x86_64-${MINIKUBE_ISO_VERSION}.iso}"
 
 if ! minikube status > /dev/null; then
     # shellcheck disable=SC2086


### PR DESCRIPTION
## Description
It had a mismatched version (0.1.6 vs 0.1.8) which means it couldn't be downloaded at all.

## Motivation and Context
Trying to start minikube failed.

## How Has This Been Tested?
Started minikube on a machine that previously failed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
