### PR TITLE
Eirini: drop cluster.local references

### DIFF
--- a/deploy/helm/kubecf/assets/operations/instance_groups/eirini-helm.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/eirini-helm.yaml
@@ -19,20 +19,20 @@
 
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/opi?/url?
-  value: "https://eirini-opi.{{ .Release.Namespace }}.svc.cluster.local:8085"
+  value: "https://eirini-opi.{{ .Release.Namespace }}.svc:8085"
 
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/packages?/webdav_config?/private_endpoint?
-  value: "https://singleton-blobstore.{{ .Release.Namespace }}.svc.cluster.local:4443"
+  value: "https://singleton-blobstore.{{ .Release.Namespace }}.svc:4443"
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/buildpacks?/webdav_config?/private_endpoint?
-  value: "https://singleton-blobstore.{{ .Release.Namespace }}.svc.cluster.local:4443"
+  value: "https://singleton-blobstore.{{ .Release.Namespace }}.svc:4443"
 - type: replace
   path: /variables/name=blobstore_tls/options/alternative_names?/-
-  value: "singleton-blobstore.{{ .Release.Namespace }}.svc.cluster.local"
+  value: "singleton-blobstore.{{ .Release.Namespace }}.svc"
 - type: replace
   path: /variables/name=cc_bridge_cc_uploader_server/options/alternative_names?/-
-  value: "api.{{ .Release.Namespace }}.svc.cluster.local"
+  value: "api.{{ .Release.Namespace }}.svc"
 - type: replace
   path: /variables/name=cc_bridge_cc_uploader/options/copies?/-
   value:
@@ -40,16 +40,16 @@
     name: var-cc-bridge-cc-uploader
 - type: replace
   path: /instance_groups/name=api/jobs/name=cc_uploader/properties/internal_hostname?
-  value: "api.{{ .Release.Namespace }}.svc.cluster.local"
+  value: "api.{{ .Release.Namespace }}.svc"
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/internal_service_hostname?
-  value: "api.{{ .Release.Namespace }}.svc.cluster.local"
+  value: "api.{{ .Release.Namespace }}.svc"
 - type: replace
   path: /variables/name=cc_public_tls/options/alternative_names?/-
-  value: "api.{{ .Release.Namespace }}.svc.cluster.local"
+  value: "api.{{ .Release.Namespace }}.svc"
 - type: replace
   path: /variables/name=cc_tls/options/alternative_names?/-
-  value: "api.{{ .Release.Namespace }}.svc.cluster.local"
+  value: "api.{{ .Release.Namespace }}.svc"
 
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/opi?/opi_staging?
@@ -69,7 +69,7 @@
   value: true
 - type: replace
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/opi?/url?
-  value: "https://eirini-opi.{{ .Release.Namespace }}.svc.cluster.local:8085" 
+  value: "https://eirini-opi.{{ .Release.Namespace }}.svc:8085" 
 - type: replace
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/cc/opi?/opi_staging?
   value: true
@@ -88,7 +88,7 @@
   value: true
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/opi?/url?
-  value: "https://eirini-opi.{{ .Release.Namespace }}.svc.cluster.local:8085"
+  value: "https://eirini-opi.{{ .Release.Namespace }}.svc:8085"
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/cc/opi?/opi_staging?
   value: true
@@ -120,7 +120,7 @@
       ca: service_cf_internal_ca
       common_name: "eirini-opi"
       alternative_names:
-      - "eirini-opi.{{ .Release.Namespace }}.svc.cluster.local"
+      - "eirini-opi.{{ .Release.Namespace }}.svc"
       extended_key_usage:
       - server_auth
 

--- a/deploy/helm/kubecf/charts/bits/Chart.yaml
+++ b/deploy/helm/kubecf/charts/bits/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for CloudFoundry/bits-service
 name: bits
-version: 1.0.17
+version: 1.0.21

--- a/deploy/helm/kubecf/charts/bits/templates/bits-config.yaml
+++ b/deploy/helm/kubecf/charts/bits/templates/bits-config.yaml
@@ -8,17 +8,18 @@ stringData:
   bits-config-key: |
     logging:
       level: debug
-    private_endpoint: "https://bits.{{ .Release.Namespace }}.svc.cluster.local"
+    private_endpoint: "https://bits.{{ .Release.Namespace }}.svc"
     {{- if .Values.ingress.use }}
     public_endpoint: "https://registry.{{ .Values.ingress.endpoint }}:443"
-    {{- else if .Values.services.loadbalanced }}
-    public_endpoint: "https://registry.{{ .Values.env.DOMAIN }}:6666"
+    {{- else if .Values.services.nodePort }}
+    public_endpoint: "https://registry.{{ .Values.env.DOMAIN }}:{{ .Values.services.nodePort }}"
     {{- else }}
     public_endpoint: "https://bits.{{ index .Values.kube.external_ips 0 }}.nip.io"
     {{- end }}
     {{- if .Values.ingress.use }}
     registry_endpoint: "https://registry.{{ .Values.ingress.endpoint }}"
-    {{- else if .Values.services.loadbalanced }}
+    {{- else if .Values.services.nodePort }}
+    # The registry endpoint must not include the port
     registry_endpoint: "https://registry.{{ .Values.env.DOMAIN }}"
     {{- else }}
     registry_endpoint: "https://registry.{{ index .Values.kube.external_ips 0 }}.nip.io"
@@ -47,11 +48,15 @@ stringData:
       blobstore_type: webdav
       webdav_config: &webdav_config
         directory_key: cc-buildpacks
-        private_endpoint: https://{{ .Values.blobstore.serviceName }}.{{ .Release.Namespace }}.svc.cluster.local:4443
+        {{- $blobstore_service := .Values.blobstore.serviceName }}
+        {{- if contains "." $blobstore_service | not }}
+        {{- $blobstore_service = printf "%s.%s.svc" $blobstore_service .Release.Namespace }}
+        {{- end }}
+        private_endpoint: https://{{ $blobstore_service }}:4443
         {{- if .Values.ingress.use }}
         public_endpoint: https://blobstore.{{ .Values.ingress.endpoint }}
-        {{- else if .Values.services.loadbalanced }}
-        public_endpoint: https://blobstore.{{ .Values.env.DOMAIN }}
+        {{- else if .Values.services.nodePort }}
+        public_endpoint: "https://blobstore.{{ .Values.env.DOMAIN }}:{{ .Values.services.nodePort }}"
         {{- else }}
         public_endpoint: https://blobstore.{{ index .Values.kube.external_ips 0 }}.nip.io
         {{- end }}

--- a/deploy/helm/kubecf/charts/bits/templates/bits.yaml
+++ b/deploy/helm/kubecf/charts/bits/templates/bits.yaml
@@ -113,19 +113,22 @@ metadata:
     external-dns.alpha.kubernetes.io/hostname: registry.{{ .Values.env.DOMAIN }}
 {{- end }}
 spec:
-{{- if and (not .Values.ingress.use) (not .Values.services.loadbalanced) }}
+{{- if and (not .Values.ingress.use) (not .Values.services.nodePort) }}
   externalIPs: {{ .Values.kube.external_ips | toJson }}
 {{- end }}
   ports:
     - port: {{ if .Values.ingress.use }}8888{{ else }}6666{{ end }}
       protocol: TCP
       targetPort: {{ if .Values.ingress.use }}8888{{ else }}6666{{ end }}
+      {{- with .Values.services.nodePort }}
+      nodePort: {{ . }}
+      {{- end }}
       name: bits
   selector:
     name: "bits"
 
-  {{- if .Values.services.loadbalanced }}
-  type: "LoadBalancer"
+  {{- if .Values.services.nodePort }}
+  type: "NodePort"
   {{- end }}
 
 # Ingress

--- a/deploy/helm/kubecf/charts/bits/values.yaml
+++ b/deploy/helm/kubecf/charts/bits/values.yaml
@@ -37,7 +37,7 @@ kube:
   external_ips: []
 
 services:
-  loadbalanced: false
+  nodePort: 31666
 
 secrets:
   BITS_SERVICE_SECRET: secret

--- a/deploy/helm/kubecf/charts/eirini-extensions/templates/ssh-proxy.yaml
+++ b/deploy/helm/kubecf/charts/eirini-extensions/templates/ssh-proxy.yaml
@@ -131,18 +131,7 @@ spec:
     protocol: TCP
     port: 2222
     targetPort: 2222
-  {{- with index .Values $component }}
-  {{- if .type }}
-  type: {{ .type | quote }}
-  {{- end}}
-
-  {{- if gt (len .externalIPs) 0 }}
-  externalIPs: {{ .externalIPs | toJson }}
-  {{- end }}
-  {{- if .clusterIP }}
-  clusterIP: {{ .clusterIP | quote }}
-  {{- end }}
-  {{- if .loadBalancerIP }}
-  loadBalancerIP: {{ .loadBalancerIP | quote }}
-  {{- end }}
+  type: ClusterIP
+  {{- if gt (len .Values.externalIPs) 0 }}
+  externalIPs: {{ .Values.externalIPs | toJson }}
   {{- end }}

--- a/deploy/helm/kubecf/charts/eirini-extensions/values.yaml
+++ b/deploy/helm/kubecf/charts/eirini-extensions/values.yaml
@@ -70,7 +70,7 @@ ssh:
   replicaCount: 1
   image:
     repository: splatform
-    tag: v0.0.0-0.g04a3871
+    tag: v0.0.0-0.ge2ed1ab
     pullPolicy: IfNotPresent
   resources: {}
   nodeSelector: {}
@@ -94,7 +94,6 @@ ssh-proxy:
   nodeSelector: {}
   affinity: {}
   tolerations: []
-  externalIPs: []
 
   secrets:
     host-keys: var-diego-ssh-proxy-host-key

--- a/deploy/helm/kubecf/charts/eirini/Chart.yaml
+++ b/deploy/helm/kubecf/charts/eirini/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 0.3.0
 description: A Helm chart for Cloud Foundry/Eirini
 icon: https://raw.githubusercontent.com/cloudfoundry-incubator/eirini-release/develop/assets/images/eirini-icon.png
 name: eirini
-version: 1.0.5
+version: 1.0.6

--- a/deploy/helm/kubecf/charts/eirini/templates/configmap.yaml
+++ b/deploy/helm/kubecf/charts/eirini/templates/configmap.yaml
@@ -18,7 +18,8 @@ data:
       registry_address: "registry.{{ index .Values.kube.external_ips 0 }}.nip.io:6666"
       {{- end }}
       registry_secret_name: {{ .Values.opi.registry_secret_name }}
-      eirini_address: "https://eirini-opi.{{ .Release.Namespace }}.svc.cluster.local:8085"
+      {{- $default_eirini_address := printf "https://eirini-opi.%s.svc:8085" .Release.Namespace }}
+      eirini_address: {{ default $default_eirini_address .Values.opi.eirini_address }}
 
       {{- if .Values.opi.staging.downloader_image }}
       downloader_image: "{{ .Values.opi.staging.downloader_image }}:{{ .Values.opi.staging.downloader_image_tag }}"
@@ -68,17 +69,29 @@ data:
       allow_run_image_as_root: false
   routing.yml: |
     app_namespace: {{ .Values.opi.namespace }}
-    nats_ip: "{{ .Values.opi.routing.nats.serviceName }}.{{ .Release.Namespace }}.svc.cluster.local"
+    {{- $serviceName := .Values.opi.routing.nats.serviceName }}
+    {{- if contains "." $serviceName | not }}
+    {{- $serviceName = printf "%s.%s.svc" $serviceName .Release.Namespace }}
+    {{- end }}
+    nats_ip: {{ $serviceName }}
     nats_port: 4222
   metrics.yml: |
     app_namespace: {{ .Values.opi.namespace }}
-    loggregator_address: "{{ .Values.opi.logs.serviceName }}.{{ .Release.Namespace }}.svc.cluster.local:8082"
+    {{- $serviceName := .Values.opi.logs.serviceName }}
+    {{- if contains "." $serviceName | not }}
+    {{- $serviceName = printf "%s.%s.svc" $serviceName .Release.Namespace }}
+    {{- end }}
+    loggregator_address: "{{ $serviceName }}:8082"
     loggergator_cert_path: "/etc/eirini/secrets/doppler.crt"
     loggregator_key_path: "/etc/eirini/secrets/doppler.key"
     loggregator_ca_path: "/etc/eirini/secrets/doppler.ca"
   events.yml: |
     app_namespace: {{ .Values.opi.namespace }}
-    cc_internal_api: "https://{{ .Values.opi.cc_api.serviceName }}.{{ .Release.Namespace }}.svc.cluster.local:9023"
+    {{- $serviceName := .Values.opi.cc_api.serviceName }}
+    {{- if contains "." $serviceName | not }}
+    {{- $serviceName = printf "%s.%s.svc" $serviceName .Release.Namespace }}
+    {{- end }}
+    cc_internal_api: "https://{{ $serviceName }}:9023"
     cc_cert_path: "/etc/eirini/secrets/cc.crt"
     cc_key_path: "/etc/eirini/secrets/cc.key"
     cc_ca_path: "/etc/eirini/secrets/cc.ca"

--- a/deploy/helm/kubecf/charts/eirini/values.yaml
+++ b/deploy/helm/kubecf/charts/eirini/values.yaml
@@ -12,6 +12,7 @@ opi:
   version: 0.0.0
 
   cc_api:
+    # The service that the CC API listens on; may be a FQDN instead.
     serviceName: "api"
 
   tls:
@@ -44,6 +45,7 @@ opi:
 
   logs:
     enable: true
+    # The service that doppler is listening on; may be a FQDN instead.
     serviceName: "doppler-doppler"
     tls:
       client:
@@ -74,6 +76,7 @@ opi:
     nats:
       secretName: "secrets-2.16.4-2"
       passwordPath: "nats-password"
+      # The service that NATS listens on; may be a FQDN instead.
       serviceName: "nats-nats"
 
   secretSmuggler:

--- a/deploy/helm/kubecf/requirements.lock
+++ b/deploy/helm/kubecf/requirements.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 1.0.6
 - name: bits
   repository: http://opensource.suse.com/bits-service-release/
-  version: 1.0.17
+  version: 1.0.21
 - name: eirini-extensions
-  repository: https://opensource.suse.com/eirinix-helm-release/
+  repository: https://cloudfoundry-incubator.github.io/eirinix-helm-release/
   version: 0.0.0-10+g3df5bb4
-digest: sha256:f9a2486719e7b24e791ef0e03023429d6afa9fe6da9da8b3e211741489924aa1
-generated: "2020-07-20T11:34:23.464810407-07:00"
+digest: sha256:d7a6a0a03266bc94b9ef45fb643463a2c0b63b12e695e2e093c4cb0ffbd6c02e
+generated: "2020-07-23T14:02:31.001980952-07:00"

--- a/deploy/helm/kubecf/requirements.lock
+++ b/deploy/helm/kubecf/requirements.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: eirini
   repository: http://opensource.suse.com/eirini-release/
-  version: 1.0.5
+  version: 1.0.6
 - name: bits
   repository: http://opensource.suse.com/bits-service-release/
   version: 1.0.17
 - name: eirini-extensions
   repository: https://opensource.suse.com/eirinix-helm-release/
   version: 0.0.0-10+g3df5bb4
-digest: sha256:ef3ea5ab17a55bb2cd371ea8e0f6a93bab6a0163be49f368304f6154b3bdab69
-generated: "2020-06-13T08:59:59.521728-07:00"
+digest: sha256:f9a2486719e7b24e791ef0e03023429d6afa9fe6da9da8b3e211741489924aa1
+generated: "2020-07-20T11:34:23.464810407-07:00"

--- a/deploy/helm/kubecf/requirements.yaml
+++ b/deploy/helm/kubecf/requirements.yaml
@@ -4,11 +4,11 @@ dependencies:
   repository: http://opensource.suse.com/eirini-release/
   condition: features.eirini.enabled
 - name: bits
-  version: 1.0.17
+  version: 1.0.21
   repository: http://opensource.suse.com/bits-service-release/
   condition: features.eirini.enabled
 - name: eirini-extensions
   alias: eirinix
-  repository: https://opensource.suse.com/eirinix-helm-release/
+  repository: https://cloudfoundry-incubator.github.io/eirinix-helm-release/
   version: "0.0.0-10+g3df5bb4"
   condition: features.eirini.enabled

--- a/deploy/helm/kubecf/requirements.yaml
+++ b/deploy/helm/kubecf/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
 - name: eirini
-  version: 1.0.5
+  version: 1.0.6
   repository: http://opensource.suse.com/eirini-release/
   condition: features.eirini.enabled
 - name: bits

--- a/deploy/helm/kubecf/templates/eirini.yaml
+++ b/deploy/helm/kubecf/templates/eirini.yaml
@@ -50,20 +50,4 @@ metadata:
   name: var-cc-bridge-cc-uploader
   namespace: {{ .Values.eirini.opi.namespace | quote }}
 
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: eirini-registry
-  namespace: {{ .Release.Namespace | quote }}
-spec:
-  type: NodePort
-  selector:
-    name: "bits"
-  ports:
-    - protocol: TCP
-      port: 6666
-      targetPort: 6666
-      nodePort: {{ .Values.features.eirini.registry.service.nodePort }}
-
 {{- end }}

--- a/deploy/helm/kubecf/values.yaml
+++ b/deploy/helm/kubecf/values.yaml
@@ -551,7 +551,7 @@ bits:
     labels: {}
     annotations: {}
     images:
-      bits_service: registry.suse.com/cap-staging/bits-service:bits-1.0.17-15.1.6.2.251-24.20
+      bits_service: registry.suse.com/cap-staging/bits-service:bits-1.0.20-15.1.6.2.264-24.33
   env:
     # This setting is not configurable and must be HIDDEN from the user.
     DOMAIN: 127.0.0.1.nip.io


### PR DESCRIPTION
## Description
This drops hard-coded instances where we assumed the Kubernetes cluster domain to be `cluster.local`; doing this is required as this isn't guaranteed on all Kubernetes deployments.

## Motivation and Context
Fixes #872 

## How Has This Been Tested?
Deployed locally (using Eirini), with a custom minikube:
- `MINIKUBE_EXTRA_OPTIONS` includes `--dns-domain=minikube --extra-config=kubelet.cluster-domain=minikube`
- Quarks-operator helm config includes `cluster.domain=minikube`
- Double checked that `/etc/resolv.conf` in the CC container doesn't include `cluster.local`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Other Notes:
⚠️ Need to see how #1119 interferes with this PR.
