### PR TITLE
Refactor rotate-ccdb-keys-test.sh to remove Bazel dependency

### DIFF
--- a/testing/ccdb_key_rotation/rotate-ccdb-keys-test.sh
+++ b/testing/ccdb_key_rotation/rotate-ccdb-keys-test.sh
@@ -4,7 +4,6 @@ set -o errexit -o nounset #-o xtrace
 
 export KUBECF_NAMESPACE="${KUBECF_NAMESPACE:-kubecf}"
 export KUBECF_INSTALL_NAME="${KUBECF_INSTALL_NAME:-kubecf}"
-KUBECF_CHART_TARGET="${KUBECF_CHART_TARGET:-//deploy/helm/kubecf}"
 VALUES_FILE="${PWD}/ccdb-new-key-label.yaml"
 
 # - -- --- ----- -------- ------------- ---------------------
@@ -29,23 +28,6 @@ echo    "KubeCF deployment                ... $(blue "${KUBECF_INSTALL_NAME}")"
 echo
 
 # - -- --- ----- -------- ------------- ---------------------
-
-# Given a bazel target, output the file name it generates ending with
-# the given extension.
-get_output_file() {
-    local package="${1}"
-    local extension="${2}"
-    awk "
-    BEGIN { wanted_action = false }
-    wanted_action && match(\$0, /^  Outputs: \\[(.*)\\]/, output) {
-      print output[1];
-    }
-    /^[^ ]/ { wanted_action = 0 }
-    /^action.*\\.${extension}'\$/ {
-      wanted_action = 1
-    }
-  " <(bazel aquery "${package}:all" 2>/dev/null)
-}
 
 rotate_job_name() {
     kubectl get jobs --namespace "${KUBECF_NAMESPACE}" --output name 2> /dev/null | \
@@ -194,8 +176,8 @@ ccdb:
 EOF
 
 # Get the deployed chart (tarball)
-bazel build "${KUBECF_CHART_TARGET}"
-chart_file="${PWD}/$(get_output_file "${KUBECF_CHART_TARGET%:*}" "tgz")"
+make kubecf-build
+chart_file="$(ls -1 -t output/kubecf-*.tgz | head -1)"
 
 echo
 echo "Chart file ... $(blue "${chart_file}")"

--- a/testing/ccdb_key_rotation/rotate-ccdb-keys-test.sh
+++ b/testing/ccdb_key_rotation/rotate-ccdb-keys-test.sh
@@ -177,7 +177,8 @@ EOF
 
 # Get the deployed chart (tarball)
 make kubecf-build
-chart_file="$(ls -1 -t output/kubecf-*.tgz | head -1)"
+chart_file="$(find output -name 'kubecf-*.tgz' -type f -printf "%T+ %p\n" \
+                   | sort | tail -1 | tr -s ' ' | cut -d ' ' -f 2)"
 
 echo
 echo "Chart file ... $(blue "${chart_file}")"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Refactor rotate-ccdb-keys-test.sh to remove Bazel dependency.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Needed by https://github.com/cloudfoundry-incubator/kubecf/issues/1010

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- An important detail to include is the version of the used cf-operator -->

Tested successfully, the change on the rotate job in the following pipeline succeeds:
https://concourse.suse.dev/teams/main/pipelines/kubecf-rmbazel/jobs/ccdb-rotate-diego-viccuad-rm-bazel-rotate

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
