### PR TITLE
Use new versioning script from kubecf-tools

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "src/cf-deployment"]
 	path = src/cf-deployment
 	url = https://github.com/cloudfoundry/cf-deployment
+[submodule "src/kubecf-tools"]
+	path = src/kubecf-tools
+	url = https://github.com/cloudfoundry-incubator/kubecf-tools

--- a/scripts/include/versions.sh
+++ b/scripts/include/versions.sh
@@ -1,8 +1,5 @@
 # shellcheck shell=bash
 
-# Version is 0.0.0 on master, and x.y.z on release-x.y branches
-: "${KUBECF_VERSION:=0.0.0}"
-
 # Used by both kind-start and minikube-start
 : "${K8S_VERSION:=1.17.5}"
 

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 source scripts/include/setup.sh
 
-require_tools ruby
+require_tools git ruby
 
 ruby src/kubecf-tools/versioning/versioning.rb

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 source scripts/include/setup.sh
 
-require_tools git
+require_tools ruby
 
-echo "${KUBECF_VERSION}-$(git rev-parse --short HEAD)"
+ruby src/kubecf-tools/versioning/versioning.rb


### PR DESCRIPTION
Adds kubecf-tools repo as a submodule per discussion with @viovanov 

The new versioning script was developed via #1013

Fixes #766

Example output:

```
$ make version
0.2.0-1455.gfa0a32f0-dirty
```

Requesting review from @viccuad to make sure it is compatible with catapult and CI.