### PR TITLE
Bump github-pr-resource image to pull down tags

### DIFF
--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -24,11 +24,13 @@ resource_types:
 # Use manually built and pushed image until upstream provides a solution:
 # https://github.com/cloudfoundry-incubator/kubecf/issues/903
 # https://github.com/SUSE/github-pr-resource/commit/3ee0816d801a7038d6125796725aa3718c688b53
+# Also fetch tags for our new versioning system
+# https://github.com/SUSE/github-pr-resource/commit/e92ede5dc3dfb34d715b5d6b38152952399512fb
 - name: pull-request
   type: docker-image
   source:
     repository: splatform/github-pr-resource
-    tag: 3ee0816
+    tag: e92ede5
 
 {{- if $config.github_status }}
 - name: github-status


### PR DESCRIPTION
This is required for the new kubecf-tools/versioning code to work.