### PR TITLE
fix: scripts: Deal with re-running tests better

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -5,26 +5,21 @@ require_tools kubectl
 
 : "${TEST:=smoke}"
 
-# Trigger the test.
-kubectl patch qjob "${TEST}-tests" \
-  --namespace "${KUBECF_NS}" \
-  --type merge \
-  --patch '{ "spec": { "trigger": { "strategy": "now" } } }'
-
 pod_name() {
   kubectl get pods \
     --namespace "${KUBECF_NS}" \
     --selector "quarks.cloudfoundry.org/qjob-name=${TEST}-tests" \
     --output name \
     | sed 's|^pod\/||' \
-    | grep "${TEST}-tests"
+    | grep "${TEST}-tests" \
+    | sort
 }
 
 container_name() {
-  kubectl get pods \
+  local pod_name="${1}"
+  kubectl get "pods/${pod_name}" \
     --namespace "${KUBECF_NS}" \
-    --selector "quarks.cloudfoundry.org/qjob-name=${TEST}-tests" \
-    --output jsonpath='{ .items[].spec.containers[0].name }'
+    --output jsonpath='{ .spec.containers[0].name }'
 }
 
 is_container_running() {
@@ -41,13 +36,18 @@ is_container_running() {
 # Wait for test pod to start.
 wait_for_test_running() {
   local timeout="300"
-  until pod_name 1> /dev/null || [[ "$timeout" == "0" ]]; do
+  local new_pod_names pod_name
+  while [[ "${timeout}" -gt 0 ]] ; do
+    new_pod_names="$(pod_name)"
+    pod_name="$(comm -13 <(echo "${existing_pods}") <(echo "${new_pod_names}"))"
+    if [[ -n "${pod_name}" ]] ; then
+      break
+    fi
     sleep 1
     timeout=$((timeout - 1))
   done
   if [[ "${timeout}" == 0 ]]; then return 1; fi
-  pod_name="$(pod_name)"
-  container_name="$(container_name)"
+  container_name="$(container_name "${pod_name}")"
   until is_container_running "${pod_name}" "${container_name}" || [[ "$timeout" == "0" ]]; do
     sleep 1
     timeout=$((timeout - 1))
@@ -56,6 +56,14 @@ wait_for_test_running() {
   return 0
 }
 
+# Trigger the test.
+kubectl patch qjob "${TEST}-tests" \
+  --namespace "${KUBECF_NS}" \
+  --type merge \
+  --patch '{ "spec": { "trigger": { "strategy": "now" } } }'
+
+existing_pods="$(pod_name || echo)"
+
 echo "Waiting for the ${TEST}-tests pod to start..."
 wait_for_test_running || {
   >&2 echo "Timed out waiting for the ${TEST}-tests pod"
@@ -63,8 +71,9 @@ wait_for_test_running || {
 }
 
 # Tail the test logs.
-pod_name="$(pod_name)"
-container_name="$(container_name)"
+new_pods="$(pod_name)"
+pod_name="$(comm -13 <(echo "${existing_pods}") <(echo "${new_pods}"))"
+container_name="$(container_name "${pod_name}")"
 kubectl logs "${pod_name}" \
   --follow \
   --namespace "${KUBECF_NS}" \

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -37,10 +37,10 @@ is_container_running() {
 wait_for_test_running() {
   local timeout="300"
   local new_pod_names pod_name
-  while [[ "${timeout}" -gt 0 ]] ; do
+  while [[ "${timeout}" -gt 0 ]]; do
     new_pod_names="$(pod_name)"
     pod_name="$(comm -13 <(echo "${existing_pods}") <(echo "${new_pod_names}"))"
-    if [[ -n "${pod_name}" ]] ; then
+    if [[ -n "${pod_name}" ]]; then
       break
     fi
     sleep 1


### PR DESCRIPTION
## Description
No longer assume that there is only one pod for running the test; instead, take a snapshot of the pods before patching the qjob, and find the new one instead.  This is necessary to re-run a (succeeded) test, as the pods are not deleted automatically after a test passes.

## Motivation and Context
I tried to run `make smoke` a few times in a row (to test updating across different configs), only the first run works correctly.  For the other runs, it tries to find a pod where the name contains `\n` (because it's actually multiple pods).

## How Has This Been Tested?
Ran `make smoke` a few times.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
