### PR TITLE
Fix docs commit to be in line with kubecf-docs

### DIFF
--- a/doc/dev/general.md
+++ b/doc/dev/general.md
@@ -139,9 +139,9 @@ helm install stable/nginx-ingress \
   --name ingress \
   --namespace ingress \
   --set "tcp.2222=kubecf/ssh-proxy-public:2222" \
-  --set "tcp.<services.tcp-router.port_range.start>=kubecf/kubecf-tcp-router:<services.tcp-router.port_range.start>" \
+  --set "tcp.<services.tcp-router.port_range.start>=kubecf/tcp-router:<services.tcp-router.port_range.start>" \
   ...
-  --set "tcp.<services.tcp-router.port_range.end>=kubecf/kubecf-tcp-router:<services.tcp-router.port_range.end>"
+  --set "tcp.<services.tcp-router.port_range.end>=kubecf/tcp-router:<services.tcp-router.port_range.end>"
 ```
 
 The `tcp.<port>` option uses the NGINX TCP pass-through (docs: https://kubernetes.github.io/ingress-nginx/user-guide/exposing-tcp-udp-services/).


### PR DESCRIPTION
## Description
Like mentioned in https://github.com/cloudfoundry-incubator/kubecf/pull/1097
it was missing the correct service names as with https://github.com/cloudfoundry-incubator/kubecf-docs/commit/8d8c10d12a0c7c120846e038030cce0b21bb5526

## Motivation and Context
Fix https://github.com/cloudfoundry-incubator/kubecf/commit/ee6b8bd6d648106cd2296c68bdffd6f1e58d72bc according to https://github.com/cloudfoundry-incubator/kubecf-docs/commit/8d8c10d12a0c7c120846e038030cce0b21bb5526

## How Has This Been Tested?
Deployed kubecf with nginx-ingress

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
