### PR TITLE
Read cf-operator URL and SHA256 from dependencies.yaml

### DIFF
--- a/scripts/cf-operator-apply.sh
+++ b/scripts/cf-operator-apply.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 source scripts/include/setup.sh
 
-require_tools kubectl helm
+require_tools cf_operator_url kubectl helm
 
 if ! kubectl get ns "${CF_OPERATOR_NS}" &> /dev/null; then
     kubectl create ns "${CF_OPERATOR_NS}" > /dev/null
 fi
 
 helm install cf-operator \
-     "${CF_OPERATOR_URL//\{version\}/${CF_OPERATOR_VERSION}}" \
+     "$(cf_operator_url)" \
      --namespace "${CF_OPERATOR_NS}" \
      --set "global.singleNamespace.name=${KUBECF_NS}"

--- a/scripts/include/versions.sh
+++ b/scripts/include/versions.sh
@@ -2,9 +2,3 @@
 
 # Used by both kind-start and minikube-start
 : "${K8S_VERSION:=1.17.5}"
-
-# The cf-operator url and sha256 are currently being read from `dependencies.yaml` via the
-# functions in ../tools/cf_operator_url.sh
-# "${CF_OPERATOR_URL:=https://s3.amazonaws.com/cf-operators/release/helm-charts/cf-operator-{version\}.tgz}"
-# "${CF_OPERATOR_SHA256:=df225af203596ca6dc11131004704632c01579bbaf80f8439b42aa8a5e24a47a}"
-# "${CF_OPERATOR_VERSION:=5.0.0%2B0.gd7ac12bc}"

--- a/scripts/include/versions.sh
+++ b/scripts/include/versions.sh
@@ -3,6 +3,8 @@
 # Used by both kind-start and minikube-start
 : "${K8S_VERSION:=1.17.5}"
 
-: "${CF_OPERATOR_URL:=https://s3.amazonaws.com/cf-operators/release/helm-charts/cf-operator-{version\}.tgz}"
-: "${CF_OPERATOR_SHA256:=df225af203596ca6dc11131004704632c01579bbaf80f8439b42aa8a5e24a47a}"
-: "${CF_OPERATOR_VERSION:=5.0.0%2B0.gd7ac12bc}"
+# The cf-operator url and sha256 are currently being read from `dependencies.yaml` via the
+# functions in ../tools/cf_operator_url.sh
+# "${CF_OPERATOR_URL:=https://s3.amazonaws.com/cf-operators/release/helm-charts/cf-operator-{version\}.tgz}"
+# "${CF_OPERATOR_SHA256:=df225af203596ca6dc11131004704632c01579bbaf80f8439b42aa8a5e24a47a}"
+# "${CF_OPERATOR_VERSION:=5.0.0%2B0.gd7ac12bc}"

--- a/scripts/kubecf-build.sh
+++ b/scripts/kubecf-build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 source scripts/include/setup.sh
 
-require_tools bosh git helm jq j2y ruby y2j
+require_tools bosh cf_operator_url git helm jq j2y ruby y2j
 
 if [[ ! "$(git submodule status -- src/cf-deployment)" =~ ^[[:space:]] ]]; then
     die "git submodule for cf-deployment is uninitialized or not up-to-date"
@@ -58,7 +58,7 @@ EOT
     sed 's/^/    /' < "${PRE_RENDER_SCRIPT}" >> "${OUTPUT}"
 done
 
-echo "operatorChartUrl: \"${CF_OPERATOR_URL//\{version\}/${CF_OPERATOR_VERSION}}\"" > "${HELM_DIR}/Metadata.yaml"
+echo "operatorChartUrl: \"$(cf_operator_url)\"" > "${HELM_DIR}/Metadata.yaml"
 
 ruby rules/kubecf/create_sample_values.rb "${HELM_DIR}/values.yaml" "${HELM_DIR}/sample-values.yaml"
 MODE=check ruby rules/kubecf/create_sample_values.rb "${HELM_DIR}/values.yaml" "${HELM_DIR}/sample-values.yaml"

--- a/scripts/kubecf-bundle.sh
+++ b/scripts/kubecf-bundle.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 source scripts/include/setup.sh
 
-require_tools curl sha256sum
+require_tools cf_operator_url cf_operator_sha256 curl sha256sum
 
 # Set default target file
 if [ -z "${TARGET_FILE:-}" ]; then
@@ -16,11 +16,12 @@ mkdir "${BUNDLE_DIR}"
 
 # Download cf-operator chart
 CF_OPERATOR_FILE="${BUNDLE_DIR}/cf-operator.tgz"
-DOWNLOAD_URL="${CF_OPERATOR_URL//\{version\}/${CF_OPERATOR_VERSION}}"
-curl -s -L "${DOWNLOAD_URL}" -o "${CF_OPERATOR_FILE}"
+CF_OPERATOR_URL="$(cf_operator_url)"
+curl -s -L "${CF_OPERATOR_URL}" -o "${CF_OPERATOR_FILE}"
 
+CF_OPERATOR_SHA256="$(cf_operator_sha256)"
 if ! echo "${CF_OPERATOR_SHA256} ${CF_OPERATOR_FILE}" | sha256sum --check --status; then
-    die "sha256 for ${DOWNLOAD_URL} does not match ${CF_OPERATOR_SHA256}"
+    die "sha256 for ${CF_OPERATOR_URL} does not match ${CF_OPERATOR_SHA256}"
 fi
 
 # Build kubecf chart

--- a/scripts/tools/cf_operator_url.sh
+++ b/scripts/tools/cf_operator_url.sh
@@ -1,0 +1,18 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034
+
+TOOLS+=(cf_operator_url cf_operator_sha256)
+
+function cf_operator_url {
+    local url version
+    url=$(y2j < dependencies.yaml | jq -r .external_files.cf_operator.url)
+    version=$(y2j < dependencies.yaml | jq -r .external_files.cf_operator.version)
+    echo "${url//\{version\}/${version}}"
+}
+
+function cf_operator_sha256 {
+    y2j < dependencies.yaml | jq -r .external_files.cf_operator.sha256
+}
+
+CF_OPERATOR_URL_REQUIRES="jq y2j"
+CF_OPERATOR_SHA256_REQUIRES="jq y2j"


### PR DESCRIPTION
That is the only location updated by CI when we bump the cf-operator version, so this commit makes sure we don't get out-of-sync between bash and bazel build rules.
