### PR TITLE
enable silk in diego

### DIFF
--- a/bosh/releases/pre_render_scripts/diego-cell/garden-cni/jobs/patch_pre-start.sh
+++ b/bosh/releases/pre_render_scripts/diego-cell/garden-cni/jobs/patch_pre-start.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset
+
+target="/var/vcap/all-releases/jobs-src/cf-networking/garden-cni/templates/pre-start.erb"
+sentinel="${target}.patch_sentinel"
+if [[ -f "${sentinel}" ]]; then
+  if sha256sum --check "${sentinel}" ; then
+    echo "Patch already applied. Skipping"
+    exit 0
+  fi
+  echo "Sentinel mismatch, re-patching"
+fi
+
+# Place the garden-external-networker into a location shared by all the jobs.
+patch --verbose "${target}" <<'EOT'
+@@ -1,3 +1,8 @@
+ #!/bin/bash -eu
+
+ rm -rf /var/vcap/data/garden-cni || true
++
++DEST=/var/vcap/data/runc-cni/bin/
++
++mkdir -p "${DEST}"
++cp /var/vcap/packages/runc-cni/bin/garden-external-networker "${DEST}/garden-external-networker"
+EOT
+
+sha256sum "${target}" > "${sentinel}"

--- a/bosh/releases/pre_render_scripts/diego-cell/silk-cni/jobs/patch_pre-start.sh
+++ b/bosh/releases/pre_render_scripts/diego-cell/silk-cni/jobs/patch_pre-start.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset
+
+target="/var/vcap/all-releases/jobs-src/silk/silk-cni/templates/pre-start.erb"
+sentinel="${target}.patch_sentinel"
+if [[ -f "${sentinel}" ]]; then
+  if sha256sum --check "${sentinel}" ; then
+    echo "Patch already applied. Skipping"
+    exit 0
+  fi
+  echo "Sentinel mismatch, re-patching"
+fi
+
+# Place the silk-cni related things into a location shared by all the jobs.
+patch --verbose "${target}" <<'EOT'
+@@ -4,3 +4,8 @@
+ /var/vcap/packages/silk-cni/bin/cni-teardown \
+   --config /var/vcap/jobs/silk-cni/config/teardown-config.json
+ <% end %>
++
++DEST=/var/vcap/data/silk-cni/bin
++
++mkdir -p "${DEST}"
++cp /var/vcap/packages/silk-cni/bin/* "${DEST}/"
+EOT
+
+sha256sum "${target}" > "${sentinel}"

--- a/deploy/helm/kubecf/assets/operations/instance_groups/diego-api.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/diego-api.yaml
@@ -1,7 +1,3 @@
-# Selectively remove jobs temporarily.
-- type: remove
-  path: /instance_groups/name=diego-api/jobs/name=silk-controller
-
 # Override the addresses for the jobs under the diego-api instance group.
 - type: replace
   path: /instance_groups/name=diego-api/jobs/name=bbs/properties/diego/bbs/locket?/api_location

--- a/deploy/helm/kubecf/assets/operations/instance_groups/diego-cell.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/diego-cell.yaml
@@ -24,18 +24,9 @@
 
 {{- end }}
 
-
-# Selectively remove jobs temporarily.
-- type: remove
-  path: /instance_groups/name=diego-cell/jobs/name=garden-cni
-- type: remove
-  path: /instance_groups/name=diego-cell/jobs/name=netmon
-- type: remove
-  path: /instance_groups/name=diego-cell/jobs/name=vxlan-policy-agent
-- type: remove
-  path: /instance_groups/name=diego-cell/jobs/name=silk-daemon
-- type: remove
-  path: /instance_groups/name=diego-cell/jobs/name=silk-cni
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=vxlan-policy-agent/properties/disable?
+  value: true
 
 # Enable BPM on garden.
 - type: replace
@@ -95,11 +86,16 @@
       job_name: "sle15-rootfs-setup"
       process_name: "sle15-rootfs-setup"
 
-# Temporarily remove garden network_plugin.
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=garden/properties/garden/network_plugin?
+  value: /var/vcap/data/runc-cni/bin/garden-external-networker
+
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=garden-cni/properties/cni_plugin_dir?
+  value: /var/vcap/data/silk-cni/bin
+
 - type: remove
-  path: /instance_groups/name=diego-cell/jobs/name=garden/properties/garden/network_plugin
-- type: remove
-  path: /instance_groups/name=diego-cell/jobs/name=garden/properties/garden/network_plugin_extra_args
+  path: /instance_groups/name=diego-cell/jobs/name=silk-cni/properties/dns_servers?
 
 # Add quarks properties for garden.
 - type: replace
@@ -194,6 +190,14 @@
 
 - type: replace
   path: /instance_groups/name=diego-cell/jobs/name=cfdot/properties/quarks?/bpm/processes
+  value: []
+
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=garden-cni/properties/quarks?/bpm/processes
+  value: []
+
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=silk-cni/properties/quarks?/bpm/processes
   value: []
 
 - type: replace


### PR DESCRIPTION
enable silk in diego

## Description
Diego in KubeCF is still using a Garden network implementation which is not maintained actively by the community, the default container network in Diego is silk. This change is to enable silk in KubeCF.


## Motivation and Context
Silk is the default container network implementation in Diego, and it's more reliable than Garden network implementation, and is maintained actively by the community.

## How Has This Been Tested?
Smoke testsuite passed 

```
 Running smoke tests...                                                                                                                                                                                                                     │
│ Running binaries smoke/isolation_segments/isolation_segments.test                                                                                                                                                                          │
│ smoke/logging/logging.test                                                                                                                                                                                                                 │
│ smoke/runtime/runtime.test                                                                                                                                                                                                                 │
│ [1596440111] CF-Isolation-Segment-Smoke-Tests - 4 specs - 2 nodes SSSS SUCCESS! 14.8570485s                                                                                                                                                │
│ [1596440111] CF-Logging-Smoke-Tests - 2 specs - 2 nodes S• SUCCESS! 37.984419451s                                                                                                                                                          │
│ [1596440111] CF-Runtime-Smoke-Tests - 2 specs - 2 nodes S• SUCCESS! 48.516057906s                                                                                                                                                          │
│ Ginkgo ran 3 suites in 1m41.593427896s                                                                                                                                                                                                     │
│ Test Suite Passed                                                                                                                                                                                                                          
```

The app container NIC in diego-cell is below, the `s-` (it was `wbrdg-` before this change) means this was created by silk.

```
17: s-010255114007@if16: <BROADCAST,MULTICAST,NOARP,UP,LOWER_UP> mtu 1390 qdisc noqueue state UP group default
    link/ether aa:aa:0a:ff:72:07 brd ff:ff:ff:ff:ff:ff link-netnsid 2
    inet 169.254.0.1 peer 10.255.114.7/32 scope link s-010255114007
       valid_lft forever preferred_lft forever
```

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
