### PR TITLE
Use containerd as default container manager in diego-cell

### DIFF
--- a/deploy/helm/kubecf/assets/operations/instance_groups/diego-cell.yaml
+++ b/deploy/helm/kubecf/assets/operations/instance_groups/diego-cell.yaml
@@ -213,10 +213,6 @@
   value: ""
 
 - type: replace
-  path: /instance_groups/name=diego-cell/jobs/name=garden/properties/garden/containerd_mode
-  value: false
-
-- type: replace
   path: /instance_groups/name=diego-cell/jobs/name=garden/properties/garden/cleanup_process_dirs_on_wait
   value: false
 


### PR DESCRIPTION
Use containerd as default container manager in diego-cell

## Description
KubeCF Diego is using RunC as the default contaienr manager, but Containerd is the default container manager in cf-deployment: https://github.com/cloudfoundry/cf-deployment/blob/master/cf-deployment.yml#L1544,  this change is to set containerd as default container manager in diego-cell.

## Motivation and Context
Containerd is the default container manager in cf-deployment, that means containerd is used widely and was tested well, so KubeCF should use containerd as the default container manager.

## How Has This Been Tested?

Smoke Testsuites passed.

The Diego Cell is using containerd as below:

```
/:/var/vcap/jobs/garden# /var/vcap/packages/containerd/bin/ctr -a /var/vcap/sys/run/containerd/containerd.sock -n garden tasks ls
TASK                            PID     STATUS
776f4e95-7cdc-4b9a-6ca0-490c    1479    RUNNING
535d6e7c-7cd8-4082-40e6-6433    1471    RUNNING
0a0520bd-8947-4ca7-7763-43bc    1489    RUNNING
```

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
