### PR TITLE
fix: scripts/include/tools.sh: cache tool states.

### DIFF
--- a/scripts/include/tools.sh
+++ b/scripts/include/tools.sh
@@ -32,6 +32,11 @@ done
 # shellcheck disable=SC2207
 TOOLS=($(printf '%s\n' "${TOOLS[@]}" | sort | uniq))
 
+# Have a cache of tool status, so that require_tools will not repeatedly try to
+# determine if the same tool has been installed.  This also lets us catch when
+# a tool (possibly through others) end up requiring itself.
+declare -A TOOL_STATUS
+
 # require_tools makes sure all required tools are available. If the current version
 # is too old (or doesn't match the required version exactly when PINNED_TOOLS is set),
 # then the tool is downloaded and installed into $TOOLS_DIR.
@@ -40,19 +45,32 @@ function require_tools {
     local tool
 
     for tool in "$@"; do
-        # Make sure additional prerequisites for the tool are also available.
-        # They must be installed first because they might be needed to install the tool itself.
-        # In this case we *want* word-splitting.
-        # shellcheck disable=SC2046
-        require_tools $(var_lookup "${tool}_requires")
-        if ! status=$(tool_status "${tool}"); then
-            tool_install "${tool}"
+        case "${TOOL_STATUS["${tool}"]:-}" in
+            "")
+                TOOL_STATUS["${tool}"]="installing"
+                # Make sure additional prerequisites for the tool are also
+                # available.  They must be installed first because they might be
+                # needed to install the tool itself.  In this case we *want*
+                # word-splitting.
+                # shellcheck disable=SC2046
+                require_tools $(var_lookup "${tool}_requires")
+                if ! status=$(tool_status "${tool}"); then
+                    tool_install "${tool}"
 
-            if ! status="$(tool_status "${tool}")"; then
-                red "Could not install ${tool}"
-                die "${status}"
-            fi
-        fi
+                    if ! status="$(tool_status "${tool}")"; then
+                        red "Could not install ${tool}"
+                        die "${status}"
+                    fi
+                fi
+                TOOL_STATUS["${tool}"]="installed"
+                ;;
+            installed)
+                # Do nothing
+                ;;
+            installing)
+                die "Recursion when installing ${tool}"
+                ;;
+        esac
     done
 }
 


### PR DESCRIPTION
## Description
Have a cache of tool status, so that require_tools will not repeatedly try to determine if the same tool has been installed.  This also lets us catch when a tool (possibly through others) end up requiring itself.

## Motivation and Context
It is slow when building things.

## How Has This Been Tested?
Before the change:
```
$ { for i in $( seq 1 3 ) ; do time make kubecf-build  ; done ; } 2>&1 | grep real
real    0m29.602s
real    0m29.171s
real    0m29.155s
```

After the change:
```
$ { for i in $( seq 1 3 ) ; do time make kubecf-build  ; done ; } 2>&1 | grep real
real    0m23.592s
real    0m23.637s
real    0m23.230s
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
