### PR TITLE
feat: cf-operator-apply: accept extra values

### DIFF
--- a/scripts/cf-operator-apply.sh
+++ b/scripts/cf-operator-apply.sh
@@ -10,4 +10,5 @@ fi
 helm install cf-operator \
      "$(cf_operator_url)" \
      --namespace "${CF_OPERATOR_NS}" \
-     --set "global.singleNamespace.name=${KUBECF_NS}"
+     --set "global.singleNamespace.name=${KUBECF_NS}" \
+     ${VALUES:+--values "${VALUES}"}


### PR DESCRIPTION
## Description
This adds an override to `cf-operator-apply.sh` to be able to pass in custom helm values.

I'm happy to entertain bike shedding of the variable name.

## Motivation and Context
This is useful when trying to deploy custom overrides to the operator (e.g. to use a custom docker image).  This is not used by default.

## How Has This Been Tested?
Deployed locally with a custom operator helm values file (so that I could develop the operator locally and test it against kubecf).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
