### PR TITLE
Add default podAntiAffinity rules and sizing.*.affinity overrides

### DIFF
--- a/deploy/helm/kubecf/assets/operations/sizing.yaml
+++ b/deploy/helm/kubecf/assets/operations/sizing.yaml
@@ -38,13 +38,63 @@
 {{- end }}{{/* if eirini */}}
 
 {{- range $instance_group := $instance_groups }}
-{{- if index (snakecase $instance_group | index $.Values.sizing) "instances" | kindIs "invalid" | not }}
+  {{- if index (snakecase $instance_group | index $.Values.sizing) "instances" | kindIs "invalid" | not }}
 - type: replace
   path: /instance_groups/name={{ $instance_group }}/instances
   value: {{ index (snakecase $instance_group | index $.Values.sizing) "instances" }}
-{{- else if not $.Values.high_availability }}
+  {{- else if not $.Values.high_availability }}
 - type: replace
   path: /instance_groups/name={{ $instance_group }}/instances
   value: 1
-{{- end }}{{/* if */}}
+  {{- end }}{{/* if */}}
+
+  {{- $affinity := index (snakecase $instance_group | index $.Values.sizing) "affinity" }}
+  {{- if $affinity }}
+- type: replace
+  path: /instance_groups/name={{ $instance_group }}/env?/bosh/agent/settings/affinity
+  value: {{ toJson $affinity }}
+  {{- else }}
+- type: replace
+  path: /instance_groups/name={{ $instance_group }}/env?/bosh/agent/settings/affinity
+  value:
+    {{- /* Each instance group has anti-affinity to itself */}}
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+            - key: quarks.cloudfoundry.org/quarks-statefulset-name
+              operator: In
+              values:
+              - {{ $instance_group }}
+          topologyKey: kubernetes.io/hostname
+
+    {{- /* diego-cell has also anti-affinity to router */}}
+    {{- if eq $instance_group "diego-cell" }}
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+            - key: quarks.cloudfoundry.org/quarks-statefulset-name
+              operator: In
+              values:
+              - router
+          topologyKey: kubernetes.io/hostname
+    {{- end }}
+
+    {{- /* router has also anti-affinity to diego-cell */}}
+    {{- if eq $instance_group "router" }}
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+            - key: quarks.cloudfoundry.org/quarks-statefulset-name
+              operator: In
+              values:
+              - diego-cell
+          topologyKey: kubernetes.io/hostname
+    {{- end }}
+  {{- end }}
+
 {{- end }}{{/* range $instance_group */}}

--- a/deploy/helm/kubecf/templates/database.yaml
+++ b/deploy/helm/kubecf/templates/database.yaml
@@ -220,6 +220,22 @@ spec:
             app.kubernetes.io/version: {{ default .Chart.Version .Chart.AppVersion | quote }}
             helm.sh/chart: {{ include "kubecf.chart" . }}
         spec:
+          {{- if $.Values.sizing.database.affinity }}
+          affinity: {{ $.Values.sizing.database.affinity | toJson }}
+          {{- else }}
+          affinity:
+            podAntiAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 100
+                podAffinityTerm:
+                  labelSelector:
+                    matchExpressions:
+                    - key: quarks.cloudfoundry.org/quarks-statefulset-name
+                      operator: In
+                      values:
+                      - database
+                  topologyKey: kubernetes.io/hostname
+          {{- end }}
           initContainers:
           - name: remove-lost-found
             {{- with $image := .Values.releases.pxc.image }}

--- a/deploy/helm/kubecf/values.yaml
+++ b/deploy/helm/kubecf/values.yaml
@@ -143,8 +143,32 @@ releases:
 multi_az: false
 high_availability: false
 
-# Sizing takes precedence over the high_availability property. I.e. setting the instance count
-# for an instance group greater than 1 will make it highly available.
+# Instance sizing takes precedence over the high_availability property. I.e. setting the
+# instance count for an instance group greater than 1 will make it highly available.
+#
+# It is also possible to specify custom affinity rules for each instance group. If no rule
+# is provided, then each group as anti-affinity to itself, to try to spread the pods between
+# different nodes. In addition diego-cell and router also have anti-affinity to each other.
+#
+# The default rules look like this:
+#
+# sizing:
+#   sample_group:
+#     affinity:
+#       podAntiAffinity:
+#         preferredDuringSchedulingIgnoredDuringExecution:
+#         - weight: 100
+#           podAffinityTerm:
+#             labelSelector:
+#               matchExpressions:
+#               - key: quarks.cloudfoundry.org/quarks-statefulset-name
+#                 operator: In
+#                 values:
+#                 - sample_group
+#             topologyKey: kubernetes.io/hostname
+#
+# Any affinity rules specified here will *overwrite* the default rule and not merge with it.
+
 sizing:
   adapter:
     instances: ~


### PR DESCRIPTION
Default rules are added to all instance groups, including pxc/database,
but not to bits/eirini/eirini-extension subcharts.

All instance groups have anti-affinity against themselves, and diego-cell
and router additionally against each other.

Based on #1215 
