### PR TITLE
fix: scripts/tools: skip empty tools on require

### DIFF
--- a/scripts/include/tools.sh
+++ b/scripts/include/tools.sh
@@ -45,6 +45,9 @@ function require_tools {
     local tool
 
     for tool in "$@"; do
+        if [[ -z "${tool}" ]]; then
+            continue
+        fi
         case "${TOOL_STATUS["${tool}"]:-}" in
             "")
                 TOOL_STATUS["${tool}"]="installing"


### PR DESCRIPTION
## Description
If a tool has no requirements, we can end up in a situation where we try to expand something approximating `${TOOL_STATUS[""]}` because we had a loop for `for tool in ""`; bash throws a fit at this nonsense.  Sanity check for that case, so we don't fall over.

## Motivation and Context
I had local tools that triggered the error condition.

## How Has This Been Tested?
Ran the relevant local tools.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
