### PR TITLE
feat: add validation label so it can be easily identified before moved to a project

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: 'bug'
+labels: 'bug', 'Status: Validation'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: 'enhancement'
+labels: 'enhancement','Status: Validation'
 assignees: 'fargozhu'
 
 ---


### PR DESCRIPTION
## Description

To support the early identification through filters when a new issue is opened and to avoid orphans issues for too long.

## Motivation and Context

I need to be constantly searching for "no:project" issues and this can't be applied to Github filters.

## How Has This Been Tested?

Will check by opening a new issue .