### PR TITLE
fix: kubecf#1181. Have rep set kernel parameters

### DIFF
--- a/bosh/releases/pre_render_scripts/diego-cell/rep/jobs/patch_set_kernel.sh
+++ b/bosh/releases/pre_render_scripts/diego-cell/rep/jobs/patch_set_kernel.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset
+
+target="/var/vcap/all-releases/jobs-src/diego/rep/templates/set-rep-kernel-params.erb"
+sentinel="${target}.patch_sentinel"
+if [[ -f "${sentinel}" ]]; then
+  if sha256sum --check "${sentinel}" ; then
+    echo "Patch already applied. Skipping"
+    exit 0
+  fi
+  echo "Sentinel mismatch, re-patching"
+fi
+
+# Disable ubuntu-specific uncontainerized connection limit.
+patch --verbose "${target}" <<'EOT'
+@@ -18,8 +18,8 @@
+ 
+ # NF_CONNTRACK_MAX
+ # Default value is 65536. We set it to a larger number to avoid running out of connections.
+-modprobe nf_conntrack
+-echo 262144 > /proc/sys/net/netfilter/nf_conntrack_max
++#modprobe nf_conntrack
++#echo 262144 > /proc/sys/net/netfilter/nf_conntrack_max
+ 
+ echo 2147483647 > /proc/sys/fs/inotify/max_user_watches
+ echo 2147483647 > /proc/sys/fs/inotify/max_user_instances
+EOT
+
+sha256sum "${target}" > "${sentinel}"

--- a/chart/assets/operations/instance_groups/diego-cell.yaml
+++ b/chart/assets/operations/instance_groups/diego-cell.yaml
@@ -16,10 +16,6 @@
   path: /instance_groups/name=diego-cell/jobs/name=garden/properties/bpm?/enabled
   value: true
 
-- type: replace
-  path: /instance_groups/name=diego-cell/jobs/name=rep/properties/set_kernel_parameters?
-  value: false
-
 # Use a PVC for garden data
 # https://github.com/cloudfoundry-incubator/kubecf/issues/441
 - type: replace
@@ -122,9 +118,7 @@
       internal: 1801
     run:
       security_context:
-        capabilities:
-          add:
-          - SYS_ADMIN
+        privileged: true
       healthcheck:
         rep:
           readiness:


### PR DESCRIPTION
## Description

  - Removed the deployment patch instruction disabling the setting of
    KPs by `rep` -> The prestart script invokes code setting the KPs.

  - Added a patch modifying the `rep` prestart script. Added removal
    of ubuntu specific code from the code path setting KPs.

  - Modified the `rep` runtime setup. Made the container privileged.
    The SYS_ADMIN capability used to allow AppArmor was not enough to
    allow setting of KPs.

## Motivation and Context

See ticket #1181 

## How Has This Been Tested?

Used a local minikube to deploy the modified chart (diego mode), and run smoke tests.
  - Deployment :heavy_check_mark: 
  - Smoke test :heavy_check_mark: 

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
