### PR TITLE
fix: kubecf#1250: Double vertical bars '|' when interpolate external database CA cert.

### DIFF
--- a/chart/assets/operations/instance_groups/database.yaml
+++ b/chart/assets/operations/instance_groups/database.yaml
@@ -259,8 +259,7 @@
 {{ if .Values.features.external_database.ca_cert -}}
 - type: replace
   path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa?/ca_certs/0
-  value: |
-    {{- toYaml .Values.features.external_database.ca_cert | nindent 4 }}
+  value: {{ toYaml .Values.features.external_database.ca_cert | indent 2 }}
 {{- else }}
 - type: remove
   path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa?/ca_certs
@@ -290,8 +289,7 @@
 {{ if .Values.features.external_database.ca_cert -}}
 - type: replace
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/ccdb/ca_cert?
-  value: |
-    {{- toYaml .Values.features.external_database.ca_cert | nindent 4 }}
+  value: {{ toYaml .Values.features.external_database.ca_cert | indent 2 }}
 {{- else }}
 - type: remove
   path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/ccdb/ca_cert?
@@ -321,8 +319,7 @@
 {{ if .Values.features.external_database.ca_cert -}}
 - type: replace
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/ccdb/ca_cert?
-  value: |
-    {{- toYaml .Values.features.external_database.ca_cert | nindent 4 }}
+  value: {{ toYaml .Values.features.external_database.ca_cert | indent 2 }}
 {{- else }}
 - type: remove
   path: /instance_groups/name=cc-worker/jobs/name=cloud_controller_worker/properties/ccdb/ca_cert?
@@ -352,8 +349,7 @@
 {{ if .Values.features.external_database.ca_cert -}}
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/ccdb/ca_cert?
-  value: |
-    {{- toYaml .Values.features.external_database.ca_cert | nindent 4 }}
+  value: {{ toYaml .Values.features.external_database.ca_cert | indent 2 }}
 {{- else }}
 - type: remove
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/ccdb/ca_cert?
@@ -383,8 +379,7 @@
 {{ if .Values.features.external_database.ca_cert -}}
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cc_deployment_updater/properties/ccdb/ca_cert?
-  value: |
-    {{- toYaml .Values.features.external_database.ca_cert | nindent 4 }}
+  value: {{ toYaml .Values.features.external_database.ca_cert | indent 2 }}
 {{- else }}
 - type: remove
   path: /instance_groups/name=scheduler/jobs/name=cc_deployment_updater/properties/ccdb/ca_cert?
@@ -414,8 +409,7 @@
 {{ if .Values.features.external_database.ca_cert -}}
 - type: replace
   path: /instance_groups/name=diego-api/jobs/name=bbs/properties/diego/bbs/sql/ca_cert?
-  value: |
-    {{- toYaml .Values.features.external_database.ca_cert | nindent 4 }}
+  value: {{ toYaml .Values.features.external_database.ca_cert | indent 2 }}
 {{- else }}
 - type: remove
   path: /instance_groups/name=diego-api/jobs/name=bbs/properties/diego/bbs/sql/ca_cert?
@@ -446,8 +440,7 @@
 {{ if .Values.features.external_database.ca_cert -}}
 - type: replace
   path: /instance_groups/name=routing-api/jobs/name=routing-api/properties/routing_api/sqldb/ca_cert?
-  value: |
-    {{- toYaml .Values.features.external_database.ca_cert | nindent 4 }}
+  value: {{ toYaml .Values.features.external_database.ca_cert | indent 2 }}
 {{- else}}
 - type: remove
   path: /instance_groups/name=routing-api/jobs/name=routing-api/properties/routing_api/sqldb/ca_cert?
@@ -478,8 +471,7 @@
 {{ if .Values.features.external_database.ca_cert -}}
 - type: replace
   path: /instance_groups/name=api/jobs/name=policy-server/properties/database/ca_cert?
-  value: |
-    {{- toYaml .Values.features.external_database.ca_cert | nindent 4 }}
+  value: {{ toYaml .Values.features.external_database.ca_cert | indent 2 }}
 {{- else }}
 - type: remove
   path: /instance_groups/name=api/jobs/name=policy-server/properties/database/ca_cert?
@@ -509,8 +501,7 @@
 {{ if .Values.features.external_database.ca_cert -}}
 - type: replace
   path: /instance_groups/name=diego-api/jobs/name=silk-controller/properties/database/ca_cert?
-  value: |
-    {{- toYaml .Values.features.external_database.ca_cert | nindent 4 }}
+  value: {{ toYaml .Values.features.external_database.ca_cert | indent 2 }}
 {{- else }}
 - type: remove
   path: /instance_groups/name=diego-api/jobs/name=silk-controller/properties/database/ca_cert?
@@ -540,8 +531,7 @@
 {{ if .Values.features.external_database.ca_cert -}}
 - type: replace
   path: /instance_groups/name=diego-api/jobs/name=locket/properties/diego/locket/sql/ca_cert?
-  value: |
-    {{- toYaml .Values.features.external_database.ca_cert | nindent 4 }}
+  value: {{ toYaml .Values.features.external_database.ca_cert | indent 2 }}
 {{- else }}
 - type: remove
   path: /instance_groups/name=diego-api/jobs/name=locket/properties/diego/locket/sql/ca_cert?
@@ -572,8 +562,7 @@
 {{ if .Values.features.external_database.ca_cert -}}
 - type: replace
   path: /instance_groups/name=credhub/jobs/name=credhub/properties/credhub/data_storage/tls_ca?
-  value: |
-    {{- toYaml .Values.features.external_database.ca_cert | nindent 4 }}
+  value: {{ toYaml .Values.features.external_database.ca_cert | indent 2 }}
 {{- else }}
 - type: remove
   path: /instance_groups/name=credhub/jobs/name=credhub/properties/credhub/data_storage/tls_ca?


### PR DESCRIPTION
## Description

fix: https://github.com/cloudfoundry-incubator/kubecf/issues/1250 : Double vertical bars '|' when interpolate external database CA cert.

'toYaml .Values.features.external_database.ca_cert' is multiple lines string, the '|' is added automatically, so don't need the explicit '|'

## How Has This Been Tested?
KubeCF with external database
KubeCF with embeded database


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
