### PR TITLE
fix: diego cells should use EmptyDir storage by default

### DIFF
--- a/bosh/releases/pre_render_scripts/diego-cell/garden/jobs/patch_grootfs_utils.sh
+++ b/bosh/releases/pre_render_scripts/diego-cell/garden/jobs/patch_grootfs_utils.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset
+
+target="/var/vcap/all-releases/jobs-src/garden-runc/garden/templates/bin/grootfs-utils.erb"
+sentinel="${target}.patch_sentinel"
+if [[ -f "${sentinel}" ]]; then
+  if sha256sum --check "${sentinel}" ; then
+    echo "Patch already applied. Skipping"
+    exit 0
+  fi
+  echo "Sentinel mismatch, re-patching"
+fi
+
+# Patch grootfs-utils to restrict the size of the sparse stores
+patch --verbose "${target}" <<'EOT'
+7,8c7,17
+<   /var/vcap/packages/thresholder/bin/thresholder "<%= p("grootfs.reserved_space_for_other_jobs_in_mb") %>" "$DATA_DIR" "$GARDEN_CONFIG_DIR/grootfs_config.yml" "<%= p("garden.graph_cleanup_threshold_in_mb") %>" "<%= p("grootfs.graph_cleanup_threshold_in_mb") %>"
+<   /var/vcap/packages/thresholder/bin/thresholder "<%= p("grootfs.reserved_space_for_other_jobs_in_mb") %>" "$DATA_DIR" "$GARDEN_CONFIG_DIR/privileged_grootfs_config.yml" "<%= p("garden.graph_cleanup_threshold_in_mb") %>" "<%= p("grootfs.graph_cleanup_threshold_in_mb") %>"
+---
+>   let grootfs_size="<%= p("grootfs.reserved_space_for_other_jobs_in_mb") %>"
+>   let disk_size=`df -BM /var/vcap/data/grootfs/store/ | tail -n 1 | awk '{gsub("M", "", $2); print $2}'`
+>   let reserved_disk="$disk_size - $grootfs_size"
+> 
+>   if [ "$grootfs_size" -gt "$disk_size" ]; then
+>     echo "The node running this cell doesn't have enough disk space. You requested ${grootfs_size}M but the disk is ${disk_size}M in size."
+>     exit 1
+>   fi
+> 
+>   /var/vcap/packages/thresholder/bin/thresholder "$reserved_disk" "$DATA_DIR" "$GARDEN_CONFIG_DIR/grootfs_config.yml" "<%= p("garden.graph_cleanup_threshold_in_mb") %>" "<%= p("grootfs.graph_cleanup_threshold_in_mb") %>"
+>   /var/vcap/packages/thresholder/bin/thresholder "$reserved_disk" "$DATA_DIR" "$GARDEN_CONFIG_DIR/privileged_grootfs_config.yml" "<%= p("garden.graph_cleanup_threshold_in_mb") %>" "<%= p("grootfs.graph_cleanup_threshold_in_mb") %>"
+EOT
+
+sha256sum "${target}" > "${sentinel}"

--- a/chart/assets/operations/instance_groups/diego-cell.yaml
+++ b/chart/assets/operations/instance_groups/diego-cell.yaml
@@ -26,6 +26,16 @@
   path: /instance_groups/name=diego-cell/jobs/name=rep/properties/diego?/executor/disk_capacity_mb
   value: {{ .Values.sizing.diego_cell.ephemeral_disk.size }}
 
+{{- if .Values.sizing.diego_cell.ephemeral_disk.storage_class }}
+# Use a PVC for garden data
+- type: replace
+  path: /instance_groups/name=diego-cell/env?/bosh?/agent?/settings?/ephemeralAsPVC?
+  value: true
+- type: replace
+  path: /instance_groups/name=diego-cell/persistent_disk_type?
+  value: {{ .Values.sizing.diego_cell.ephemeral_disk.storage_class | quote }}
+{{- end }}
+
 # Rep data should not be a PVC - since that could end up as a PVC
 # and if it's NFS, garden won't work
 - type: replace

--- a/chart/assets/operations/instance_groups/diego-cell.yaml
+++ b/chart/assets/operations/instance_groups/diego-cell.yaml
@@ -16,21 +16,15 @@
   path: /instance_groups/name=diego-cell/jobs/name=garden/properties/bpm?/enabled
   value: true
 
-# Use a PVC for garden data
-# https://github.com/cloudfoundry-incubator/kubecf/issues/441
+# Configure the size of the diego cell grootfs store
+# We are repurposing reserved_space_for_other_jobs_in_mb as the size of the grootfs store 
 - type: replace
-  path: /instance_groups/name=diego-cell/env?/bosh?/agent?/settings?/ephemeralAsPVC?
-  value: true
-- type: replace
-  path: /instance_groups/name=diego-cell/vm_resources?/ephemeral_disk_size?
+  path: /instance_groups/name=diego-cell/jobs/name=garden/properties/grootfs?/reserved_space_for_other_jobs_in_mb
   value: {{ .Values.sizing.diego_cell.ephemeral_disk.size }}
-- type: remove
-  path: /instance_groups/name=diego-cell/persistent_disk_type?
-{{- if .Values.sizing.diego_cell.ephemeral_disk.storage_class }}
+
 - type: replace
-  path: /instance_groups/name=diego-cell/persistent_disk_type?
-  value: {{ .Values.sizing.diego_cell.ephemeral_disk.storage_class | quote }}
-{{- end }}
+  path: /instance_groups/name=diego-cell/jobs/name=rep/properties/diego?/executor/disk_capacity_mb
+  value: {{ .Values.sizing.diego_cell.ephemeral_disk.size }}
 
 # Rep data should not be a PVC - since that could end up as a PVC
 # and if it's NFS, garden won't work

--- a/chart/config/unsupported.yaml
+++ b/chart/config/unsupported.yaml
@@ -10,7 +10,3 @@ unsupported:
   properties.diego-cell.garden.grootfs.reserved_space_for_other_jobs_in_mb: |
     Don't use properties.diego-cell.garden.grootfs.reserved_space_for_other_jobs_in_mb.
     Use sizing.diego_cell.ephemeral_disk.size to set the amount of disk available to the cell.
-
-  sizing.diego_cell.ephemeral_disk.storage_class: |
-    Don't use garden.grootfs.reserved_space_for_other_jobs_in_mb. 
-    Diego cells no longer use PVCs for app containers, they use an EmptyDir.

--- a/chart/config/unsupported.yaml
+++ b/chart/config/unsupported.yaml
@@ -1,4 +1,3 @@
-
 # This file contains a set of values.yaml keys that have become unsupported
 # and should no longer be used.
 

--- a/chart/config/unsupported.yaml
+++ b/chart/config/unsupported.yaml
@@ -1,0 +1,16 @@
+
+# This file contains a set of values.yaml keys that have become unsupported
+# and should no longer be used.
+
+unsupported:
+  properties.diego-cell.rep.diego.executor.disk_capacity_mb: |
+    Don't use properties.diego-cell.rep.diego.executor.disk_capacity_mb.
+    Use sizing.diego_cell.ephemeral_disk.size to set the amount of disk available to the cell.
+
+  properties.diego-cell.garden.grootfs.reserved_space_for_other_jobs_in_mb: |
+    Don't use properties.diego-cell.garden.grootfs.reserved_space_for_other_jobs_in_mb.
+    Use sizing.diego_cell.ephemeral_disk.size to set the amount of disk available to the cell.
+
+  sizing.diego_cell.ephemeral_disk.storage_class: |
+    Don't use garden.grootfs.reserved_space_for_other_jobs_in_mb. 
+    Diego cells no longer use PVCs for app containers, they use an EmptyDir.

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -21,16 +21,11 @@
     {{- $disk_size := .Values.sizing.diego_cell.ephemeral_disk.size }}
     {{- $app_disk_quota := 1024 }}
 
-    {{- /* We need the nested ifs because of https://github.com/helm/helm/issues/8026 */ -}}
-    {{- if and .Values.properties.api }}
-      {{- if .Values.properties.api.cloud_controller_ng }}
-        {{- if .Values.properties.api.cloud_controller_ng.cc }}
-          {{- if .Values.properties.api.cloud_controller_ng.cc.default_app_disk_in_mb }}
-            {{- $app_disk_quota := .Values.properties.api.cloud_controller_ng.cc.default_app_disk_in_mb }}
-          {{ end }}
-        {{ end }}
-      {{ end }}
+    {{- include "_config.lookup" (list $ "properties.api.cloud_controller_ng.cc.default_app_disk_in_mb") }}
+    {{- if $.kubecf.retval }}
+      {{- $app_disk_quota = $.kubecf.retval }}
     {{- end }}
+
     {{- $estimated_apps := div (mul $cell_count $disk_size) $app_disk_quota }}
 
     You will be running [1;35m{{ $cell_count }}[0m diego cell(s), with [1;35m{{ $disk_size }}Mi[0m of disk each.

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -16,5 +16,27 @@
 
     to monitor continuously.
 
+    {{- if not .Values.features.eirini.enabled }}
+    {{- $cell_count := .Values.sizing.diego_cell.instances | default 1 }}
+    {{- $disk_size := .Values.sizing.diego_cell.ephemeral_disk.size }}
+    {{- $app_disk_quota := 1024 }}
+
+    {{- /* We need the nested ifs because of https://github.com/helm/helm/issues/8026 */ -}}
+    {{- if and .Values.properties.api }}
+      {{- if .Values.properties.api.cloud_controller_ng }}
+        {{- if .Values.properties.api.cloud_controller_ng.cc }}
+          {{- if .Values.properties.api.cloud_controller_ng.cc.default_app_disk_in_mb }}
+            {{- $app_disk_quota := .Values.properties.api.cloud_controller_ng.cc.default_app_disk_in_mb }}
+          {{ end }}
+        {{ end }}
+      {{ end }}
+    {{- end }}
+    {{- $estimated_apps := div (mul $cell_count $disk_size) $app_disk_quota }}
+
+    You will be running [1;35m{{ $cell_count }}[0m diego cell(s), with [1;35m{{ $disk_size }}Mi[0m of disk each.
+    The default app quota is set to [1;35m{{ $app_disk_quota }}Mi[0m, which means you'll have enough disk
+    space to run about [1;35m{{ $estimated_apps }}[0m apps.
+    {{- end }}
+
     The online documentation (release notes, deployment guide) can be found at
         [1;36mhttps://kubecf.suse.dev/docs[0m

--- a/chart/templates/_config.tpl
+++ b/chart/templates/_config.tpl
@@ -59,7 +59,7 @@
 
     {{- range $condition, $message := $.Values.unsupported }}
       {{- if eq "true" (include "_config.condition" (list $ $condition)) }}
-        {{- fail $message }}
+        {{- fail (printf "\n\n\n\n============================\n\n%s" $message) }}
       {{- end }}
     {{- end }}
   {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -112,9 +112,9 @@ sizing:
       # IMPORTANT! Only set this if you understand the consequences of using a PVC as ephemeral
       # storage for diego cells. The storage class should be high performance, and not based on NFS.
       # Do not set this value in production environments unless you've tested your storage class with
-      # diego cells and have found no problems. 
+      # diego cells and have found no problems.
       # The name of the storage class used for the ephemeral disk PVC.
-      storage_class: ""
+      storage_class: ~
     instances: ~
   doppler:
     instances: ~

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -109,8 +109,6 @@ sizing:
     ephemeral_disk:
       # Size of the ephemeral disk used to store applications in MB
       size: 40960
-      # The name of the storage class used for the ephemeral disk PVC.
-      storage_class: ~
     instances: ~
   doppler:
     instances: ~

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -109,6 +109,12 @@ sizing:
     ephemeral_disk:
       # Size of the ephemeral disk used to store applications in MB
       size: 40960
+      # IMPORTANT! Only set this if you understand the consequences of using a PVC as ephemeral
+      # storage for diego cells. The storage class should be high performance, and not based on NFS.
+      # Do not set this value in production environments unless you've tested your storage class with
+      # diego cells and have found no problems. 
+      # The name of the storage class used for the ephemeral disk PVC.
+      storage_class: ""
     instances: ~
   doppler:
     instances: ~


### PR DESCRIPTION
## Description
Diego cells no longer use a PVC. They will use EmptyDir storage from the host node.
The host node will need to have sufficient disk space to host the cell.
The amount of disk used by grootfs is calculated using the amount of ephemeral storage configured for the cells.

## Motivation and Context
Fixes #489 
Fixes #1241 

## How Has This Been Tested?
Ran locally.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
