### PR TITLE
Return empty string when looking up non-existing properties

### DIFF
--- a/chart/templates/_config.tpl
+++ b/chart/templates/_config.tpl
@@ -169,6 +169,9 @@
       {{- end }}
     {{- end }}
   {{- else }}
+    {{- if gt (len $path) 1 }}
+      {{- $_ := set $kubecf "retval" nil }}
+    {{- end }}
     {{- /* Return YAML compatible string versions of "zero" values; empty string for all other kinds */}}
     {{- $zero := dict "bool" "false" "int" 0 "int64" 0 "float64" 0 "map" "{}" "slice" "[]" }}
     {{- get $zero (kindOf $kubecf.retval) }}

--- a/tests/config/templates/lookup.yaml
+++ b/tests/config/templates/lookup.yaml
@@ -26,10 +26,17 @@
 
 {{ include "lookup" (list $ "nil" "" "invalid") }}
 {{ include "lookup" (list $ "helm_nil" "" "invalid") }}
+{{ include "lookup" (list $ "does_not_exist" "" "invalid") }}
 
 {{ include "lookup" (list $ "empty_string" "" "string") }}
 {{ include "lookup" (list $ "empty_list" "[]" "slice") }}
 {{ include "lookup" (list $ "empty_hash" "{}" "map") }}
+
+# if the element at the end of the path does not exist, then the result is always nil
+{{ include "lookup" (list $ "nil.does_not_exist" "" "invalid") }}
+{{ include "lookup" (list $ "empty_string.does_not_exist" "" "invalid") }}
+{{ include "lookup" (list $ "empty_list.does_not_exist" "" "invalid") }}
+{{ include "lookup" (list $ "empty_hash.does_not_exist" "" "invalid") }}
 
 {{ include "lookup" (list $ "helm_empty" "" "string") }}
 


### PR DESCRIPTION
The documentation says:

> Lookup $path under $context and return either the value found, or the empty string.

However, if along the path there is an empty map or slice, lookup would return this map or slice, even though should have been more path elements to traverse.

This commit fixes the logic to set `$.kubecf.retval` to `nil` and return an empty string instead. The only time when _config.lookup should return `{}` or `[]` is when the value **at the end of the path** exists and is an empty map or slice.
