### PR TITLE
feat: add conventional GH action

### DIFF
--- a/.commitsar.yaml
+++ b/.commitsar.yaml
@@ -1,0 +1,2 @@
+commits:
+  disabled: true

--- a/.github/workflows/conventional-commits-lit.yml
+++ b/.github/workflows/conventional-commits-lit.yml
@@ -1,0 +1,17 @@
+name: Conventional Commits Litter
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  validate-commits:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v1
+      - name: Commitsar check
+        uses: aevea/commitsar@v0.15.0


### PR DESCRIPTION
## Description

This new GH action will check if the pull request message follows the conventional commit standards. 
It will happen only to the pull request message and not for the commits within since the commitsar configuration file is explicitly disabling it.

## Motivation and Context

To help the reviewer (or anyone else) to immediately understand the type of pull request and it's the first step to support a better and more efficient release notes process.

fixes #624.

## How Has This Been Tested?
N/A

## Screenshots (if appropriate):
N/A

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Maintenance

## Checklist:
- [ ] My code has security implications.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
