### PR TITLE
fix: missing loadBalancerIP on values.yaml

### DIFF
--- a/chart/values.schema.yaml
+++ b/chart/values.schema.yaml
@@ -114,7 +114,6 @@ definitions:
         type: array
         items: {type: string}
       clusterIP: {"$ref": "#/definitions/string_or_null"}
-      # loadBalancerIP is not mentioned in values.yaml but referenced in ingress.yaml
       loadBalancerIP: {"$ref": "#/definitions/string_or_null"}
       port_range:
         type: object

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -138,16 +138,19 @@ services:
     type: LoadBalancer
     externalIPs: []
     clusterIP: ~
+    loadBalancerIP: ~
   ssh-proxy:
     annotations: ~
     type: LoadBalancer
     externalIPs: []
     clusterIP: ~
+    loadBalancerIP: ~
   tcp-router:
     annotations: ~
     type: LoadBalancer
     externalIPs: []
     clusterIP: ~
+    loadBalancerIP: ~
     port_range:
       start: 20000
       end: 20008


### PR DESCRIPTION
## Description

It doesn't hurt to add the `loadBalancerIP` key to `values.yaml`, eh? Actually, it helps a lot when discovering it.

## Motivation and Context

I went to make sure what was the correct syntax to specify a static IP for the load balancer and I realized we were missing it in the `values.yaml`.

## How Has This Been Tested?

It has not been tested, the change is simple enough to not require that. It's all about being explicit.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
