### PR TITLE
feat: Implement eirini-dns-aliases

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -46,6 +46,45 @@ Get the metadata name for an ops file.
 {{- end }}
 
 {{- /*
+==========================================================================================
+| kubecf.component.selector (list $ $component)
++-----------------------------------------------------------------------------------------
+| Emit standard labels for use in selectors (for services and the like).
+|
+| $component should be the name of a component; ideally this will match the name of the
+| service / pod.
+==========================================================================================
+*/ -}}
+{{- define "kubecf.component.selector" }}
+{{- $root := first . }}
+{{- $component := index . 1 }}
+app.kubernetes.io/name: {{ include "kubecf.fullname" $root }}
+app.kubernetes.io/instance: {{ $root.Release.Name | quote }}
+app.kubernetes.io/component: {{ $component | quote }}
+{{- end }}
+
+{{- /*
+==========================================================================================
+| kubecf.component.labels (list $ $component)
++-----------------------------------------------------------------------------------------
+| Emit standard labels for use in pod/etc. declarations.
+|
+| $component should be the name of a component; ideally this will match the name of the
+| service / pod.
+|
+| This will include any labels relevant for selectors.
+==========================================================================================
+*/ -}}
+{{- define "kubecf.component.labels" }}
+{{- $root := first . }}
+{{- $component := last . }}
+{{- include "kubecf.component.selector" . }}
+app.kubernetes.io/managed-by: {{ $root.Release.Service | quote }}
+app.kubernetes.io/version: {{ default $root.Chart.Version $root.Chart.AppVersion | quote }}
+helm.sh/chart: {{ include "kubecf.chart" $root }}
+{{- end }}
+
+{{- /*
   Template "kubecf.dig" takes a dict and a list; it indexes the dict with each
   successive element of the list.
 

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -47,7 +47,7 @@ Get the metadata name for an ops file.
 
 {{- /*
 ==========================================================================================
-| kubecf.component.selector (list $ $component)
+| component.selector (list $ $component)
 +-----------------------------------------------------------------------------------------
 | Emit standard labels for use in selectors (for services and the like).
 |
@@ -55,7 +55,7 @@ Get the metadata name for an ops file.
 | service / pod.
 ==========================================================================================
 */ -}}
-{{- define "kubecf.component.selector" }}
+{{- define "component.selector" }}
 {{- $root := first . }}
 {{- $component := index . 1 }}
 app.kubernetes.io/name: {{ include "kubecf.fullname" $root }}
@@ -65,7 +65,7 @@ app.kubernetes.io/component: {{ $component | quote }}
 
 {{- /*
 ==========================================================================================
-| kubecf.component.labels (list $ $component)
+| component.labels (list $ $component)
 +-----------------------------------------------------------------------------------------
 | Emit standard labels for use in pod/etc. declarations.
 |
@@ -75,10 +75,10 @@ app.kubernetes.io/component: {{ $component | quote }}
 | This will include any labels relevant for selectors.
 ==========================================================================================
 */ -}}
-{{- define "kubecf.component.labels" }}
+{{- define "component.labels" }}
 {{- $root := first . }}
 {{- $component := last . }}
-{{- include "kubecf.component.selector" . }}
+{{- include "component.selector" . }}
 app.kubernetes.io/managed-by: {{ $root.Release.Service | quote }}
 app.kubernetes.io/version: {{ default $root.Chart.Version $root.Chart.AppVersion | quote }}
 helm.sh/chart: {{ include "kubecf.chart" $root }}

--- a/chart/values.schema.yaml
+++ b/chart/values.schema.yaml
@@ -136,6 +136,9 @@ definitions:
     - type: object
       additionalProperties: {"$ref": "#/definitions/tree_of_strings"}
 
+  image_pull_policy:
+    enum: [ Always, Never, IfNotPresent, ~ ]
+
 properties:
 
   ccdb:
@@ -346,4 +349,13 @@ properties:
   # mixin configs
   bits: {type: object}
   eirini: {type: object}
-  eirinix: {type: object}
+  eirinix:
+    type: object
+    additionalProperties: true
+    properties:
+      dns-aliases:
+        type: object
+        properties:
+          image: {type: string}
+          image_tag: {type: string}
+          pullPolicy: {"$ref": "#/definitions/image_pull_policy"}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -438,3 +438,7 @@ eirinix:
     icon_image: Eirini broker
     secrets:
       auth-password: ~ # Password is randomly generated if not given
+  dns-aliases:
+    image: ghcr.io/cfcontainerizationbot/eirini-dns-aliases
+    image_tag: 0.0.0-18.gdf4c9f7b
+    pullPolicy: IfNotPresent

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -438,7 +438,3 @@ eirinix:
     icon_image: Eirini broker
     secrets:
       auth-password: ~ # Password is randomly generated if not given
-  dns-aliases:
-    image: ghcr.io/cfcontainerizationbot/eirini-dns-aliases
-    image_tag: 0.0.0-18.gdf4c9f7b
-    pullPolicy: IfNotPresent

--- a/mixins/eirinix/config/eirinix.yaml
+++ b/mixins/eirinix/config/eirinix.yaml
@@ -1,7 +1,7 @@
 eirinix:
   dns-aliases:
     image: ghcr.io/cfcontainerizationbot/eirini-dns-aliases
-    image_tag: 0.0.0-22.gdb77bf4a
+    image_tag: 0.0.0-25.g85d1e391
     pullPolicy: IfNotPresent
 
   loggregator-bridge:

--- a/mixins/eirinix/config/eirinix.yaml
+++ b/mixins/eirinix/config/eirinix.yaml
@@ -1,7 +1,7 @@
 eirinix:
   dns-aliases:
     image: ghcr.io/cfcontainerizationbot/eirini-dns-aliases
-    image_tag: 0.0.0-29.gcc4c08ea
+    image_tag: 0.0.0-32.g585bc34d
     pullPolicy: IfNotPresent
 
   loggregator-bridge:

--- a/mixins/eirinix/config/eirinix.yaml
+++ b/mixins/eirinix/config/eirinix.yaml
@@ -1,4 +1,9 @@
 eirinix:
+  dns-aliases:
+    image: ghcr.io/cfcontainerizationbot/eirini-dns-aliases
+    image_tag: 0.0.0-18.gdf4c9f7b
+    pullPolicy: IfNotPresent
+
   loggregator-bridge:
     replicaCount: 1
     image:

--- a/mixins/eirinix/config/eirinix.yaml
+++ b/mixins/eirinix/config/eirinix.yaml
@@ -1,7 +1,7 @@
 eirinix:
   dns-aliases:
     image: ghcr.io/cfcontainerizationbot/eirini-dns-aliases
-    image_tag: 0.0.0-18.gdf4c9f7b
+    image_tag: 0.0.0-22.gdb77bf4a
     pullPolicy: IfNotPresent
 
   loggregator-bridge:

--- a/mixins/eirinix/config/eirinix.yaml
+++ b/mixins/eirinix/config/eirinix.yaml
@@ -1,7 +1,7 @@
 eirinix:
   dns-aliases:
     image: ghcr.io/cfcontainerizationbot/eirini-dns-aliases
-    image_tag: 0.0.0-25.g85d1e391
+    image_tag: 0.0.0-29.gcc4c08ea
     pullPolicy: IfNotPresent
 
   loggregator-bridge:

--- a/mixins/eirinix/templates/dns-aliases/deployment.yaml
+++ b/mixins/eirinix/templates/dns-aliases/deployment.yaml
@@ -6,15 +6,15 @@ kind: Deployment
 metadata:
   name: eirini-dns-aliases
   labels:
-    {{- list . "eirini-dns-aliases" | include "kubecf.component.labels" | nindent 4 }}
+    {{- list . "eirini-dns-aliases" | include "component.labels" | nindent 4 }}
 spec:
   selector:
     matchLabels:
-      {{- list . "eirini-dns-aliases" | include "kubecf.component.selector" | nindent 6 }}
+      {{- list . "eirini-dns-aliases" | include "component.selector" | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- list . "eirini-dns-aliases" | include "kubecf.component.labels" | nindent 8 }}
+        {{- list . "eirini-dns-aliases" | include "component.labels" | nindent 8 }}
     spec:
       serviceAccountName: eirinix
       containers:

--- a/mixins/eirinix/templates/dns-aliases/deployment.yaml
+++ b/mixins/eirinix/templates/dns-aliases/deployment.yaml
@@ -32,11 +32,9 @@ spec:
             value: "8443"
           - name: SERVICE_NAME
             value: eirini-dns-aliases
-          - name: OPERATOR_FINGERPRINT
-            value: eirini-dns-aliases
           - name: DNS_SERVICE_HOST
             value: {{ printf "apps-dns.%s.svc" .Release.Namespace }}
           ports:
-          - name: webhook-tls
+          - name: webhook
             containerPort: 8443
 {{- end }}

--- a/mixins/eirinix/templates/dns-aliases/deployment.yaml
+++ b/mixins/eirinix/templates/dns-aliases/deployment.yaml
@@ -1,0 +1,42 @@
+{{- $_ := include "_config.load" $ }}
+{{- if .Values.features.eirini.enabled }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: eirini-dns-aliases
+  labels:
+    {{- list . "eirini-dns-aliases" | include "kubecf.component.labels" | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- list . "eirini-dns-aliases" | include "kubecf.component.selector" | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- list . "eirini-dns-aliases" | include "kubecf.component.labels" | nindent 8 }}
+    spec:
+      serviceAccountName: eirinix
+      containers:
+        - name: eirini-dns-aliases
+          {{- with index .Values.eirinix "dns-aliases" }}
+          image: {{ printf "%s:%s" .image .image_tag | quote }}
+          imagePullPolicy: {{ .pullPolicy }}
+          {{- end }}
+          env:
+          - name: EIRINI_NAMESPACE
+            value: {{ .Values.eirini.opi.namespace }}
+          - name: WEBHOOK_NAMESPACE
+            value: {{ .Release.Namespace }}
+          - name: PORT
+            value: "8443"
+          - name: SERVICE_NAME
+            value: eirini-dns-aliases
+          - name: OPERATOR_FINGERPRINT
+            value: eirini-dns-aliases
+          - name: DNS_SERVICE_HOST
+            value: {{ printf "apps-dns.%s.svc" .Release.Namespace }}
+          ports:
+          - name: webhook-tls
+            containerPort: 8443
+{{- end }}

--- a/mixins/eirinix/templates/dns-aliases/service.yaml
+++ b/mixins/eirinix/templates/dns-aliases/service.yaml
@@ -16,5 +16,4 @@ spec:
   - protocol: TCP
     name: webhook
     port: 8443
-    targetPort: webhook-tls
 {{- end }}

--- a/mixins/eirinix/templates/dns-aliases/service.yaml
+++ b/mixins/eirinix/templates/dns-aliases/service.yaml
@@ -7,11 +7,11 @@ metadata:
   name: eirini-dns-aliases
   namespace: {{ .Release.Namespace | quote }}
   labels:
-    {{- list . "eirini-dns-aliases" | include "kubecf.component.labels" | nindent 4 }}
+    {{- list . "eirini-dns-aliases" | include "component.labels" | nindent 4 }}
 spec:
   type: ClusterIP
   selector:
-    {{- list . "eirini-dns-aliases" | include "kubecf.component.selector" | nindent 4 }}
+    {{- list . "eirini-dns-aliases" | include "component.selector" | nindent 4 }}
   ports:
   - protocol: TCP
     name: webhook

--- a/mixins/eirinix/templates/dns-aliases/service.yaml
+++ b/mixins/eirinix/templates/dns-aliases/service.yaml
@@ -15,6 +15,6 @@ spec:
   ports:
   - protocol: TCP
     name: webhook
-    port: 443
+    port: 8443
     targetPort: webhook-tls
 {{- end }}

--- a/mixins/eirinix/templates/dns-aliases/service.yaml
+++ b/mixins/eirinix/templates/dns-aliases/service.yaml
@@ -1,0 +1,20 @@
+{{- $_ := include "_config.load" $ }}
+{{- if .Values.features.eirini.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: eirini-dns-aliases
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- list . "eirini-dns-aliases" | include "kubecf.component.labels" | nindent 4 }}
+spec:
+  type: ClusterIP
+  selector:
+    {{- list . "eirini-dns-aliases" | include "kubecf.component.selector" | nindent 4 }}
+  ports:
+  - protocol: TCP
+    name: webhook
+    port: 443
+    targetPort: webhook-tls
+{{- end }}


### PR DESCRIPTION
## Description
This adds the [eirini-dns-aliases](https://github.com/SUSE/eirini-dns-aliases) eirini extension; it causes the application containers (as in, things deployed with `cf push`) to use the BOSH DNS resolver instead of the default Kubernetes one.

## Motivation and Context
Fixes #284

## How Has This Been Tested?
- Deployed locally, with eirini
- From an application container, `curl -kv https://credhub:8844`
- Resolving `credhub` (to `credhub.service.cf.internal`, then to an IP address) was only possible because of the extension.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Additional Information:

- We may want to wait for #1259 to land first, and then rebase this on top of that work.
- This needs to wait for https://github.com/SUSE/eirini-dns-aliases/pull/1 to be merged first.
- This will affect https://github.com/cloudfoundry-incubator/kubecf/issues/776 — but that should just mean `DNS_SERVICE_HOST` from `bosh-dns.kubecf.svc` to whatever the "App DNS" service mentioned in https://github.com/cloudfoundry-incubator/kubecf/issues/776#issuecomment-684916460 is instead.
- I intentionally omitted resource constraints, as #1142 is still in flux.  If that lands first, we'll need to rebase this to include it.

I'm marking this blocked for now to wait on #1259. /cc @jandubois as a heads up for that.