### PR TITLE
fix: Rename GitHub action that validates the PR title semantics.

### DIFF
--- a/.github/workflows/conventional-commits-lit.yml
+++ b/.github/workflows/conventional-commits-lit.yml
@@ -1,4 +1,4 @@
-name: "Lint PR"
+name: "Pull Request Semantic Validation"
 
 on: [pull_request]
 


### PR DESCRIPTION
## Description

Rename the GitHub action name to something more suitable.

## Motivation and Context

The current GitHub action is bringing some confusion special with the _lint_ word on it.

## How Has This Been Tested?
N/A

## Screenshots (if appropriate):
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code has security implications.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
