### PR TITLE
Limit disk usage during tests to 60GB

### DIFF
--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -217,7 +217,7 @@ deploy_args: &deploy_args
   sizing:
     diego_cell:
       ephemeral_disk:
-        size: 300000
+        size: 60000
   EOF
   export CONFIG_OVERRIDE
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Size was too large

## Motivation and Context
Using local node storage for cells.

## How Has This Been Tested?
Pipeline already flown.

