### PR TITLE
fix: scripts/kubecf-wait: no longer wait for dm

### DIFF
--- a/scripts/kubecf-wait.sh
+++ b/scripts/kubecf-wait.sh
@@ -24,7 +24,6 @@ check_qjob_ready() {
     local output='--output=jsonpath={.status.completed}'
     test true == "$(get_resource "${qjob}" "${output}")"
 }
-RETRIES=180 DELAY=10 retry check_qjob_ready dm
 RETRIES=180 DELAY=10 retry check_qjob_ready ig
 
 green "Waiting for things to exist"


### PR DESCRIPTION
## Description
The `dm` qjob doesn't appear to exist anymore with the new operator; drop it when waiting for the deployment.

## Motivation and Context
The script never finishes waiting (or rather, it eventually times out).

## How Has This Been Tested?
Ran locally.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
