### PR TITLE
feat: scripts/image_list: support VALUES override

### DIFF
--- a/scripts/image_list.rb
+++ b/scripts/image_list.rb
@@ -8,11 +8,15 @@ require 'yaml'
 
 # Make Hash act like OpenStruct for key lookups
 class Hash
+  def respond_to_missing?(symbol, _include_all)
+    [symbol, symbol.to_s].any? { |key| key? key }
+  end
+
   def method_missing(symbol, *args)
     [symbol, symbol.to_s].each do |key|
-        return self[key] if self.key? key
+      return self[key] if key? key
     end
-    super(symbol, *args)
+    super
   end
 end
 
@@ -102,10 +106,11 @@ class HelmRenderer
 
   # Find a resource from the documents
   def find(kind: nil, name: nil)
-    fail "No documents" if documents.empty?
+    raise 'No documents' if documents.empty?
+
     documents.find do |doc|
-      (kind.nil? || doc.kind.downcase == kind.to_s.downcase) &&
-      (name.nil? || doc.metadata.name == name.to_s)
+      (kind.nil? || doc.kind.casecmp?(kind.to_s)) &&
+        (name.nil? || doc.metadata.name == name.to_s)
     end
   end
 end
@@ -148,17 +153,19 @@ class BOSHDeployment < Resource
 
   def interpolated
     return @interpolated unless @interpolated.nil?
+
     result = nil
     Tempfile.open(['ops-', '.yaml']) do |ops_file|
       doc.spec.ops.each do |op|
         ops_doc = resources.find(kind: op.type, name: op.name)
         contents = ops_doc.data.ops
-        if contents.match? /(?:^|\n)---/
+        if contents.match?(/(?:^|\n)---/)
           raise <<~ERROR
             The ops-file #{op.name} should not have multiple YAML documents:
             #{contents}
           ERROR
         end
+
         ops_file.puts contents
       end
 
@@ -186,7 +193,7 @@ class BOSHDeployment < Resource
   end
 
   def output
-    @output ||= Hash.new.tap do |result|
+    @output ||= {}.tap do |result|
       result[:images] = Set.new
       result[:stemcells] = Set.new
       result[:repository_bases] = Set.new
@@ -209,17 +216,22 @@ class PodSpec
   def initialize(doc:)
     @doc = doc
   end
+
   attr_reader :doc
+
   def containers
-    %w(initContainers containers ephemeralContainers).flat_map { |k| doc.fetch(k, []) }
+    %w[initContainers containers ephemeralContainers].flat_map do |k|
+      doc.fetch(k, [])
+    end
   end
+
   def images
     @images ||= containers.flat_map(&:image)
   end
 end
 
 # Standard classes
-%w(DaemonSet Deployment Job).each do |class_name|
+%w[DaemonSet Deployment Job].each do |class_name|
   Object.const_set(class_name, Class.new(Resource) do
     def images
       @images ||= PodSpec.new(doc: doc.spec.template.spec).images
@@ -228,7 +240,7 @@ end
 end
 
 # Quarks classes
-%w(QuarksJob QuarksStatefulSet).each do |class_name|
+%w[QuarksJob QuarksStatefulSet].each do |class_name|
   Object.const_set(class_name, Class.new(Resource) do
     def images
       @images ||= PodSpec.new(doc: doc.spec.template.spec.template.spec).images
@@ -240,9 +252,10 @@ end
 # https://github.com/cloudfoundry-incubator/eirini-release/blob/d87444b10e17/helm/eirini/templates/configmap.yaml#L20-L34
 class ConfigMap < Resource
   def images
-    return [] unless doc.data.has_key? 'opi.yml'
+    return [] unless doc.data.key? 'opi.yml'
+
     opi_config = YAML.safe_load doc.data['opi.yml']
-    %w(downloader_image executor_image uploader_image).map do |key|
+    %w[downloader_image executor_image uploader_image].map do |key|
       opi_config.opi.fetch(key, nil)
     end.compact
   end
@@ -253,7 +266,9 @@ end
 # So far running with features either all enabled or all disabled generates
 # the complete set of used images and is nearly instantaneous.
 features = values['features'].keys
-permutations = [ features.map{ |x| [x, false] }.to_h, features.map{ |x| [x, true] }.to_h ]
+permutations = [false, true].map do |v|
+  features.map { |x| [x, v] }.to_h
+end
 
 # Iterate over all permutations, rendering the chart to obtain all possible
 # images.
@@ -268,13 +283,15 @@ permutations.each do |permutation|
   # Render the Helm chart.
   docs = HelmRenderer.new(chart: chart, values: values)
   # Sanity check: we should have at least _one_ BDPL
-  fail "Could not find BDPL" if docs.find(kind: :BOSHDeployment).nil?
+  raise 'Could not find BDPL' if docs.find(kind: :BOSHDeployment).nil?
 
   # Iterate through all objects and get images from them if we know how
   docs.documents.each do |doc|
     next unless Object.constants.include? doc.kind.to_sym
+
     clazz = Object.const_get(doc.kind)
     next unless clazz.ancestors.include? Resource
+
     obj = clazz.new(resources: docs, doc: doc)
     output.keys.each do |key|
       output[key].merge obj.output[key]


### PR DESCRIPTION
## Description
This adds support for the `VALUES` override when building the image list.  This is helpful when testing local changes to be able to customize the list of images that will be needed (so they can be traferred to the kubernetes cluster).  This should not be used in CI builds.

Note that most of the changes are to make rubocop happy.

## Motivation and Context
While working on #284 I needed to set an override for the image for a new thing that we are not publishing yet (to use my WIP image).  That means I need to provide overrides, but that wasn't possible with the way we were doing the image list.

## How Has This Been Tested?
Ran locally, and loaded all the resulting images into minikube.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
