### PR TITLE
fix: image_list.rb: use $defaults for release name

### DIFF
--- a/scripts/image_list.rb
+++ b/scripts/image_list.rb
@@ -67,11 +67,9 @@ output = {
 }
 
 # Process the non-BOSH releases.
-values.releases.keys.each do |release_name|
-  # Filter out the 'defaults' key as it's not a release.
-  next if release_name == 'defaults'
-
-  release = values.releases[release_name]
+values.releases.each_pair do |release_name, release|
+  # Filter out the '$defaults' key as it's not a release.
+  next if release_name == '$defaults'
 
   # Filter out the releases that don't specify the 'image' key. I.e. if the
   # 'image' key is not specified, it's assumed that the release will be
@@ -79,9 +77,8 @@ values.releases.keys.each do |release_name|
   next unless release.key?('image')
 
   repository_base = release.image.repository.rpartition('/').first
-  output[:repository_bases].add?(repository_base)
-  image = "#{release.image.repository}:#{release.image.tag}"
-  output[:images].add?(image)
+  output.repository_bases.add repository_base
+  output.images.add "#{release.image.repository}:#{release.image.tag}"
 end
 
 # HelmRenderer renders the helm chart


### PR DESCRIPTION
## Description
The default release name (since the stacks change) is now `$defaults` rather than defaults.

## Motivation and Context
Addresses https://github.com/cloudfoundry-incubator/kubecf/pull/1290#discussion_r483275140

## How Has This Been Tested?
Ran locally, generating an image list that I used to load images into minikube.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
