### PR TITLE
fix: define _config.fail template for more readable error messages

### DIFF
--- a/chart/assets/operations/instance_groups/api.yaml
+++ b/chart/assets/operations/instance_groups/api.yaml
@@ -34,10 +34,10 @@
 
 {{- range $keyLabel := .Values.ccdb.encryption.rotation.key_labels }}
 {{- if not (regexMatch "^[a-zA-Z]+[a-zA-Z0-9_]*[a-zA-Z0-9]+$" $keyLabel) }}
-{{ fail "One or more items in ccdb.encryption.rotation.key_labels don't match the regex /^[a-zA-Z]+[a-zA-Z0-9_]*[a-zA-Z0-9]+$/" }}
+{{- include "_config.fail" "One or more items in ccdb.encryption.rotation.key_labels don't match the regex /^[a-zA-Z]+[a-zA-Z0-9_]*[a-zA-Z0-9]+$/" }}
 {{- end }}
 {{- if gt (len $keyLabel) 240 }}
-{{ fail "One or more items in ccdb.encryption.rotation.key_labels exceed the maximum length of 240 characters" }}
+{{- include "_config.fail" "One or more items in ccdb.encryption.rotation.key_labels exceed the maximum length of 240 characters" }}
 {{- end }}
 - type: replace
   path: /variables/-

--- a/chart/assets/operations/instance_groups/eirini-helm.yaml
+++ b/chart/assets/operations/instance_groups/eirini-helm.yaml
@@ -6,7 +6,7 @@
   {{- $ok := len $.Values.install_stacks | eq 1 }}
   {{- $ok = first $.Values.install_stacks | eq $eirini_stack | and $ok }}
   {{- if not $ok }}
-    {{ fail (printf "Eirini can only be enabled with \"install_stacks=[%s]\"" $eirini_stack) }}
+    {{- include "_config.fail" (printf "Eirini can only be enabled with \"install_stacks=[%s]\"" $eirini_stack) }}
   {{- end }}
 
 - type: replace

--- a/chart/templates/_config.tpl
+++ b/chart/templates/_config.tpl
@@ -59,13 +59,25 @@
 
     {{- range $condition, $message := $.Values.unsupported }}
       {{- if eq "true" (include "_config.condition" (list $ $condition)) }}
-        {{- fail (printf "\n\n\n\n============================\n\n%s" $message) }}
+        {{- include "_config.fail" $message }}
       {{- end }}
     {{- end }}
   {{- end }}
 {{- end }}
 
-{{- /*
+{- /*
+==========================================================================================
+| _config.fail $message
++-----------------------------------------------------------------------------------------
+| Fails with $message but also with additional newlines and a separator upfront
+| to make it distinct from the mix of stack trace and YAML data preceeding it.
+==========================================================================================
+*/}}
+{{- define "_config.fail" }}
+  {{- fail (printf "\n\n\n\n============================\n\n%s" .) }}
+{{- end }}
+
+{- /*
 ==========================================================================================
 | _config.lookup (list $ $path)
 +-----------------------------------------------------------------------------------------

--- a/chart/templates/_stacks.tpl
+++ b/chart/templates/_stacks.tpl
@@ -31,7 +31,7 @@
   {{- $cc_stacks := $.kubecf.retval }}
 
   {{- if ne (len $cc_stacks) 1 }}
-    {{- fail "cf-deployment defines more than one stack (or none)" }}
+    {{- include "_config.fail" "cf-deployment defines more than one stack (or none)" }}
   {{- end }}
   {{- $cc_stack := index $cc_stacks 0 }}
 
@@ -39,7 +39,7 @@
   {{- $_ := include "_config.lookup" (list $ "stacks" $cc_stack.name) }}
   {{- $stack := $.kubecf.retval }}
   {{- if not $stack }}
-    {{- fail (printf "cf-deployment stack %q not configured in kubecf" $cc_stack.name) }}
+    {{- include "_config.fail" (printf "cf-deployment stack %q not configured in kubecf" $cc_stack.name) }}
   {{- end }}
 
   {{- /* *** Copy stack "description" from manifest *** */}}
@@ -122,15 +122,15 @@
   {{- /* *** Make sure all requested stacks and their buildpacks are defined *** */}}
   {{- range $stack_name := $.Values.install_stacks }}
     {{- if not (include "_config.lookup" (list $ "stacks" $stack_name)) }}
-      {{- fail (printf "Stack %s is not defined" $stack_name) }}
+      {{- include "_config.fail" (printf "Stack %s is not defined" $stack_name) }}
     {{- end }}
     {{- $stack := $.kubecf.retval }}
     {{- if not (include "_config.lookup" (list $ "releases" $stack_name)) }}
-      {{- fail (printf "No rootfs release found for stack %s" $stack_name) }}
+      {{- include "_config.fail" (printf "No rootfs release found for stack %s" $stack_name) }}
     {{- end }}
     {{- range $buildpack_name := $stack.install_buildpacks }}
       {{- if not (include "_config.lookup" (list $ "stacks" $stack_name "buildpacks" $buildpack_name)) }}
-        {{- fail (printf "No release found for buildpack %s (used by stack %s)" $buildpack_name $stack_name) }}
+        {{- include "_config.fail" (printf "No release found for buildpack %s (used by stack %s)" $buildpack_name $stack_name) }}
       {{- end }}
     {{- end }}
   {{- end }}

--- a/chart/templates/database.yaml
+++ b/chart/templates/database.yaml
@@ -198,7 +198,7 @@ spec:
     spec:
       {{- with $replicas := default 1 .Values.sizing.database.instances }}
       {{- if eq (mod $replicas 2) 0 }}
-      {{- fail "The number of database instances must be odd to avoid split-brain" }}
+      {{- include "_config.fail" "The number of database instances must be odd to avoid split-brain" }}
       {{- end }}
       replicas: {{ $replicas }}
       {{- end }}


### PR DESCRIPTION
Just adds some newlines and a separator in front of the message.

So instead of

```
[...]-eirini-tls-client-cert\n\n# Remove the whole diego-cell instance group.\n- type: remove\n  path: /instance_groups/name=diego-cell\n\n# Remove bbs from diego-api.\n# TODO: remove bbs in the future - when the clock and worker no longer need it.\n# - type: remove\n#   path: /instance_groups/name=diego-api/jobs/name=bbs\n\n# Remove auctioneer, tps and ssh_proxy from scheduler.\n- type: remove\n  path: /instance_groups/name=auctioneer\n- type: remove\n  path: /instance_groups/name=scheduler/jobs/name=tps\n- type: remove\n  path: /instance_groups/name=scheduler/jobs/name=ssh_proxy\n\n# For eirini-extensions: Add hostname-only names to the CC/UAA certificates\n- type: replace\n  path: /variables/name=cc_public_tls/options/alternative_names/-\n  value: api\n- type: replace\n  path: /variables/name=uaa_ssl/options/alternative_names/-\n  value: uaa\n- type: replace\n  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/zones/internal/hostnames/-\n  value: uaa\n\n{{- end }}\n": template: kubecf/templates/ops.yaml:9:7: executing "kubecf/templates/ops.yaml" at <fail (printf "Eirini can only be enabled with \"install_stacks=[%s]\"" $eirini_stack)>: error calling fail: Eirini can only be enabled with "install_stacks=[sle15]"
```

the output looks like this:

```
[...]extensions: Add hostname-only names to the CC/UAA certificates\n- type: replace\n  path: /variables/name=cc_public_tls/options/alternative_names/-\n  value: api\n- type: replace\n  path: /variables/name=uaa_ssl/options/alternative_names/-\n  value: uaa\n- type: replace\n  path: /instance_groups/name=uaa/jobs/name=uaa/properties/uaa/zones/internal/hostnames/-\n  value: uaa\n\n{{- end }}\n": template: kubecf/templates/ops.yaml:9:8: executing "kubecf/templates/ops.yaml" at <include "_config.fail" (printf "Eirini can only be enabled with \"install_stacks=[%s]\"" $eirini_stack)>: error calling include: template: kubecf/templates/_config.tpl:77:6: executing "_config.fail" at <fail (printf "\n\n\n\n============================\n\n%s" .)>: error calling fail:



============================

Eirini can only be enabled with "install_stacks=[sle15]"
```