### PR TITLE
feat: Add tolerations for instance groups

### DIFF
--- a/chart/assets/operations/sizing.yaml
+++ b/chart/assets/operations/sizing.yaml
@@ -39,18 +39,18 @@
 {{- end }}{{/* if eirini */}}
 
 {{- range $instance_group := $instance_groups }}
-  {{- if index (snakecase $instance_group | index $.Values.sizing) "instances" | kindIs "invalid" | not }}
+  {{- $sizing := snakecase $instance_group | index $.Values.sizing }}
+  {{- if $sizing.instances | kindIs "invalid" | not }}
 - type: replace
   path: /instance_groups/name={{ $instance_group }}/instances
-  value: {{ index (snakecase $instance_group | index $.Values.sizing) "instances" }}
+  value: {{ $sizing.instances }}
   {{- else if not $.Values.high_availability }}
 - type: replace
   path: /instance_groups/name={{ $instance_group }}/instances
   value: 1
-  {{- end }}{{/* if */}}
+  {{- end }}{{/* with $instances */}}
 
-  {{- $affinity := index (snakecase $instance_group | index $.Values.sizing) "affinity" }}
-  {{- if $affinity }}
+  {{- with $affinity := $sizing.affinity }}
 - type: replace
   path: /instance_groups/name={{ $instance_group }}/env?/bosh/agent/settings/affinity
   value: {{ toJson $affinity }}
@@ -58,44 +58,32 @@
 - type: replace
   path: /instance_groups/name={{ $instance_group }}/env?/bosh/agent/settings/affinity
   value:
-    {{- /* Each instance group has anti-affinity to itself */}}
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
+      {{- /* Each instance group has anti-affinity to itself */}}
+      {{- $anti_groups := list $instance_group }}
+      {{- if eq $instance_group "diego-cell" }}
+        {{- /* diego-cell has also anti-affinity to router */}}
+        {{- $anti_groups = append $anti_groups "router" }}
+      {{- end }}
+      {{- if eq $instance_group "router" }}
+        {{- /* router has also anti-affinity to diego-cell */}}
+        {{- $anti_groups = append $anti_groups "diego-cell" }}
+      {{- end }}
       - weight: 100
         podAffinityTerm:
           labelSelector:
             matchExpressions:
             - key: quarks.cloudfoundry.org/quarks-statefulset-name
               operator: In
-              values:
-              - {{ $instance_group }}
+              values: {{- $anti_groups | toYaml | nindent 14 }}
           topologyKey: kubernetes.io/hostname
+  {{- end }}{{/* with $affinity */}}
 
-    {{- /* diego-cell has also anti-affinity to router */}}
-    {{- if eq $instance_group "diego-cell" }}
-      - weight: 100
-        podAffinityTerm:
-          labelSelector:
-            matchExpressions:
-            - key: quarks.cloudfoundry.org/quarks-statefulset-name
-              operator: In
-              values:
-              - router
-          topologyKey: kubernetes.io/hostname
-    {{- end }}
-
-    {{- /* router has also anti-affinity to diego-cell */}}
-    {{- if eq $instance_group "router" }}
-      - weight: 100
-        podAffinityTerm:
-          labelSelector:
-            matchExpressions:
-            - key: quarks.cloudfoundry.org/quarks-statefulset-name
-              operator: In
-              values:
-              - diego-cell
-          topologyKey: kubernetes.io/hostname
-    {{- end }}
+  {{- with $tolerations := $sizing.tolerations }}
+- type: replace
+  path: /instance_groups/name={{ $instance_group }}/env?/bosh/agent/settings/tolerations
+  value: {{- $tolerations | toYaml | nindent 2 }}
   {{- end }}
 
 {{- end }}{{/* range $instance_group */}}

--- a/chart/templates/bosh_deployment.yaml
+++ b/chart/templates/bosh_deployment.yaml
@@ -31,11 +31,15 @@ spec:
   vars: []
 {{- end }}
   ops:
+
+# Job moving operations
 {{- range $path, $_ := .Files.Glob "assets/operations/job_moving/*" }}
   - name: {{ include "kubecf.ops-name" (dict "ReleaseName" $root.Release.Name "Path" $path) }}
     type: configmap
 {{- end }}
+
 {{- if eq .Values.features.blobstore.provider "s3" }}
+# S3 blobstore operations
   - name: {{ include "kubecf.ops-name" (dict "Path" "assets/use-external-blobstore.yml") }}
     type: configmap
   - name: {{ include "kubecf.ops-name" (dict "Path" "assets/use-s3-blobstore.yml") }}
@@ -45,25 +49,38 @@ spec:
     type: configmap
 {{- end }}
 {{- end }}
+
+# Instance group operations
 {{- range $path, $bytes := .Files.Glob "assets/operations/instance_groups/*" }}
   - name: {{ include "kubecf.ops-name" (dict "Path" $path) }}
     type: configmap
 {{- end }}
-  - name: {{ include "kubecf.ops-name" (dict "Path" "assets/operations/sizing.yaml") }}
-    type: configmap
-  - name: {{ include "kubecf.ops-name" (dict "Path" "assets/operations/azs.yaml") }}
-    type: configmap
-{{- range $path, $bytes := .Files.Glob "assets/operations/*" }}
+
+# General operations
+{{- /* We want to have specific order here, hence the extra work */}}
+{{- $ops := list }}
+{{- /* `.Files.Glob` results can't be piped to `keys` for some reason */}}
+{{- range $path, $_ := .Files.Glob "assets/operations/*" }}
+  {{- $ops = append $ops $path }}
+{{- end }}
+{{- $ops = sortAlpha $ops }}
+{{- /* Put sizing.yaml and azs.yaml at the start, then the rest */}}
+{{- $ops = prepend $ops "assets/operations/sizing.yaml" }}
+{{- $ops = prepend $ops "assets/operations/azs.yaml" }}
+{{- range $path := uniq $ops }}
   - name: {{ include "kubecf.ops-name" (dict "Path" $path) }}
     type: configmap
 {{- end }}
-{{- range $_, $ops := .Values.operations.custom }}
-  - name: {{ $ops | quote }}
-    type: configmap
-{{- end }}
+
 # To support multi-clusters
 {{- if or .Values.features.multiple_cluster_mode.control_plane.enabled .Values.features.multiple_cluster_mode.cell_segment.enabled }}
   - name: multiple-cluster-mode-operations
+    type: configmap
+{{- end }}
+
+# Custom operations
+{{- range $_, $ops := .Values.operations.custom }}
+  - name: {{ $ops | quote }}
     type: configmap
 {{- end }}
 {{- if gt (len .Values.operations.inline) 0 }}

--- a/chart/templates/bosh_deployment.yaml
+++ b/chart/templates/bosh_deployment.yaml
@@ -49,10 +49,6 @@ spec:
   - name: {{ include "kubecf.ops-name" (dict "Path" $path) }}
     type: configmap
 {{- end }}
-{{- range $path, $bytes := .Files.Glob "assets/operations/temporary/*" }}
-  - name: {{ include "kubecf.ops-name" (dict "Path" $path) }}
-    type: configmap
-{{- end }}
   - name: {{ include "kubecf.ops-name" (dict "Path" "assets/operations/sizing.yaml") }}
     type: configmap
   - name: {{ include "kubecf.ops-name" (dict "Path" "assets/operations/azs.yaml") }}

--- a/chart/templates/ops.yaml
+++ b/chart/templates/ops.yaml
@@ -33,11 +33,11 @@ data:
 {{- end }}
 {{- end }}
 
-{{- range $path, $bytes := .Files.Glob "assets/operations/instance_groups/*" }}
+{{- range $path, $_ := .Files.Glob "assets/operations/instance_groups/*" }}
 {{ include "kubecf.ops" (dict "Root" $root "Path" $path) }}
 {{- end }}
 
-{{- range $path, $bytes := .Files.Glob "assets/operations/*" }}
+{{- range $path, $_ := .Files.Glob "assets/operations/*" }}
 {{ include "kubecf.ops" (dict "Root" $root "Path" $path) }}
 {{- end }}
 

--- a/chart/templates/ops.yaml
+++ b/chart/templates/ops.yaml
@@ -37,10 +37,6 @@ data:
 {{ include "kubecf.ops" (dict "Root" $root "Path" $path) }}
 {{- end }}
 
-{{- range $path, $bytes := .Files.Glob "assets/operations/temporary/*" }}
-{{ include "kubecf.ops" (dict "Root" $root "Path" $path) }}
-{{- end }}
-
 {{- range $path, $bytes := .Files.Glob "assets/operations/*" }}
 {{ include "kubecf.ops" (dict "Root" $root "Path" $path) }}
 {{- end }}

--- a/chart/values.schema.yaml
+++ b/chart/values.schema.yaml
@@ -279,6 +279,19 @@ properties:
           properties:
             size: {type: string}
           additionalProperties: false
+        tolerations:
+          # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#toleration-v1-core
+          type: array
+          items:
+            type: object
+            properties:
+              effect: {"$ref": "#/definitions/string_or_null"}
+              key: {"$ref": "#/definitions/string_or_null"}
+              operator: {"$ref": "#/definitions/string_or_null"}
+              tolerationSeconds:
+                anyOf: [{type: integer}, {type: 'null'}]
+              value: {"$ref": "#/definitions/string_or_null"}
+            additionalProperties: false
       additionalProperties: false
 
   stacks:


### PR DESCRIPTION
## Description
This adds the ability to set [tolerations] on the instance groups, to be able to do things such as allocating diego-cell pods on separate kubernetes nodes.

Also includes some misc helm template cleanups for readability.  Looking at separate commits is recommended.

Note that I'm doing this under `.Values.sizing`, as `.Values.sizing.*.affinity` is already a thing (even though it makes no sense).  We should add a migration to rename that to `.Values.instance_groups`, I think.

[tolerations]: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/

## Motivation and Context
Fixes #607

## How Has This Been Tested?
Deployed with a toleration:
```yaml
sizing:
  nats:
    tolerations:
    - key: "key"
      operator: "Equal"
      value: "value"
      effect: "NoSchedule"
```
Examined the pod after deployment. (This has no effect, as there are no nodes in my cluster with a taint of `key`.)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
  * This will need to go in kubecf-docs.
