### PR TITLE
Remove the extra nats.service.cf.internal dns alias

### DIFF
--- a/chart/assets/operations/instance_groups/nats.yaml
+++ b/chart/assets/operations/instance_groups/nats.yaml
@@ -1,15 +1,3 @@
-# Add the nats BOSH DNS alias.
-- type: replace
-  path: /addons/name=bosh-dns-aliases/jobs/name=bosh-dns-aliases/properties/aliases/-
-  value:
-    domain: nats.service.cf.internal
-    targets:
-    - deployment: cf
-      domain: bosh
-      instance_group: nats
-      network: default
-      query: '*'
-
 # Add quarks properties.
 - type: replace
   path: /instance_groups/name=nats/jobs/name=nats/properties/quarks?


### PR DESCRIPTION
## Description
The `nats.service.cf.internal` is defined in https://github.com/cloudfoundry/cf-deployment/blob/master/cf-deployment.yml#L320-L326 , but a duplicated alias name is added here: https://github.com/cloudfoundry-incubator/kubecf/blob/master/chart/assets/operations/instance_groups/nats.yaml#L2-L11 , that causes the generated manifest yml file contains two `nats.service.cf.internal` in secret `with-ops` as below:

```
      - domain: nats.service.cf.internal
        targets:
        - deployment: cf
          domain: bosh
          instance_group: nats
          network: default
          query: '*'
      - domain: _.nats.service.cf.internal
        targets:
        - deployment: cf
          domain: bosh
          instance_group: nats
          network: default
          query: _
      - domain: log-cache.service.cf.internal
        targets:
        - deployment: cf
          domain: bosh
          instance_group: log-cache
          network: default
          query: '*'
      - domain: nats.service.cf.internal
        targets:
        - deployment: cf
          domain: bosh
          instance_group: nats
          network: default
          query: '*'
```


## Motivation and Context
Remove the duplicated alias `nats.service.cf.internal`

## How Has This Been Tested?
Smoke test passed

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
