### PR TITLE
fix: Add back v before semver into published artifacts

### DIFF
--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -2001,9 +2001,10 @@ jobs:
         args:
         - -ce
         - |
-          # Revert to original name without the timestamp part
+          # Revert to original name without the timestamp part, then add back `v`
           for file in s3.kubecf-ci*/*.tgz; do
-              new_filename=$(basename $file | sed  's/-[0-9]\+\.tgz/\.tgz/')
+              new_filename=$(basename $file | sed  's/-[0-9]\+\.tgz/\.tgz/' \
+                                            | sed  's/\([0-9]\+\.[0-9]\+\.[0-9]\+\)/v\1/g')
               mv "$file" "output/${new_filename}"
           done
   - task: test-if-file-exists


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Right now, things consuming from GH release artifacts expect artifacts with `v` before the semver.
We have added `v` manually for kubecf-v2.4.0.tgz and kubecf-bundle-v2.4.0.tgz.
This changes the publish job of the concourse pipeline to release artifacts with `v` in it, so we will not need to do it manually on following releases.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This is the easy fix: no need to change consumers of GH releases (kubecf, CAP pipelines, etc) nor docs.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- An important detail to include is the version of the used cf-operator -->

Manually running the sed command.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
