### PR TITLE
fix: replace pull_request trigger with pull_request_target to include forks

### DIFF
--- a/.github/workflows/conventional-commits-lit.yml
+++ b/.github/workflows/conventional-commits-lit.yml
@@ -1,7 +1,12 @@
 name: "Pull Request Semantic Validation"
 
-on: [pull_request]
-
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      
 jobs:
   main:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

Currently, the pull requests from fork repositories are not triggering the title validation GitHub Action.

## Motivation and Context

In August, GitHub [released](https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/) fork support for the GitHub Actions and by replacing the trigger from pull_request to _pull_request_target is now possible to perform pull request title validation through the existent GH action.

## How Has This Been Tested?

Tested on a side project by opening a pull request from a fork repo.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code has security implications.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
