### PR TITLE
fix: Limit disk usage during tests to 60GB also in upgrade job

### DIFF
--- a/.concourse/tasks/upgrade.sh
+++ b/.concourse/tasks/upgrade.sh
@@ -90,7 +90,7 @@ read -r -d '' CONFIG_OVERRIDE <<'EOF' || true
 sizing:
   diego_cell:
     ephemeral_disk:
-      size: 300000
+      size: 60000
 EOF
 export CONFIG_OVERRIDE
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

Analogous to https://github.com/cloudfoundry-incubator/kubecf/pull/1285, for the upgrade job.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We hit the limit on /var/vcap/data grootfs for the node when perfoming upgrades. This solves it.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- An important detail to include is the version of the used cf-operator -->

Manually testing upgrade jobs out of CI. Since this is in ` .concourse/tasks/upgrade.sh` and not a pipeline definition, there's nothing to be flown for the kubecf pipeline.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
