### PR TITLE
fix: missing links in multi_cluster mode

### DIFF
--- a/chart/generate-minions-values.sh
+++ b/chart/generate-minions-values.sh
@@ -2,7 +2,6 @@
 
 scriptname=$(basename "${0}")
 minions_value_file="minions-values.yaml"
-placement_tags='minions-1'
 cp_namespace='kubecf'
 #
 # Usage statement
@@ -14,8 +13,6 @@ usage() {
     echo
     echo "   -o"
     echo "              The output value file name for minions cluster, default is minions-values.yaml"
-    echo "   -t"
-    echo "              The placement tag for minions cluster, default is minions-1"
     echo "   -n"
     echo "              The namespace of KubeCF control plane, default is kubecf"
     echo
@@ -32,10 +29,6 @@ shift
 case $key in
     -o)
     minions_value_file=$1
-    shift
-    ;;
-    -t)
-    placement_tags=$1
     shift
     ;;
     -n)
@@ -83,18 +76,20 @@ loggregator_tls_agent.certificate
 loggregator_tls_agent.private_key
 ssh_proxy_backends_tls.ca
 uaa_ssl.ca
+cf_app_sd_client_tls.ca
+cf_app_sd_client_tls.certificate
+cf_app_sd_client_tls.private_key
+nats_client_cert.ca
+nats_client_cert.certificate
+nats_client_cert.private_key
+network_policy_client.ca
+network_policy_client.certificate
+network_policy_client.private_key
+silk_daemon.ca
+silk_daemon.certificate
+silk_daemon.private_key
 )
 
-function AddPropertiesFun(){
-  cat >>"${minions_value_file}" <<EOF
-properties:
-  diego-cell:
-    rep:
-      diego:
-        rep:
-          placement_tags: ['${placement_tags}']
-EOF
-}
 
 function AddCredentialsFun(){
   echo "credentials:" >> "${minions_value_file}"
@@ -130,24 +125,222 @@ function AddCredentialsFun(){
 function AddFeaturesFun(){
    cat >>"${minions_value_file}" <<EOF 
 features:
-  multiple_cluster_mode:
-    cell_segment:
-      enabled: true
   embedded_database:
     enabled: false
   routing_api:
     enabled: false
   credhub:
     enabled: false
+  multiple_cluster_mode:
+    control_plane:
+      enabled: false
+    cell_segment:
+      enabled: true
+    control_plane_workers:
+      uaa:
+        name: uaa
+        addresses:
 EOF
+    temp_log="temp_log"
+    kubectl get pods -n kubecf -o wide > $temp_log
+    # uaa
+    for ip in `cat $temp_log | grep uaa |awk '{print$6}'`
+    do
+     echo "        - ip: $ip" >> "${minions_value_file}"
+    done
+    
+    # diego-api
+    cat >>"${minions_value_file}" << EOF
+      diego_api:
+        name: diego-api
+        addresses:
+EOF
+    
+    for ip in `cat $temp_log | grep diego-api|awk '{print$6}'`
+    do
+      echo "        - ip: $ip" >> diego_api.yaml
+    done
+    cat diego_api.yaml >> "${minions_value_file}"
+
+    # api
+    cat >>"${minions_value_file}" << EOF
+      api:
+        name: api
+        addresses:
+EOF
+    for ip in `cat $temp_log | grep api |grep -v diego-api|grep -v log-api|awk '{print$6}'`
+    do
+     echo "        - ip: $ip" >> api_vms.yaml
+    done
+    cat api_vms.yaml >> "${minions_value_file}"
+    
+    # singleton_blobstore
+    cat >>"${minions_value_file}" << EOF
+      singleton_blobstore:
+        name: singleton_blobstore
+        addresses:
+EOF
+    for ip in `cat $temp_log | grep singleton-blobstore|awk '{print$6}'`
+    do
+      echo "        - ip: $ip" >> "${minions_value_file}"
+    done
+  
+  nats_password=$(kubectl get secret var-nats-password -n kubecf -o yaml 2> /dev/null | grep "^  password:" | awk '{print $2}' | base64 --decode)
+  
+  #nats
+  for ip in `cat $temp_log | grep nats |awk '{print$6}'`
+  do
+     echo "        - ip: $ip" >> nats_vms.yaml
+  done
+  cat >>"${minions_value_file}" << EOF
+    provider_link_service:
+      nats:
+        secret_name: minion-link-nats
+        service_name: minion-service-nats
+        addresses:
+EOF
+  cat nats_vms.yaml  >> "${minions_value_file}"
+  cat >>"${minions_value_file}" << EOF
+        link:  |
+          ---
+          nats.user: "nats"
+          nats.password: "${nats_password}"
+          nats.hostname: "nats.service.cf.internal"
+          nats.port: 4222
+      nats_tls:
+        secret_name: minion-link-nats-tls
+        service_name: minion-service-nats-tls
+        addresses:
+EOF
+  cat nats_vms.yaml  >> "${minions_value_file}"
+  cat >>"${minions_value_file}" << EOF
+        link:  |
+          ---
+          nats.user: "nats"
+          nats.password: "${nats_password}"
+          nats.hostname: "nats.service.cf.internal"
+          nats.port: 4224
+          nats.cluster_port: 4225
+EOF
+  nats_ca=$(kubectl get secret var-nats-ca -n kubecf -o yaml 2> /dev/null | grep "^  certificate:" | awk '{print $2}' | base64 --decode) 
+  if [ "X${nats_ca}" != "X" ]; then   
+      echo "          nats.external.tls.ca: |" >> "${minions_value_file}"
+      for j in ${nats_ca}; do
+        if [[ "$j" =~ "-----"$ ]] || [ "$j" == "RSA" ] || [ "$j" == "PRIVATE" ]; then
+          ${sed_cmd} "$ s/$/ $j/" "${minions_value_file}"
+        else
+          echo "            $j" >> "${minions_value_file}"
+        fi
+      done
+  else
+      echo "Warning: Not find , please manually update it in credentials part in file ${minions_value_file}."
+  fi
+
+  cat >>"${minions_value_file}" << EOF
+      doppler:
+        secret_name: minion-link-doppler
+        service_name: minion-service-doppler
+        link: |
+          doppler.grpc_port: 8082
+        addresses:
+EOF
+  #doppler
+  for ip in `cat $temp_log | grep doppler |awk '{print$6}'`
+  do
+     echo "        - ip: $ip" >> doppler_vms.yaml
+  done
+  cat doppler_vms.yaml >> "${minions_value_file}"
+  cat >>"${minions_value_file}" << EOF
+      loggregator:
+        secret_name: minion-link-loggregator
+        service_name: minion-service-loggregator
+        addresses:
+EOF
+  cat doppler_vms.yaml >> "${minions_value_file}"
+  cat >>"${minions_value_file}" << EOF
+        link: |
+          metron_endpoint.grpc_port: 3459
+EOF
+
+credentials_list=(
+  loggregator.tls.doppler.ca_cert
+  loggregator.tls.doppler.cert
+  loggregator.tls.doppler.key
+)
+for (( i = 0 ; i < ${#credentials_list[@]} ; i++ )) do
+    credential_type=$(echo "${credentials_list[$i]}" | cut -d "." -f 4 )
+    credential_name=$(echo "${credentials_list[$i]}")
+    if [[ "X${credential_type}" != "X" ]]; then
+      case ${credential_type} in 
+      'ca_cert')
+         type="ca"
+         credential_name="loggregator.tls.ca_cert"
+         ;;
+      'cert')
+         type="certificate"
+         ;;
+      'key')
+         type="private_key"
+         ;;
+       *)
+         echo "credentail type is false"
+         ;;
+       esac
+    fi
+    if [ "X${credential_name}" != "X" ] && [ "X${credential_type}" != "X" ]; then  
+        credential_value=$(kubectl get secret var-loggregator-tls-doppler -n kubecf -o yaml 2> /dev/null | grep "^  ${type}:" | awk '{print $2}' | base64 --decode) 
+        if [ "X${credential_value}" != "X" ]; then   
+            echo "          ${credential_name}: |" >> "${minions_value_file}"
+            for j in ${credential_value}; do
+              if [[ "$j" =~ "-----"$ ]] || [ "$j" == "RSA" ] || [ "$j" == "PRIVATE" ]; then
+                ${sed_cmd} "$ s/$/ $j/" "${minions_value_file}"
+              else
+                echo "            $j" >> "${minions_value_file}"
+              fi
+            done
+        else
+            echo "Warning: Not find , please manually update it in credentials part in file ${minions_value_file}."
+        fi
+    fi
+done
+  
+  # cloud-controller
+  cat >> "${minions_value_file}" << EOF
+      cloud_controller:
+        secret_name: minion-link-cloud-controller
+        service_name: minion-service-cloud-controller
+        link: |
+          system_domain: "{{ .Values.system_domain }}"
+          app_domains: []
+        addresses:
+EOF
+  
+  cat api_vms.yaml  >> "${minions_value_file}"
+
+  # cloud_controller_container_networking_info
+  cat >>"${minions_value_file}" << EOF
+      cloud_controller_container_networking_info:
+        secret_name: minion-link-cloud-controller-container-networking-info
+        service_name: minion-service-cloud-controller-container-networking-info
+        link: |
+          cc.internal_route_vip_range: "127.128.0.0/9"
+        addresses:
+EOF
+  cat api_vms.yaml  >> "${minions_value_file}"
+  
+  #cf-network from diego-api
+  cat >>"${minions_value_file}" << EOF
+      cf_network:
+        secret_name: minion-link-cf-network
+        service_name: minion-service-cf-network
+        link: |
+          network: "10.255.0.0/16"
+          subnet_prefix_length: 24
+        addresses:
+EOF
+  cat diego_api.yaml >> "${minions_value_file}"
 }
 
-#Check placement tag file
-if  [[ -z ${placement_tags} ]]; then
-  echo  "Not find placement tag, please provide one with -t option."
-  usage
-  exit 1
-fi
 
 #Check kubectl command
 if ! hash kubectl 2>/dev/null; then
@@ -182,8 +375,6 @@ else
 fi
 
 #Add required properties, credentials, inline, features into output value file
-echo "add Properties ..."
-AddPropertiesFun
 echo "add Credentials ..."
 AddCredentialsFun
 echo "add Features ..."
@@ -191,3 +382,9 @@ AddFeaturesFun
 
 echo "Complete. Please check output value file ${minions_value_file}."
 
+#clean vm files
+rm -f $temp_log
+rm -f nats_vms.yaml
+rm -f doppler_vms.yaml
+rm -f api_vms.yaml 
+rm -f diego_api.yaml

--- a/chart/templates/multiple_cluster_mode.yaml
+++ b/chart/templates/multiple_cluster_mode.yaml
@@ -63,9 +63,9 @@ data:
       value:
         nats: {from: nats}
         nats-tls: {from: nats-tls}
-{{- if .Values.features.routing_api.enabled }}
+        {{- if .Values.features.routing_api.enabled }}
         routing_api: {from: routing_api}
-{{- end }}{{/* if .Values.features.routing_api.enabled */}}
+        {{- end }}{{/* if .Values.features.routing_api.enabled */}}
     - type: replace
       path: /instance_groups/name=diego-cell/jobs/name=loggr-udp-forwarder/consumes?
       value:
@@ -106,6 +106,7 @@ metadata:
     quarks.cloudfoundry.org/provides: '{"name":"nats-tls","type":"nats-tls"}'
 stringData:
   link: {{- toYaml .Values.features.multiple_cluster_mode.provider_link_service.nats_tls.link | nindent 4 }} 
+{{- if .Values.features.routing_api.enabled }}
 ---
 apiVersion: v1
 kind: Secret
@@ -116,6 +117,7 @@ metadata:
     quarks.cloudfoundry.org/provides: '{"name":"routing_api","type":"routing_api"}'
 stringData:
   link: {{- toYaml .Values.features.multiple_cluster_mode.provider_link_service.routing_api.link | nindent 4 }} 
+{{- end }}
 ---
 apiVersion: v1
 kind: Secret
@@ -148,6 +150,26 @@ stringData:
   link: {{- toYaml .Values.features.multiple_cluster_mode.provider_link_service.cloud_controller.link | nindent 4 }} 
 ---
 apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.features.multiple_cluster_mode.provider_link_service.cf_network.secret_name }} 
+  annotations:
+    quarks.cloudfoundry.org/deployment-name: "{{ include "kubecf.deployment-name" . }}"
+    quarks.cloudfoundry.org/provides: '{"name":"cf_network","type":"cf_network"}'
+stringData:
+  link:  {{- toYaml .Values.features.multiple_cluster_mode.provider_link_service.cf_network.link | nindent 4 }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.features.multiple_cluster_mode.provider_link_service.cloud_controller_container_networking_info.secret_name }} 
+  annotations:
+    quarks.cloudfoundry.org/deployment-name: "{{ include "kubecf.deployment-name" . }}"
+    quarks.cloudfoundry.org/provides: '{"name":"cloud_controller_container_networking_info","type":"cloud_controller_container_networking_info"}'
+stringData:
+  link: {{- toYaml .Values.features.multiple_cluster_mode.provider_link_service.cloud_controller_container_networking_info.link | nindent 4 }}
+---
+apiVersion: v1
 kind: Service
 metadata:
   annotations:
@@ -168,6 +190,7 @@ metadata:
 spec:
   clusterIP: None
   type: ClusterIP
+{{- if .Values.features.routing_api.enabled }}
 ---
 apiVersion: v1
 kind: Service
@@ -179,6 +202,7 @@ metadata:
 spec:
   clusterIP: None
   type: ClusterIP
+{{- end }}
 ---
 apiVersion: v1
 kind: Service
@@ -214,6 +238,28 @@ spec:
   type: ClusterIP
 ---
 apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    quarks.cloudfoundry.org/deployment-name: "{{ include "kubecf.deployment-name" . }}"
+    quarks.cloudfoundry.org/link-provider-name: cloud_controller_container_networking_info
+  name: {{ .Values.features.multiple_cluster_mode.provider_link_service.cloud_controller_container_networking_info.service_name }} 
+spec:
+  clusterIP: None
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    quarks.cloudfoundry.org/deployment-name: "{{ include "kubecf.deployment-name" . }}"
+    quarks.cloudfoundry.org/link-provider-name: cf_network
+  name: {{ .Values.features.multiple_cluster_mode.provider_link_service.cf_network.service_name }} 
+spec:
+  clusterIP: None
+  type: ClusterIP
+---
+apiVersion: v1
 kind: Endpoints
 metadata:
   name: {{ .Values.features.multiple_cluster_mode.provider_link_service.nats.service_name }} 
@@ -232,6 +278,7 @@ subsets:
   {{- range .Values.features.multiple_cluster_mode.provider_link_service.nats_tls.addresses }}
     - ip: {{ .ip }}
   {{- end }}
+{{- if .Values.features.routing_api.enabled }}
 ---
 apiVersion: v1
 kind: Endpoints
@@ -242,6 +289,7 @@ subsets:
   {{- range .Values.features.multiple_cluster_mode.provider_link_service.routing_api.addresses }}
     - ip: {{ .ip }}
   {{- end }}
+{{- end }}
 ---
 apiVersion: v1
 kind: Endpoints
@@ -270,6 +318,26 @@ metadata:
 subsets:
 - addresses:
   {{- range .Values.features.multiple_cluster_mode.provider_link_service.cloud_controller.addresses }}
+    - ip: {{ .ip }}
+  {{- end }}
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: {{ .Values.features.multiple_cluster_mode.provider_link_service.cloud_controller_container_networking_info.service_name }} 
+subsets:
+- addresses:
+  {{- range .Values.features.multiple_cluster_mode.provider_link_service.cloud_controller_container_networking_info.addresses }}
+    - ip: {{ .ip }}
+  {{- end }}
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: {{ .Values.features.multiple_cluster_mode.provider_link_service.cf_network.service_name }} 
+subsets:
+- addresses:
+  {{- range .Values.features.multiple_cluster_mode.provider_link_service.cf_network.addresses }}
     - ip: {{ .ip }}
   {{- end }}
 ---

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -285,7 +285,6 @@ features:
         service_name: minion-service-cloud-controller-container-networking-info
         addresses:
         - ip: ~
-        # To support multi-clusters, fill the provider link secrets context of cloud_controller_container_networking_info, for example:
         # link: |
         #   cc.internal_route_vip_range: "127.128.0.0/9"
         link: ~
@@ -294,7 +293,6 @@ features:
         service_name: minion-service-cf-network
         addresses:
         - ip: ~
-        # To support multi-clusters, fill the provider link secrets context of cf_network, for example:
         # link: |
         #   network: "10.255.0.0/16"
         #   subnet_prefix_length: 24

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -280,6 +280,25 @@ features:
         #   system_domain: "{{ .Values.system_domain }}"
         #   app_domains: []
         link: ~
+      cloud_controller_container_networking_info:
+        secret_name: minion-link-cloud-controller-container-networking-info
+        service_name: minion-service-cloud-controller-container-networking-info
+        addresses:
+        - ip: ~
+        # To support multi-clusters, fill the provider link secrets context of cloud_controller_container_networking_info, for example:
+        # link: |
+        #   cc.internal_route_vip_range: "127.128.0.0/9"
+        link: ~
+      cf_network:
+        secret_name: minion-link-cf-network
+        service_name: minion-service-cf-network
+        addresses:
+        - ip: ~
+        # To support multi-clusters, fill the provider link secrets context of cf_network, for example:
+        # link: |
+        #   network: "10.255.0.0/16"
+        #   subnet_prefix_length: 24
+        link: ~
   ingress:
     enabled: false
     tls:

--- a/doc/multi-cluster.md
+++ b/doc/multi-cluster.md
@@ -13,8 +13,6 @@ usage() {
     echo
     echo "   -o"
     echo "              The output value file name for minions cluster, default is minions-values.yaml"
-    echo "   -t"
-    echo "              The placement tag for minions cluster, default is minions-1"
     echo
     echo "   -h --help  Output this help."
 }
@@ -23,12 +21,10 @@ usage() {
 Run `generate-minions-values.sh` on the host with kubectl targeting to the control plane cluster.
 
 ```
-$ bash generate-minions-values.sh -o test-minions-values.yaml -t test
+$ bash generate-minions-values.sh -o test-minions-values.yaml
 Generating value file for minions cluster ...
 add system_domain ...
-add Properties ...
 add Credentials ...
-add Inline ...
 add Features ...
 Complete. Please check output value file test-minions-values.yaml.
 ```
@@ -36,12 +32,6 @@ Complete. Please check output value file test-minions-values.yaml.
 Part of the output file `test-minions-values.yaml` content as below:
 ```
 system_domain: cluster01-xxxxxxxxx-0000.cloud
-properties:
-  diego-cell:
-    rep:
-      diego:
-        rep:
-          placement_tags: ['test']
 credentials:
   diego_bbs_client.ca: |
     -----BEGIN CERTIFICATE-----


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When deploying kubecf in multi_cluster mode, failed with the error:
```
2020-09-10T06:19:51.473Z	ERROR	boshdeployment-reconciler	boshdeployment/deployment_reconciler.go:121	failed to list quarks-link secrets for BOSHDeployment 'kubecf/kubecf': missing link secrets for providers: cloud_controller_container_networking_info, cf_network
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To fix the missing  link error in multi-cluster mode.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- An important detail to include is the version of the used cf-operator -->

Tested in IBM multi cluster.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
