### PR TITLE
feat: add apps-dns

### DIFF
--- a/bosh/releases/pre_render_scripts/diego-cell/silk-cni/jobs/patch_cni-wrapper-plugin.conflist.sh
+++ b/bosh/releases/pre_render_scripts/diego-cell/silk-cni/jobs/patch_cni-wrapper-plugin.conflist.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o pipefail
+
+target="/var/vcap/all-releases/jobs-src/silk/silk-cni/templates/cni-wrapper-plugin.conflist.erb"
+sentinel="${target}.patch_sentinel"
+if [[ -f "${sentinel}" ]]; then
+  if sha256sum --check "${sentinel}" ; then
+    echo "Patch already applied. Skipping"
+    exit 0
+  fi
+  echo "Sentinel mismatch, re-patching"
+fi
+
+# Resolve DNS Servers passed via the `dns_servers` property if any is a hostname
+# instead of an IP address.
+patch --verbose "${target}" <<'EOT'
+@@ -2,6 +2,7 @@
+ <%=
+   require 'ipaddr'
+   require 'json'
++  require 'resolv'
+ 
+   def compute_mtu
+     vxlan_overhead = 50
+@@ -41,6 +42,14 @@
+     end
+   end
+ 
++  dns_servers = p('dns_servers').map do |dns_server|
++    if !(dns_server =~ Regexp.union([Resolv::IPv4::Regex, Resolv::IPv6::Regex]))
++      Resolv.getaddress dns_server
++    else
++      dns_server
++    end
++  end
++
+   toRender = {
+     'name' => 'cni-wrapper',
+     'cniVersion' => '0.3.1',
+@@ -61,7 +70,7 @@
+       'ingress_tag' => 'ffff0000',
+       'vtep_name' => 'silk-vtep',
+       'policy_agent_force_poll_address' => '127.0.0.1:' + link('vpa').p('force_policy_poll_cycle_port').to_s,
+-      'dns_servers' => p('dns_servers'),
++      'dns_servers' => dns_servers,
+       'host_tcp_services' => p('host_tcp_services'),
+       'host_udp_services' => p('host_udp_services'),
+       'deny_networks' => {
+EOT
+
+sha256sum "${target}" > "${sentinel}"

--- a/chart/assets/operations/instance_groups/acceptance-tests.yaml
+++ b/chart/assets/operations/instance_groups/acceptance-tests.yaml
@@ -25,7 +25,7 @@
           credhub_mode: assisted
           credhub_secret: ((credhub_admin_client_secret))
           {{- end }}
-          include: '+docker,tasks{{ if .Values.features.routing_api.enabled }},tcp_routing{{ end }}'
+          include: '+container_networking,docker,service_discovery,tasks{{ if .Values.features.routing_api.enabled }},tcp_routing{{ end }}'
           skip_ssl_validation: true
           timeout_scale: 3
         bpm:

--- a/chart/assets/operations/instance_groups/diego-cell.yaml
+++ b/chart/assets/operations/instance_groups/diego-cell.yaml
@@ -92,8 +92,25 @@
   path: /instance_groups/name=diego-cell/jobs/name=garden-cni/properties/cni_plugin_dir?
   value: /var/vcap/data/silk-cni/bin
 
-- type: remove
+- type: replace
   path: /instance_groups/name=diego-cell/jobs/name=silk-cni/properties/dns_servers?
+  value:
+  # The bosh-dns.<namespace>.svc gets resolved to the service ClusterIP it points to and then
+  # replaced with its value when rendering the silk-cni configuration file. This functionality is
+  # provided by a patch on a pre-render script.
+  - {{ printf "apps-dns.%s.svc" .Release.Namespace | quote }}
+
+- type: replace
+  path: /variables/name=cf_app_sd_ca/options/common_name
+  value: {{ printf "service-discovery-controller.%s.svc" .Release.Namespace | quote }}
+- type: replace
+  path: /variables/name=cf_app_sd_client_tls/options/common_name
+  value: {{ printf "service-discovery-controller.%s.svc" .Release.Namespace | quote }}
+- type: replace
+  path: /variables/name=cf_app_sd_server_tls/options/common_name
+  value: {{ printf "service-discovery-controller.%s.svc" .Release.Namespace | quote }}
+- type: remove
+  path: /instance_groups/name=diego-cell/jobs/name=bosh-dns-adapter?
 
 # Add quarks properties for garden.
 - type: replace

--- a/chart/config/releases.yaml
+++ b/chart/config/releases.yaml
@@ -14,6 +14,10 @@ releases:
   app-autoscaler:
     condition: features.autoscaler.enabled
     version: 3.0.1
+  apps_dns:
+    image:
+      repository: ghcr.io/cfcontainerizationbot/kubecf-apps-dns
+      tag: 0.1.0
   brain-tests:
     condition: testing.brain_tests.enabled
     version: v0.0.13

--- a/chart/templates/apps_dns.yaml
+++ b/chart/templates/apps_dns.yaml
@@ -1,0 +1,189 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: apps-dns
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app: apps-dns
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: {{ include "kubecf.fullname" . }}
+    app.kubernetes.io/version: {{ default .Chart.Version .Chart.AppVersion | quote }}
+    helm.sh/chart: {{ include "kubecf.chart" . }}
+spec:
+  ports:
+  - name: dns-udp
+    protocol: UDP
+    port: 53
+    targetPort: dns-udp
+  - name: dns-tcp
+    protocol: TCP
+    port: 53
+    targetPort: dns-tcp
+  selector:
+    app: apps-dns
+    app.kubernetes.io/name: {{ include "kubecf.fullname" . }}
+    app.kubernetes.io/version: {{ default .Chart.Version .Chart.AppVersion | quote }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: apps-dns
+  namespace:
+  labels:
+data:
+  Corefile: |-
+    . {
+      errors
+      health
+
+      svcdiscovery {
+        tls_ca_path /tls/ca.pem
+        tls_client_cert_path /tls/cert.pem
+        tls_client_key_path /tls/key.pem
+        sdc_host {{ printf "service-discovery-controller.%s.svc" .Release.Namespace }}
+        sdc_port 8054
+        ttl 300
+      }
+
+      forward . /config/forward.conf
+
+      cache 120
+      loop
+      reload
+      loadbalance
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: apps-dns
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app: apps-dns
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: {{ include "kubecf.fullname" . }}
+    app.kubernetes.io/version: {{ default .Chart.Version .Chart.AppVersion | quote }}
+    helm.sh/chart: {{ include "kubecf.chart" . }}
+spec:
+  {{- if $.Values.sizing.apps_dns.instances }}
+  replicas: {{ $.Values.sizing.apps_dns.instances }}
+  {{- else if $.Values.high_availability }}
+  replicas: 2
+  {{- else }}
+  replicas: 1
+  {{- end }}
+  selector:
+    matchLabels:
+      app: apps-dns
+      app.kubernetes.io/instance: {{ .Release.Name | quote }}
+      app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+      app.kubernetes.io/name: {{ include "kubecf.fullname" . }}
+      app.kubernetes.io/version: {{ default .Chart.Version .Chart.AppVersion | quote }}
+      helm.sh/chart: {{ include "kubecf.chart" . }}
+  template:
+    metadata:
+      labels:
+        app: apps-dns
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        app.kubernetes.io/name: {{ include "kubecf.fullname" . }}
+        app.kubernetes.io/version: {{ default .Chart.Version .Chart.AppVersion | quote }}
+        helm.sh/chart: {{ include "kubecf.chart" . }}
+    spec:
+      {{- if $.Values.sizing.apps_dns.affinity }}
+      affinity: {{ $.Values.sizing.apps_dns.affinity | toJson }}
+      {{- else }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - apps-dns
+              topologyKey: kubernetes.io/hostname
+      {{- end }}
+      volumes:
+      - name: corefile-config
+        configMap:
+          name: apps-dns
+      - name: forward-config
+        emptyDir: {}
+      - name: client-tls
+        secret:
+          secretName: var-cf-app-sd-client-tls
+          items:
+          - key: ca
+            path: ca.pem
+          - key: certificate
+            path: cert.pem
+          - key: private_key
+            path: key.pem
+      initContainers:
+      - name: resolv-writer
+        {{- with $image := $.Values.releases.apps_dns.image }}
+        image: {{ printf "%s:%s" $image.repository $image.tag | quote }}
+        {{- end }}
+        imagePullPolicy: IfNotPresent
+        command: [/resolvwriter]
+        args:
+        - --upstream-dns-host
+        - {{ printf "bosh-dns.%s.svc" .Release.Namespace | quote }}
+        - --out
+        - /config/forward.conf
+        volumeMounts:
+        - name: forward-config
+          mountPath: /config
+      containers:
+      - name: apps-dns
+        {{- with $image := $.Values.releases.apps_dns.image }}
+        image: {{ printf "%s:%s" $image.repository $image.tag | quote }}
+        {{- end }}
+        imagePullPolicy: IfNotPresent
+        args:
+        - -conf
+        - /config/Corefile
+        ports:
+        - containerPort: 53
+          name: dns-udp
+          protocol: UDP
+        - containerPort: 53
+          name: dns-tcp
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /health
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /health
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        volumeMounts:
+        - name: corefile-config
+          mountPath: /config/Corefile
+          subPath: Corefile
+          readOnly: true
+        - name: forward-config
+          mountPath: /config/forward.conf
+          subPath: forward.conf
+          readOnly: true
+        - name: client-tls
+          mountPath: /tls
+          readOnly: true

--- a/chart/templates/service_discovery_controller.yaml
+++ b/chart/templates/service_discovery_controller.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: service-discovery-controller
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app: service-discovery-controller
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: {{ include "kubecf.fullname" . }}
+    app.kubernetes.io/version: {{ default .Chart.Version .Chart.AppVersion | quote }}
+    helm.sh/chart: {{ include "kubecf.chart" . }}
+spec:
+  type: ClusterIP
+  ports:
+  - name: service-discovery-controller
+    port: 8054
+    protocol: TCP
+    targetPort: 8054
+  selector:
+    quarks.cloudfoundry.org/deployment-name: {{ include "kubecf.deployment-name" . }}
+    quarks.cloudfoundry.org/instance-group-name: scheduler

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -83,6 +83,8 @@ sizing:
     instances: ~
   api:
     instances: ~
+  apps_dns:
+    instances: ~
   asactors:
     instances: ~
   asapi:


### PR DESCRIPTION
## Description

Integrates https://github.com/SUSE/kubecf-apps-dns with KubeCF. This enables DNS-based Service Discovery for apps, replacing the `bosh-dns-adapter`.

Fixes https://github.com/cloudfoundry-incubator/kubecf/issues/776.

## Motivation and Context

`bosh-dns-adapter` is not suitable to use with our current CoreDNS-based solution. The approach presented in this PR was initially posted in https://github.com/cloudfoundry-incubator/kubecf/issues/776.

## How Has This Been Tested?

Followed the instructions on https://github.com/cloudfoundry-attic/cf-networking-examples/blob/8e3be5faa135746cfd1e05bc618fe18053eab2b5/docs/c2c-with-service-discovery.md#use-case-1-frontend-connects-to-single-backend.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
