### PR TITLE
fix: eirini-routing: wait for nats

### DIFF
--- a/mixins/eirini/templates/routing.yaml
+++ b/mixins/eirini/templates/routing.yaml
@@ -14,6 +14,8 @@ spec:
     metadata:
       labels:
         name: "eirini-routing"
+      annotations:
+        quarks.cloudfoundry.org/wait-for: '[ "nats" ]'
     spec:
       dnsPolicy: "ClusterFirst"
       serviceAccountName: "eirini-routing"


### PR DESCRIPTION
## Description
Eirini-routing will just crash repeatedly if it can't reach NATS.  So actually annotate that so we can reduce the number of crashes on startup (hopefully to make things run faster since we don't need to restart pods all the time).

## Motivation and Context
My `eirini-routing` pod was crashing a lot on startup.

## How Has This Been Tested?
Deployed with eirini on minikube.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
