### PR TITLE
fix: Adapt pipelines to new path

### DIFF
--- a/.concourse/suse-buildpacks-ci/buildpack-version-bump/config.yaml
+++ b/.concourse/suse-buildpacks-ci/buildpack-version-bump/config.yaml
@@ -5,7 +5,7 @@ build_image_resource_uri: https://github.com/concourse/docker-image-resource
 build_image_resource_branch: master
 kubecf_repo: git@github.com:cloudfoundry-incubator/kubecf.git
 kubecf_branch: master
-kubecf_values: chart/values.yaml
+kubecf_values: chart/config/sle15.yaml
 fissile_linux_s3_bucket: cf-opensusefs2
 stemcell_repository: splatform/fissile-stemcell-sle
 stemcell_versions_bucket: cf-operators

--- a/.concourse/suse-buildpacks-ci/buildpack-version-bump/tasks/create_pr.sh
+++ b/.concourse/suse-buildpacks-ci/buildpack-version-bump/tasks/create_pr.sh
@@ -3,91 +3,14 @@
 # NEVER SET xtrace!
 set -o errexit -o nounset
 
-# Updates release information in values.yaml.
+# Updates release information in sle15.yaml.
 # It looks for a release like:
-#
-# suse-go-buildpack:
-#   url: registry.suse.com/cap-staging
-#   version: "1.9.4.1"
-#   stemcell:
-#     os: SLE_15_SP1
-#     version: 23.1-7.0.0_374.gb8e8e6af
-#   file: suse-go-buildpack/packages/go-buildpack-sle15/go-buildpack-sle15-v1.9.4.1-1.1-436eaf5d.zip
+# stacks:
+#   sle15:
+#     releases:
+#       suse-staticfile-buildpack:
+#         version: "1.5.11"
 
-function update_buildpack_info() {
-
-BUILDPACK_NAME=$1
-KUBECF_VALUES=$2
-BUILT_IMAGE=$3
-NEW_FILE_NAME=$4
-
-PYTHON_CODE=$(cat <<EOF 
-#!/usr/bin/python3
-
-import ruamel.yaml
-import semver
-
-# Adds ~ to the null values to preserve existing structure of values.yaml.
-def represent_none(self, data):
-    return self.represent_scalar(u'tag:yaml.org,2002:null', u'~')
-
-# Replaces the filename at the end of the original 'file'.
-def get_new_filename():
-    # we cant rely on java buildpack package for retrieving filename since its packaging is different.
-    # this bit will take care of inserting sle15 in file name.
-    # see: https://github.com/SUSE/cf-java-buildpack-release/blob/master/packages/java-buildpack-sle15/packaging
-    if "${BUILDPACK_NAME}" == "suse-java-buildpack":
-        new_file_name = "${NEW_FILE_NAME}".split("-")
-        new_file_name.insert(2,"sle15")
-        new_file_name = "-".join(new_file_name)
-    else:
-        new_file_name = "${NEW_FILE_NAME}"
-    new_file = values['releases']["${BUILDPACK_NAME}"]['file'].split("/")[:3]
-    new_file.append(new_file_name)
-    return "/".join(new_file)
-
-def get_semver(s):
-    v = s.split(".")
-    return semver.VersionInfo(*v)
-
-yaml = ruamel.yaml.YAML()
-yaml.preserve_quotes = True
-yaml.representer.add_representer(type(None), represent_none)
-
-# Breaking down the BUILT_IMAGE to retrieve individual values.
-built_image_splitted = "${BUILT_IMAGE}".split("/", 2)
-NEW_URL = "/".join(built_image_splitted[:2])
-built_image_splitted2 = built_image_splitted[-1].split(":")[1].split("-")
-NEW_STEMCELL_OS = built_image_splitted2[0]
-NEW_STEMCELL_VERSION = "-".join(built_image_splitted2[1:3])
-NEW_VERSION = built_image_splitted2[3]
-
-with open("${KUBECF_VALUES}") as fp:
-    values = yaml.load(fp)
-
-new_stemcell_semver = get_semver(built_image_splitted2[1])
-existing_stemcell_semver = get_semver(values['releases']["${BUILDPACK_NAME}"]['stemcell']['version'].split("-")[0])
-
-new_buildpack_version = get_semver(NEW_VERSION)
-existing_buildpack_version = get_semver(values['releases']["${BUILDPACK_NAME}"]['version'])
-
-# Only update if new buildpack version is higher and stemcell version is higher or equal.
-if new_buildpack_version > existing_buildpack_version:
-    if new_stemcell_semver >= existing_stemcell_semver:
-        values['releases']["${BUILDPACK_NAME}"]['url'] = NEW_URL
-        values['releases']["${BUILDPACK_NAME}"]['version'] = NEW_VERSION
-        values['releases']["${BUILDPACK_NAME}"]['stemcell']['os'] = NEW_STEMCELL_OS
-        values['releases']["${BUILDPACK_NAME}"]['stemcell']['version'] = NEW_STEMCELL_VERSION
-        values['releases']["${BUILDPACK_NAME}"]['file'] = get_new_filename()
-
-with open("${KUBECF_VALUES}", 'w') as f:
-    yaml.dump(values, f)
-
-EOF
-)
-
-python3 -c "${PYTHON_CODE}"
-}
 
 if [[ -z "$GITHUB_TOKEN" ]]; then
     echo "GITHUB_TOKEN environment variable not set"
@@ -107,7 +30,7 @@ RELEASE_VERSION=$(cat suse_final_release/version)
 BUILT_IMAGE=$(cat built_image/image)
 NEW_FILE=$(tar -zxOf suse_final_release/*.tgz packages | tar -ztf - | grep zip | cut -d'/' -f3)
 
-COMMIT_TITLE="Bump ${BUILDPACK_NAME} release to ${RELEASE_VERSION}"
+COMMIT_TITLE="feat: Bump ${BUILDPACK_NAME} release to ${RELEASE_VERSION}"
 
 # Update release in kubecf repo
 cp -r kubecf/. updated-kubecf/
@@ -117,7 +40,7 @@ git pull
 GIT_BRANCH_NAME="bump_${BUILDPACK_NAME}-$(date +%Y%m%d%H%M%S)"
 git checkout -b "${GIT_BRANCH_NAME}"
 
-update_buildpack_info "${BUILDPACK_NAME}" "${KUBECF_VALUES}" "${BUILT_IMAGE}" "${NEW_FILE}"
+perl -i -0pe "s/      ${BUILDPACK_NAME}:\n        version: \"[\d.]+\"/      ${BUILDPACK_NAME}:\n        version: \"${RELEASE_VERSION}\"/" ${KUBECF_VALUES}
 
 git commit "${KUBECF_VALUES}" -m "${COMMIT_TITLE}"
 

--- a/.concourse/suse-buildpacks-ci/stemcell-version-bump/config.yaml
+++ b/.concourse/suse-buildpacks-ci/stemcell-version-bump/config.yaml
@@ -5,7 +5,7 @@ build_image_resource_uri: https://github.com/concourse/docker-image-resource
 build_image_resource_branch: master
 kubecf_repo: git@github.com:cloudfoundry-incubator/kubecf.git
 kubecf_branch: master
-kubecf_values: chart/values.yaml
+kubecf_values: chart/config/sle15.yaml
 built_images_file: built_images/images
 fissile_linux_s3_bucket: cf-opensusefs2
 stemcell_repository: splatform/fissile-stemcell-sle

--- a/.concourse/suse-buildpacks-ci/stemcell-version-bump/pipeline.yaml.gomplate
+++ b/.concourse/suse-buildpacks-ci/stemcell-version-bump/pipeline.yaml.gomplate
@@ -51,7 +51,7 @@ jobs:
       privileged: true
       params:
         RELEASES_YAML: ci/.concourse/suse-buildpacks-ci/releases.yaml
-        KUBECF_VALUES_YAML: kubecf/chart/values.yaml
+        KUBECF_VALUES_YAML: kubecf/chart/config/sle15.yaml
       file: ci/.concourse/suse-buildpacks-ci/stemcell-version-bump/tasks/prep.yaml
 
     - task: build

--- a/.concourse/suse-buildpacks-ci/stemcell-version-bump/tasks/prep.sh
+++ b/.concourse/suse-buildpacks-ci/stemcell-version-bump/tasks/prep.sh
@@ -26,7 +26,7 @@ yaml.preserve_quotes = True
 
 with open("${RELEASES_YAML}") as f1, open("${KUBECF_VALUES_YAML}") as f2:
     input_releases = yaml.load(f1)["releases"]
-    values = yaml.load(f2)["releases"]
+    values = yaml.load(f2)["stacks"]["sle15"]["releases"]
 
 output_releases = []
 for release in input_releases:


### PR DESCRIPTION
## Description
The SUSE buildpacks and stemcell information was moved from `values.yaml` to `chart/config/sle15.yaml`. The stemcell and buildpack update pipelines were adapted accordingly.

The replacement is a simple regex to reduce complexity of the pipelines and save time since we might implement #1109 in the nearby future so it is not worth covering every corner case.

Since the stemcell pipeline triggers every time there is a new stemcell I do not think it is necessary to handle different stemcell versions for each buildpack.

## How Has This Been Tested?
The pipelines were updated manually and ran against current master. Since all buildpacks and the stemcell are already up to date there were no changes to commit yet.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
