### PR TITLE
fix: Change services.foo.annotations to {} from ~

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -140,19 +140,19 @@ sizing:
 #  External endpoints are created for the instance groups only if features.ingress.enabled is false.
 services:
   router:
-    annotations: ~
+    annotations: {}
     type: LoadBalancer
     externalIPs: []
     clusterIP: ~
     loadBalancerIP: ~
   ssh-proxy:
-    annotations: ~
+    annotations: {}
     type: LoadBalancer
     externalIPs: []
     clusterIP: ~
     loadBalancerIP: ~
   tcp-router:
-    annotations: ~
+    annotations: {}
     type: LoadBalancer
     externalIPs: []
     clusterIP: ~


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Without this change, setting annotations of `services.foo.annotations` on up to helm 3.3.1 gives the
following warnings on helm install/upgrade:

```
secret/susecf-scf.var-cf-admin-password created
secret/var-cf-admin-password created
coalesce.go:199: warning: destination for annotations is a table. Ignoring non-table value <nil>
coalesce.go:199: warning: destination for annotations is a table. Ignoring non-table value <nil>
coalesce.go:199: warning: destination for annotations is a table. Ignoring non-table value <nil>
coalesce.go:199: warning: destination for annotations is a table. Ignoring non-table value <nil>
coalesce.go:199: warning: destination for annotations is a table. Ignoring non-table value <nil>
coalesce.go:199: warning: destination for annotations is a table. Ignoring non-table value <nil>
```

See:
https://github.com/helm/helm/issues/4514


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Discovered while testing https://github.com/SUSE/catapult/pull/253.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- An important detail to include is the version of the used cf-operator -->

Warnings are present when doing `helm install/upgrade`. Changing `chart/values.yaml`, `helm upgrade` doesn't show the warnings anymore. Reinstanting `annotations: ~` makes the warnings appear again. Annotations are correctly created in any case.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
