### PR TITLE
fix: Actually run CATS with eirini config in CI

### DIFF
--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -967,7 +967,11 @@ jobs:
       - name: kubecf
       - name: semver.gke-cluster
       params:
+        {{- if eq $cfScheduler "eirini" }}
+        KUBECF_TEST_SUITE: cats-eirini
+        {{- else }}
         KUBECF_TEST_SUITE: cats
+        {{- end }}
         BRANCH: {{ $branch | strings.Trunc 12 }}
         CFSCHEDULER: {{ $cfScheduler }}
       run:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Actually run CATS with eirini config in CI. We were using the default config of cats with `KUBECF_TEST_SUITE=cats`.
We should be using `KUBECF_TEST_SUITE=cats-eirini`, which will patch the cats config.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- An important detail to include is the version of the used cf-operator -->

Running locally with `KUBECF_TEST_SUITE=cats-eirini`, and attempting to fly the pipeline (without flying) to see that the change only affects the `cf-acceptance-tests-eirini-*` jobs in concourse.  

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
