### PR TITLE
fix: Fix linting errors in .concourse/suse-buildpacks-ci

### DIFF
--- a/.concourse/suse-buildpacks-ci/buildpack-version-bump/tasks/create_pr.sh
+++ b/.concourse/suse-buildpacks-ci/buildpack-version-bump/tasks/create_pr.sh
@@ -27,8 +27,6 @@ git config --global user.email "$GIT_MAIL"
 git config --global user.name "$GIT_USER"
 
 RELEASE_VERSION=$(cat suse_final_release/version)
-BUILT_IMAGE=$(cat built_image/image)
-NEW_FILE=$(tar -zxOf suse_final_release/*.tgz packages | tar -ztf - | grep zip | cut -d'/' -f3)
 
 COMMIT_TITLE="feat: Bump ${BUILDPACK_NAME} release to ${RELEASE_VERSION}"
 

--- a/.concourse/suse-buildpacks-ci/buildpack-version-bump/tasks/create_pr.sh
+++ b/.concourse/suse-buildpacks-ci/buildpack-version-bump/tasks/create_pr.sh
@@ -38,7 +38,7 @@ git pull
 GIT_BRANCH_NAME="bump_${BUILDPACK_NAME}-$(date +%Y%m%d%H%M%S)"
 git checkout -b "${GIT_BRANCH_NAME}"
 
-perl -i -0pe "s/      ${BUILDPACK_NAME}:\n        version: \"[\d.]+\"/      ${BUILDPACK_NAME}:\n        version: \"${RELEASE_VERSION}\"/" ${KUBECF_VALUES}
+perl -i -0pe "s/      ${BUILDPACK_NAME}:\n        version: \"[\d.]+\"/      ${BUILDPACK_NAME}:\n        version: \"${RELEASE_VERSION}\"/" "${KUBECF_VALUES}"
 
 git commit "${KUBECF_VALUES}" -m "${COMMIT_TITLE}"
 

--- a/.concourse/suse-buildpacks-ci/stemcell-version-bump/tasks/create_pr.sh
+++ b/.concourse/suse-buildpacks-ci/stemcell-version-bump/tasks/create_pr.sh
@@ -27,7 +27,7 @@ chmod 0600 ~/.ssh/id_ecdsa
 git config --global user.email "$GIT_MAIL"
 git config --global user.name "$GIT_USER"
 
-stemcell_version="$(cat s3.stemcell-version/"${STEMCELL_VERSIONED_FILE##*/}" | cut -d- -f2)"
+stemcell_version="$(cut -d- -f2 < s3.stemcell-version/"${STEMCELL_VERSIONED_FILE##*/}" )"
 COMMIT_TITLE="feat: Bump stemcell version for SUSE buildpacks to ${stemcell_version}"
 
 # Update release in kubecf repo

--- a/.concourse/suse-buildpacks-ci/stemcell-version-bump/tasks/create_pr.sh
+++ b/.concourse/suse-buildpacks-ci/stemcell-version-bump/tasks/create_pr.sh
@@ -30,8 +30,6 @@ git config --global user.name "$GIT_USER"
 stemcell_version="$(cat s3.stemcell-version/"${STEMCELL_VERSIONED_FILE##*/}" | cut -d- -f2)"
 COMMIT_TITLE="feat: Bump stemcell version for SUSE buildpacks to ${stemcell_version}"
 
-images_dir=$(pwd)/"${BUILT_IMAGES}"
-
 # Update release in kubecf repo
 cp -r kubecf/. updated-kubecf/
 cd updated-kubecf

--- a/.concourse/suse-buildpacks-ci/stemcell-version-bump/tasks/create_pr.sh
+++ b/.concourse/suse-buildpacks-ci/stemcell-version-bump/tasks/create_pr.sh
@@ -38,7 +38,7 @@ git pull
 GIT_BRANCH_NAME="bump_${stemcell_version}-$(date +%Y%m%d%H%M%S)"
 git checkout -b "${GIT_BRANCH_NAME}"
 
-perl -i -0pe "s/        stemcell:\n          version: \"\d+\.\d+\"/        stemcell:\n          version: \"${stemcell_version}\"/" ${KUBECF_VALUES}
+perl -i -0pe "s/        stemcell:\n          version: \"\d+\.\d+\"/        stemcell:\n          version: \"${stemcell_version}\"/" "${KUBECF_VALUES}"
 
 git commit "${KUBECF_VALUES}" -m "${COMMIT_TITLE}"
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Fix shellcheck lint errors in __.concourse/suse-buildpacks-ci/__


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Appears to have been introduced in https://github.com/cloudfoundry-incubator/kubecf/pull/1315

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- An important detail to include is the version of the used cf-operator -->

I've run `make lint` locally, but I haven't tested nor flown the changes to the pipelines.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
