### PR TITLE
fix: apps-dns: change certs when using eirini

### DIFF
--- a/chart/assets/operations/instance_groups/diego-cell.yaml
+++ b/chart/assets/operations/instance_groups/diego-cell.yaml
@@ -100,15 +100,6 @@
   # provided by a patch on a pre-render script.
   - {{ printf "apps-dns.%s.svc" .Release.Namespace | quote }}
 
-- type: replace
-  path: /variables/name=cf_app_sd_ca/options/common_name
-  value: {{ printf "service-discovery-controller.%s.svc" .Release.Namespace | quote }}
-- type: replace
-  path: /variables/name=cf_app_sd_client_tls/options/common_name
-  value: {{ printf "service-discovery-controller.%s.svc" .Release.Namespace | quote }}
-- type: replace
-  path: /variables/name=cf_app_sd_server_tls/options/common_name
-  value: {{ printf "service-discovery-controller.%s.svc" .Release.Namespace | quote }}
 - type: remove
   path: /instance_groups/name=diego-cell/jobs/name=bosh-dns-adapter?
 

--- a/chart/assets/operations/instance_groups/scheduler.yaml
+++ b/chart/assets/operations/instance_groups/scheduler.yaml
@@ -27,6 +27,16 @@
   path: /instance_groups/name=scheduler/jobs/name=statsd_injector/properties/quarks?/run/healthcheck/statsd_injector/readiness/exec/command
   value: ["/bin/sh", "-c", "ss -nlu src localhost:8125 | grep :8125"]
 
+- type: replace
+  path: /variables/name=cf_app_sd_ca/options/alternative_names?/-
+  value: {{ printf "service-discovery-controller.%s.svc" .Release.Namespace | quote }}
+- type: replace
+  path: /variables/name=cf_app_sd_client_tls/options/alternative_names?/-
+  value: {{ printf "service-discovery-controller.%s.svc" .Release.Namespace | quote }}
+- type: replace
+  path: /variables/name=cf_app_sd_server_tls/options/alternative_names?/-
+  value: {{ printf "service-discovery-controller.%s.svc" .Release.Namespace | quote }}
+
 {{- if not .Values.features.eirini.enabled }}
 
 - type: replace


### PR DESCRIPTION
## Description
In order to support apps DNS, we changed the TLS certificate host name for the service discovery controller.  However, we need to move it to a place where it's used for Eirini as well; move it to the scheduler group (where the service discovery controller lives) instead.

## Motivation and Context
Eirini apps failed to deploy, because we couldn't upload to the blobstore (on account of DNS being hosed).

## How Has This Been Tested?
Deployed apps on eirini.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
