### PR TITLE
feat: Configurable database seeder connection timeout

### DIFF
--- a/chart/assets/scripts/jobs/pxc/seeder.sh
+++ b/chart/assets/scripts/jobs/pxc/seeder.sh
@@ -10,7 +10,7 @@ password=${DATABASE_ROOT_PASSWORD}
 EOF
 
 echo "Waiting for database to be ready..."
-until echo "SELECT 'Ready!'" | mysql --connect-timeout=3 1> /dev/null 2> /dev/null; do
+until echo "SELECT 'Ready!'" | mysql --connect-timeout="${DATABASE_CONNECT_TIMEOUT}" 1> /dev/null 2> /dev/null; do
   sleep 1
 done
 

--- a/chart/templates/database.yaml
+++ b/chart/templates/database.yaml
@@ -403,6 +403,8 @@ spec:
                   key: password
             - name: DATABASE_HOST
               value: {{ printf "database.%s" .Release.Namespace | quote }}
+            - name: DATABASE_CONNECT_TIMEOUT
+              value: {{ $.Values.features.embedded_database.connect_timeout | quote }}
             - name: CHARACTER_SET
               value: utf8
             - name: COLLATE

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -313,6 +313,8 @@ features:
     # https://kubecf.suse.dev/docs/getting-started/kubernetes-deploy/#external-database for details.
     # See also features.external_database.
     enabled: true
+    # Number of seconds to wait for the database to be ready, per iteration of the waiter loop
+    connect_timeout: 3
   blobstore:
     # Possible values for provider: singleton and s3.
     provider: singleton


### PR DESCRIPTION
## Description

  - Added timeout to `values.yaml`. Already handled by the schema, generically.
  - Added templating to database, propagating the data in the `values.yaml` into the pod environment.
  - Extended the seeder script to use the value from the environment.

## Motivation and Context

#1191 

:warning: On looking at the modified code I am not sure why a configurable timeout is needed. The command where the timeout applies is wrapped into a loop which repeats forever until the database is ready. Regardless of timeout used AFAICT.

As such I am not sure of the original diagnosis in #1191 :warning:

## How Has This Been Tested?

Used a minikube to deploy kubecf, with the new key set to

```
features:
  embedded_database:
    connect_timeout: 10
```

and inspected the generated kube object to verify that

  - It contains the value in the proper/new environment variable.
  - The inlined script properly used the new environment variable.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
