### PR TITLE
fix: chart: public svcs: don't select on version

### DIFF
--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -118,7 +118,6 @@ spec:
   selector:
     app.kubernetes.io/component: router
     app.kubernetes.io/instance: {{ $root.Release.Name | quote }}
-    app.kubernetes.io/version: {{ default $root.Chart.Version $root.Chart.AppVersion | quote }}
   ports:
   - name: http
     protocol: TCP
@@ -162,7 +161,6 @@ spec:
   selector:
     app.kubernetes.io/component: ssh-proxy
     app.kubernetes.io/instance: {{ $root.Release.Name | quote }}
-    app.kubernetes.io/version: {{ default $root.Chart.Version $root.Chart.AppVersion | quote }}
   ports:
   - name: ssh
     protocol: TCP
@@ -202,7 +200,6 @@ spec:
   selector:
     app.kubernetes.io/component: tcp-router
     app.kubernetes.io/instance: {{ $root.Release.Name | quote }}
-    app.kubernetes.io/version: {{ default $root.Chart.Version $root.Chart.AppVersion | quote }}
   ports:
   - name: healthcheck
     protocol: TCP


### PR DESCRIPTION
## Description
In the public services (used when we're not using ingress), don't have a version label in the selector when finding backends.  This is necessary to ensure that, during upgrades, we can select for whichever pod happens to be running at the time (including the old version).  Otherwise we'll unnecessarily introduce downtime as we refuse to connect to the perfectly fine pods (from the previous version).

The same logic also applies to downgrades (where the working pods are from a newer version).

## Motivation and Context
For https://github.com/cloudfoundry-incubator/kubecf/issues/1257 - but this might not fix the whole thing (as the database is still not properly HA).

## How Has This Been Tested?
Deployed locally on a HA cluster.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
