### PR TITLE
fix: bump loggregator-bridge version

### DIFF
--- a/mixins/eirinix/config/eirinix.yaml
+++ b/mixins/eirinix/config/eirinix.yaml
@@ -3,7 +3,7 @@ eirinix:
     replicaCount: 1
     image:
       repository: splatform
-      tag: v0.0.0-0.g2c55fd6
+      tag: v0.0.0-0.g91156e8
       pullPolicy: IfNotPresent
     resources: {}
     nodeSelector: {}

--- a/mixins/eirinix/templates/loggregator-bridge.yaml
+++ b/mixins/eirinix/templates/loggregator-bridge.yaml
@@ -48,6 +48,14 @@ spec:
             value: {{ .Values.eirini.opi.namespace }}
           - name: LOGGREGATOR_ENDPOINT
             value: {{ index .Values.eirinix "loggregator-bridge" "endpoint" }}
+          - name: OPERATOR_SERVICE_NAME
+            value: eirinix-{{ $component }}
+          - name: OPERATOR_WEBHOOK_NAMESPACE
+            value: {{ .Release.Namespace | quote }}
+          - name: OPERATOR_WEBHOOK_HOST
+            value: "0.0.0.0"
+          - name: OPERATOR_WEBHOOK_PORT
+            value: "8443"
           volumeMounts:
           - name: loggregator-ca
             mountPath: /run/secrets/loggregator-ca
@@ -80,4 +88,20 @@ spec:
       tolerations:
         {{- toYaml .tolerations | nindent 8 }}
     {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: eirinix-{{ $component }}
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: {{ include "eirinix.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: {{ $component }}
+  ports:
+  - protocol: TCP
+    name: https
+    port: 8443
 {{- end }}


### PR DESCRIPTION
Should fix https://github.com/cloudfoundry-incubator/kubecf/issues/923 . As now the loggregator-bridge ships an extension, adding the related services/options.

## Description


## Motivation and Context
https://github.com/cloudfoundry-incubator/kubecf/issues/923

## How Has This Been Tested?
Locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
