### PR TITLE
fix: Bump catapult on Concourse CI to consume cf-o upgrade

### DIFF
--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -120,7 +120,7 @@ resources:
   source:
     uri: https://github.com/SUSE/catapult
   version:
-    ref: 53d070314a3351aff3fcd74c5ea6bf844f3ccbb4
+    ref: 6786ef6e0c44e50e7960200dd472639d03ed3091
 
 - name: s3.kubecf-ci
   type: s3


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This consumes catapult's changes to upgrade cf-operator too on kubecf-upgrade
target. Which means this may fix the upgrade job.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

To fix the upgrade job.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- An important detail to include is the version of the used cf-operator -->

Deployed several times, and upgraded successfully from 2.4.0 to current master with this catapult commit. I've

With current master I can't reproduce, but in the past, after upgrading `cf-operator`, the `cc-deployment-updater` of the scheduler pod gets stuck not ready. On the deployment-updater I get `DatabaseDisconnectError (…) Mysql2::Error: WSREP has not yet prepared node for application use`.
Nevertheless, this change needs to go in.

Compared catapult's history between the previously pinned hash and this one, no additional changes needed to CI.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
