### PR TITLE
fix: Bumped db liveness initial delay to 5 minutes.

### DIFF
--- a/chart/templates/database.yaml
+++ b/chart/templates/database.yaml
@@ -295,7 +295,7 @@ spec:
                   - "/bin/bash"
                   - "-c"
                   - "mysqladmin ping || test -e /var/lib/mysql/sst_in_progress"
-              initialDelaySeconds: 30
+              initialDelaySeconds: 300
               timeoutSeconds: 2
             readinessProbe:
               exec:


### PR DESCRIPTION
## Description

Start of liveness checks is delayed longer to give the database (in resource-constrained environments) the time to come up properly instead of getting killed by kube as not-live.

## Motivation and Context

See #1128 

## How Has This Been Tested?

Reproduction of the original issue on a minikube was only semi-successful. 
It was necessary to set `initialDelaySecond: 1`, `timeoutSeconds: 1`, and `failureThreshold: 1` to get a deployment where the database was restarted a few times instead of getting up smoothly. Even then the environment was good enough to recover and get the pod fully started.

That said, even with this limited reproduction it is clear that bumping the `initialDelaySeconds` should have a positive effect in more constrained environments.

Conversely it is recommend that a person who had the original issue reviews and verifies the change.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
