### PR TITLE
fix: loggr-udp-forwarder  incorrect 'INDEX' and 'IP' environment

### DIFF
--- a/chart/assets/operations/instance_groups/api.yaml
+++ b/chart/assets/operations/instance_groups/api.yaml
@@ -228,8 +228,19 @@
       # routes are healthy
 
 - type: replace
-  path: /instance_groups/name=api/jobs/name=loggr-udp-forwarder/properties/quarks?/run/healthcheck/loggr-udp-forwarder/readiness/exec/command
-  value: ["sh", "-c", "ss -nlu sport = 3457 | grep :3457"]
+  path: /instance_groups/name=api/jobs/name=loggr-udp-forwarder/properties/quarks?
+  value:
+    run:
+      healthcheck:
+        loggr-udp-forwarder:
+          readiness:
+            exec:
+              command: ["sh", "-c", "ss -nlu sport = 3457 | grep :3457"]
+    envs:
+    - name: INDEX
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.labels['statefulset.kubernetes.io/pod-name']
 
 {{- range $path, $bytes := .Files.Glob "assets/operations/pre_render_scripts/api_*" }}
 {{ $bytes | toString }}

--- a/chart/assets/operations/instance_groups/api.yaml
+++ b/chart/assets/operations/instance_groups/api.yaml
@@ -241,6 +241,10 @@
       valueFrom:
         fieldRef:
           fieldPath: metadata.labels['statefulset.kubernetes.io/pod-name']
+    - name: IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.podIP
 
 {{- range $path, $bytes := .Files.Glob "assets/operations/pre_render_scripts/api_*" }}
 {{ $bytes | toString }}

--- a/chart/assets/operations/instance_groups/diego-api.yaml
+++ b/chart/assets/operations/instance_groups/diego-api.yaml
@@ -70,6 +70,14 @@
   path: /instance_groups/name=diego-api/jobs/name=cfdot/properties/quarks?/bpm/processes
   value: []
 
+- type: replace
+  path: /instance_groups/name=diego-api/jobs/name=loggr-udp-forwarder/properties?/quarks/envs
+  value:
+  - name: INDEX
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.labels['statefulset.kubernetes.io/pod-name']
+
 {{- range $bytes := .Files.Glob "assets/operations/pre_render_scripts/diego-api_*" }}
 {{ $bytes | toString }}
 {{- end }}

--- a/chart/assets/operations/instance_groups/diego-api.yaml
+++ b/chart/assets/operations/instance_groups/diego-api.yaml
@@ -77,6 +77,10 @@
     valueFrom:
       fieldRef:
         fieldPath: metadata.labels['statefulset.kubernetes.io/pod-name']
+  - name: IP
+    valueFrom:
+      fieldRef:
+        fieldPath: status.podIP
 
 {{- range $bytes := .Files.Glob "assets/operations/pre_render_scripts/diego-api_*" }}
 {{ $bytes | toString }}

--- a/chart/assets/operations/instance_groups/router.yaml
+++ b/chart/assets/operations/instance_groups/router.yaml
@@ -40,6 +40,10 @@
       valueFrom:
         fieldRef:
           fieldPath: metadata.labels['statefulset.kubernetes.io/pod-name']
+    - name: IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.podIP
 
 # Add necessary labels to the router instance group so that the service can select it to create the
 # endpoint.

--- a/chart/assets/operations/instance_groups/router.yaml
+++ b/chart/assets/operations/instance_groups/router.yaml
@@ -27,11 +27,19 @@
   value: false
 
 - type: replace
-  path: /instance_groups/name=router/jobs/name=loggr-udp-forwarder/properties/quarks?/run/healthcheck/loggr-udp-forwarder
+  path: /instance_groups/name=router/jobs/name=loggr-udp-forwarder/properties/quarks?
   value:
-    readiness:
-      exec:
-        command: ["sh", "-c", "ss -nlu sport = 3457 | grep :3457"]
+    run:
+      healthcheck:
+        loggr-udp-forwarder:
+          readiness:
+            exec:
+              command: ["sh", "-c", "ss -nlu sport = 3457 | grep :3457"]
+    envs:
+    - name: INDEX
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.labels['statefulset.kubernetes.io/pod-name']
 
 # Add necessary labels to the router instance group so that the service can select it to create the
 # endpoint.

--- a/chart/assets/operations/instance_groups/scheduler.yaml
+++ b/chart/assets/operations/instance_groups/scheduler.yaml
@@ -93,6 +93,10 @@
     valueFrom:
       fieldRef:
         fieldPath: metadata.labels['statefulset.kubernetes.io/pod-name']
+  - name: IP
+    valueFrom:
+      fieldRef:
+        fieldPath: status.podIP
 
 {{- if not .Values.features.eirini.enabled }}
 

--- a/chart/assets/operations/instance_groups/scheduler.yaml
+++ b/chart/assets/operations/instance_groups/scheduler.yaml
@@ -86,6 +86,14 @@
   path: /instance_groups/name=scheduler/jobs/name=cfdot/properties/quarks?/bpm/processes
   value: []
 
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=loggr-udp-forwarder/properties?/quarks/envs
+  value:
+  - name: INDEX
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.labels['statefulset.kubernetes.io/pod-name']
+
 {{- if not .Values.features.eirini.enabled }}
 
 {{- range $bytes := .Files.Glob "assets/operations/pre_render_scripts/scheduler_*" }}

--- a/chart/assets/operations/instance_groups/tcp-router.yaml
+++ b/chart/assets/operations/instance_groups/tcp-router.yaml
@@ -45,6 +45,10 @@
     valueFrom:
       fieldRef:
         fieldPath: metadata.labels['statefulset.kubernetes.io/pod-name']
+  - name: IP
+    valueFrom:
+      fieldRef:
+        fieldPath: status.podIP
 
 {{- else }}
 # Disable the tcp-router ig, as there will be no routing-api SSE events to read from.

--- a/chart/assets/operations/instance_groups/tcp-router.yaml
+++ b/chart/assets/operations/instance_groups/tcp-router.yaml
@@ -37,6 +37,15 @@
 - type: replace
   path: /instance_groups/name=tcp-router/env?/bosh/agent/settings/labels/app.kubernetes.io~1version
   value: {{ default .Chart.Version .Chart.AppVersion | quote }}
+
+- type: replace
+  path: /instance_groups/name=tcp-router/jobs/name=loggr-udp-forwarder/properties?/quarks/envs
+  value:
+  - name: INDEX
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.labels['statefulset.kubernetes.io/pod-name']
+
 {{- else }}
 # Disable the tcp-router ig, as there will be no routing-api SSE events to read from.
 - type: remove


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description


## Motivation and Context
fix the loggr-udp-forwarder incorrect INDEX issue.
https://github.com/cloudfoundry-incubator/kubecf/issues/1337

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Environment
cf-operator: 5.2.0
kubecf: v2.2.3

<!--- Include details of your testing environment, and the tests you ran to -->
apply the fix code and deploy kubecf with multi_az="true"(2 azs) and instance=1.
after all pod up and running,
check container loggr-udp-forwarder-loggr-udp-forwarder's environemnt INDEX and IP.
for example:
```
$ k exec -it scheduler-z1-0 -n kubecf -c loggr-udp-forwarder-loggr-udp-forwarder  sh
sh-4.4# printenv |grep INDEX
AZ_INDEX=2
INDEX=scheduler-z1-0
sh-4.4# printenv |grep IP
IP=x.168.119.18

```
<!--- An important detail to include is the version of the used cf-operator -->
cf-operator: 5.2.0

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
