### PR TITLE
fix: Fix Concourse upgrade job by changing disk size and upgrading cf-o

### DIFF
--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -217,7 +217,7 @@ deploy_args: &deploy_args
   sizing:
     diego_cell:
       ephemeral_disk:
-        size: 60000
+        size: 40000
   EOF
   export CONFIG_OVERRIDE
 

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -120,7 +120,7 @@ resources:
   source:
     uri: https://github.com/SUSE/catapult
   version:
-    ref: 53d070314a3351aff3fcd74c5ea6bf844f3ccbb4
+    ref: 6786ef6e0c44e50e7960200dd472639d03ed3091
 
 - name: s3.kubecf-ci
   type: s3

--- a/.concourse/tasks/upgrade.sh
+++ b/.concourse/tasks/upgrade.sh
@@ -90,7 +90,7 @@ read -r -d '' CONFIG_OVERRIDE <<'EOF' || true
 sizing:
   diego_cell:
     ephemeral_disk:
-      size: 60000
+      size: 40000
 EOF
 export CONFIG_OVERRIDE
 

--- a/.concourse/tasks/upgrade.sh
+++ b/.concourse/tasks/upgrade.sh
@@ -124,3 +124,4 @@ export SCF_CHART
 
 make kubecf-chart
 make kubecf-upgrade
+KUBECF_TEST_SUITE=smokes make tests-kubecf


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Limit diego-cell's ephemeral_disk to 40000 in CI.
Consume catapult's changes to upgrade cf-operator too on kubecf-upgrade.
Validate a kubecf upgrade by running smokes afterwards in Concourse's upgrade job.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

To fix the upgrade job.

Amalgamates:
https://github.com/cloudfoundry-incubator/kubecf/pull/1335
https://github.com/cloudfoundry-incubator/kubecf/pull/1332

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- An important detail to include is the version of the used cf-operator -->

Tested successfully in job https://concourse.suse.dev/teams/main/pipelines/kubecf-viccuad/jobs/upgrade-test-limit-disk-usage-ci/builds/6 .
Compared catapult's history between the previously pinned hash and this one, no additional changes needed to CI.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
