### PR TITLE
feat: QuarksJob to rotate all secrets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,13 @@ version:
 update-subcharts:
 	@./scripts/update-subcharts.sh
 
-lint: shellcheck yamllint helmlint httplint
+lint: shellcheck yamllint helmlint httplint rubocop
 
 helmlint:
 	@./scripts/helmlint.sh
+
+rubocop:
+	@./scripts/rubocop.sh
 
 shellcheck:
 	@./scripts/shellcheck.sh
@@ -26,6 +29,7 @@ yamllint:
 
 test:
 	./tests/config.sh
+	./tests/rspec.sh
 
 .PHONY: httplint
 httplint:

--- a/chart/assets/scripts/helm/secret-rotation/rotate-secrets.rb
+++ b/chart/assets/scripts/helm/secret-rotation/rotate-secrets.rb
@@ -1,0 +1,98 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# This script is used to generate a ConfigMap to rotate all secrets in the
+# deployment.
+
+require 'English'
+require 'kubeclient'
+require 'json'
+require 'open3'
+require 'time'
+require 'yaml'
+
+# SecretRotator will rotate all quarks secrets for the current deployment
+class SecretRotator
+  # Path to the Kubernetes API server CA certificate
+  CA_CERT_PATH = '/var/run/secrets/kubernetes.io/serviceaccount/ca.crt'
+
+  # Path to the Kubernetes service account token
+  TOKEN_PATH = '/var/run/secrets/kubernetes.io/serviceaccount/token'
+
+  # HTTP status code when a resource already exists
+  HTTP_STATUS_CONFLICT = 409
+
+  # The namespace the QuarksSecrets is in, and the same to create the ConfigMap
+  def namespace
+    @namespace ||= ENV['NAMESPACE'] || raise('NAMESPACE not set')
+  end
+
+  # The BOSHDeployment name
+  def deployment
+    @deployment ||= ENV['DEPLOYMENT'] || raise('DEPLOYMENT not set')
+  end
+
+  # Authentication options to create a Kubernetes client
+  def auth_options
+    { bearer_token_file: TOKEN_PATH }
+  end
+
+  # SSL options to create a Kubernetes client
+  def ssl_options
+    @ssl_options ||= {}.tap do |options|
+      options[:ca_file] = CA_CERT_PATH if File.exist? CA_CERT_PATH
+    end
+  end
+
+  # Kubernetes client to access default APIs
+  def client
+    @client ||= Kubeclient::Client.new(
+      'https://kubernetes.default.svc',
+      'v1',
+      auth_options: auth_options,
+      ssl_options: ssl_options
+    )
+  end
+
+  # Kubernetes client to access Quarks APIs
+  def quarks_client
+    @quarks_client ||= Kubeclient::Client.new(
+      'https://kubernetes.default.svc/apis/quarks.cloudfoundry.org',
+      'v1alpha1',
+      auth_options: auth_options,
+      ssl_options: ssl_options
+    )
+  end
+
+  # The selector used to find interesting secrets
+  def secret_selector
+    "quarks.cloudfoundry.org/deployment-name=#{deployment}"
+  end
+
+  # The names of the QuarksSecrets to rotate
+  def secrets
+    quarks_client
+      .get_quarks_secrets(namespace: namespace, selector: secret_selector)
+      .map { |secret| secret.metadata.name }
+  end
+
+  # The ConfigMap resource to be created
+  def configmap
+    @configmap ||= Kubeclient::Resource.new(
+      metadata: {
+        namespace: namespace,
+        # Set a unique-ish name to help running this multiple times
+        name: "rotate.all-secrets-#{Time.now.to_i}",
+        labels: { 'quarks.cloudfoundry.org/secret-rotation': 'true' }
+      },
+      data: { secrets: secrets.to_json }
+    )
+  end
+
+  # Trigger rotation of all QuarksSecrets
+  def rotate
+    client.create_config_map configmap
+  end
+end
+
+SecretRotator.new.rotate if $PROGRAM_NAME == __FILE__

--- a/chart/assets/scripts/helm/secret-rotation/rotate-secrets_spec.rb
+++ b/chart/assets/scripts/helm/secret-rotation/rotate-secrets_spec.rb
@@ -1,0 +1,131 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative 'rotate-secrets'
+
+RSpec.describe(SecretRotator) do
+  def instance
+    @instance ||= described_class.new
+  end
+
+  before :each do
+    # Default to having a good setup
+    allow(ENV).to receive(:[]).with('NAMESPACE').and_return 'namespace'
+    allow(ENV).to receive(:[]).with('DEPLOYMENT').and_return 'deployment'
+    allow(File).to receive(:exist?).with(described_class::CA_CERT_PATH).and_return true
+  end
+
+  describe '#namespace' do
+    it 'returns the namespace' do
+      expect(ENV).to receive(:[]).with('NAMESPACE').and_return 'ns'
+      expect(instance.namespace).to eq 'ns'
+    end
+
+    it 'errors out if namespace is not set' do
+      expect(ENV).to receive(:[]).with('NAMESPACE').and_return nil
+      expect { instance.namespace }.to raise_error(/NAMESPACE not set/)
+    end
+  end
+
+  describe '#deployment' do
+    it 'returns the deployment name' do
+      expect(ENV).to receive(:[]).with('DEPLOYMENT').and_return 'dp'
+      expect(instance.deployment).to eq 'dp'
+    end
+
+    it 'errors out if deployment name is not set' do
+      expect(ENV).to receive(:[]).with('DEPLOYMENT').and_return nil
+      expect { instance.deployment }.to raise_error(/DEPLOYMENT not set/)
+    end
+  end
+
+  describe '#ssl_options' do
+    it 'returns empty options if the CA cert is missing' do
+      allow(File).to receive(:exist?).with(described_class::CA_CERT_PATH).and_return false
+      expect(instance.ssl_options).to be_empty
+    end
+
+    it 'returns options with the CA cert path' do
+      expect(instance.ssl_options).to eq(ca_file: described_class::CA_CERT_PATH)
+    end
+  end
+
+  describe '#client' do
+    it 'creates a Kubernetes client' do
+      expected_client = {}
+      expect(Kubeclient::Client).to receive(:new).with(
+        'https://kubernetes.default.svc',
+        'v1',
+        auth_options: { bearer_token_file: described_class::TOKEN_PATH },
+        ssl_options: { ca_file: described_class::CA_CERT_PATH }
+      ).once.and_return expected_client
+      expect(instance.client).to be expected_client
+
+      # call it again should not ask for a new client
+      expect(instance.client).to be expected_client
+    end
+  end
+
+  describe '#quarks_client' do
+    it 'creates a Kubernetes client' do
+      expected_client = {}
+      expect(Kubeclient::Client).to receive(:new).with(
+        'https://kubernetes.default.svc/apis/quarks.cloudfoundry.org',
+        'v1alpha1',
+        auth_options: { bearer_token_file: described_class::TOKEN_PATH },
+        ssl_options: { ca_file: described_class::CA_CERT_PATH }
+      ).once.and_return expected_client
+      expect(instance.quarks_client).to be expected_client
+
+      # call it again should not ask for a new client
+      expect(instance.quarks_client).to be expected_client
+    end
+  end
+
+  describe '#secrets' do
+    it 'returns the QuarksSecret names' do
+      expected_names = %w[one two three]
+      secrets = expected_names.map do |name|
+        double('QuarksSecret').tap do |secret|
+          expect(secret).to receive_message_chain(:metadata, :name).and_return name
+        end
+      end
+
+      expect(instance)
+        .to receive_message_chain(:quarks_client, :get_quarks_secrets)
+        .with(
+          namespace: 'namespace',
+          selector: 'quarks.cloudfoundry.org/deployment-name=deployment'
+        )
+        .and_return(secrets)
+
+      expect(instance.secrets).to eq expected_names
+    end
+  end
+
+  describe '#configmap' do
+    it 'returns the desired config map' do
+      expect(instance).to receive(:secrets).and_return %w[one two]
+      allow(Time).to receive(:now).and_return 123
+      expect(instance.configmap.to_h).to eq(
+        metadata: {
+          namespace: 'namespace',
+          name: 'rotate.all-secrets-123',
+          labels: { 'quarks.cloudfoundry.org/secret-rotation': 'true' }
+        },
+        data: { secrets: %w[one two].to_json }
+      )
+    end
+  end
+
+  describe '#rotate' do
+    it 'attempts to create a config map' do
+      configmap = {}
+      expect(instance).to receive(:configmap).and_return configmap
+      expect(instance)
+        .to receive_message_chain(:client, :create_config_map)
+        .with(be(configmap))
+      instance.rotate
+    end
+  end
+end

--- a/chart/config/releases.yaml
+++ b/chart/config/releases.yaml
@@ -48,6 +48,11 @@ releases:
   postgres:
     condition: features.autoscaler.enabled
     version: "39"
+  secret-rotation:
+    # secret-rotation is not a BOSH release.  It requires ruby & kubectl.
+    image:
+      repository: splatform/fissile-stemcell-sle
+      tag: SLE_15_SP1-27.4
   sync-integration-tests:
     # XXX SITS only makes sense when using Diego; add error check somewhere?
     condition: testing.sync_integration_tests.enabled

--- a/chart/templates/secret-rotation.yaml
+++ b/chart/templates/secret-rotation.yaml
@@ -1,0 +1,79 @@
+# This creates a (manually triggered) Quarks Job to rotate all generated
+# secrets.
+---
+apiVersion: quarks.cloudfoundry.org/v1alpha1
+kind: QuarksJob
+metadata:
+  name: secret-rotation
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- list $ "secret-rotation" | include "component.labels" | nindent 4 }}
+spec:
+  trigger:
+    strategy: manual
+  template:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: generate-rotation-config-map
+            {{- with $image := index $.Values.releases "secret-rotation" "image" }}
+            image: {{ printf "%s:%s" $image.repository $image.tag }}
+            imagePullPolicy: {{ $image.pullPolicy | quote }}
+            {{- end }}
+            command:
+            - /usr/bin/env
+            - ruby
+            - -e
+            - |
+              {{- .Files.Get "assets/scripts/helm/secret-rotation/rotate-secrets.rb" | nindent 14 }}
+            env:
+            - name: DEPLOYMENT
+              value: {{ include "kubecf.deployment-name" . | quote }}
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          restartPolicy: Never
+          serviceAccountName: secret-rotation
+        automountServiceAccountToken: true
+---
+# We require a ServiceAccount with access to listing QuarksSecrets
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: secret-rotation
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- list $ "secret-rotation" | include "component.labels" | nindent 4 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: secret-rotation
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- list $ "secret-rotation" | include "component.labels" | nindent 4 }}
+rules:
+- apiGroups: [ quarks.cloudfoundry.org ]
+  resources: [ quarkssecrets ]
+  verbs: [ list ]
+- apiGroups: [ '' ]
+  resources: [ configmaps ]
+  verbs: [ create ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: secret-rotation
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- list $ "secret-rotation" | include "component.labels" | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  namespace: {{ .Release.Namespace | quote}}
+  name: secret-rotation
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: secret-rotation

--- a/scripts/rubocop.sh
+++ b/scripts/rubocop.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+source scripts/include/setup.sh
+
+require_tools rubocop
+
+dirs=(
+    chart/assets/scripts/
+)
+
+disabled_cops=(
+    Metrics/BlockLength
+)
+disabled_cops_string="$(IFS=, ; echo "${disabled_cops[*]}")"
+
+rubocop --except "${disabled_cops_string}" "${dirs[@]}"

--- a/tests/rspec.sh
+++ b/tests/rspec.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+source scripts/include/setup.sh
+
+require_tools rspec
+
+dirs=(
+    chart/assets/scripts/
+)
+
+rspec "${dirs[@]}"


### PR DESCRIPTION
## Description
This adds a job to trigger secret rotation for all generated secrets.

This is useful for administrators to rotate all secrets (generally as a precaution); attempting to document manual instructions is likely to be error-prone.

## Motivation and Context
This is in support of #703 — trying to get the administrator/operator to type in a script correctly is going to be painful; much better to automate it instead.

## How Has This Been Tested?
Triggered the QuarksJob locally to see that secrets are rotated.

Generally speaking though, my experiences has tended towards this actually breaking the cluster (because the database password gets out of sync).  That will be filed as a bug afterwards, because the user can _already_ manually rotate the secrets; this just automates the process.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has security implications.
  (new service account + role + role binding; all minimally scoped)
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
  (That will be a follow-up)