### PR TITLE
fix: remove the validation label

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: 'bug'
+labels: 'Type: Bug'
 assignees: 'fargozhu'
 
 ---

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,8 +2,8 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: 'bug', 'Status: Validation'
-assignees: ''
+labels: 'bug'
+assignees: 'fargozhu'
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: 'enhancement'
+labels: 'Type: Enhancement'
 assignees: 'fargozhu'
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: 'enhancement','Status: Validation'
+labels: 'enhancement'
 assignees: 'fargozhu'
 
 ---


### PR DESCRIPTION
## Description

The latest changes to the GitHub templates for some reason made the templates useless 'cause they are not being triggered since then.

## Motivation and Context

To have the Bug and Feature templates back to the game.

## How Has This Been Tested?

Nope.

## Screenshots (if appropriate):

## Types of changes
N/A

## Checklist:
N/A