### PR TITLE
feat: brain tests 0.0.14

### DIFF
--- a/chart/config/releases.yaml
+++ b/chart/config/releases.yaml
@@ -10,7 +10,7 @@ releases:
     url: docker.io/cfcontainerization
     stemcell:
       os: SLE_15_SP1
-      version: 27.4-7.0.0_374.gb8e8e6af
+      version: 27.5-7.0.0_374.gb8e8e6af
   app-autoscaler:
     condition: features.autoscaler.enabled
     version: 3.0.1

--- a/chart/config/releases.yaml
+++ b/chart/config/releases.yaml
@@ -20,7 +20,7 @@ releases:
       tag: 0.1.0
   brain-tests:
     condition: testing.brain_tests.enabled
-    version: v0.0.13
+    version: v0.0.14
   bosh-dns-aliases:
     # not needed for kubecf; functionality provided by quarks-operator
     condition: false


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Bumps the brain tests to the latest version that removes the Minibroker-related suites.
Also, bumped the stemcell from 27.4 to 27.5.

## Motivation and Context

Brain tests don't assert the Minibroker functionality anymore, this is done by the MITS.

## How Has This Been Tested?

CI shall do.
I verified that the images exist for the releases we include out of the cf-deployment.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
