### PR TITLE
fix: build script when KUBECONFIG is exported

### DIFF
--- a/scripts/kubecf-build.sh
+++ b/scripts/kubecf-build.sh
@@ -3,6 +3,8 @@ source scripts/include/setup.sh
 
 require_tools bosh cf_operator_url git helm jq j2y ruby y2j
 
+unset KUBECONFIG
+
 if [[ ! "$(git submodule status -- src/cf-deployment)" =~ ^[[:space:]] ]]; then
     die "git submodule for cf-deployment is uninitialized or not up-to-date"
 fi


### PR DESCRIPTION
When having `KUBECONFIG` environment variable set on my shell session, the `make kubecf-build` command would fail with:
```
Traceback (most recent call last):
	4: from scripts/image_list.rb:48:in `<main>'
	3: from /usr/lib64/ruby/2.5.0/psych.rb:314:in `safe_load'
	2: from /usr/lib64/ruby/2.5.0/psych.rb:350:in `parse'
	1: from /usr/lib64/ruby/2.5.0/psych.rb:402:in `parse_stream'
/usr/lib64/ruby/2.5.0/psych.rb:402:in `parse': (<unknown>): mapping values are not allowed in this context at line 1 column 85 (Psych::SyntaxError)
make: *** [Makefile:38: kubecf-build] Error 1
```