### PR TITLE
fix: mutating deployment selector on apps-dns

### DIFF
--- a/chart/templates/apps_dns.yaml
+++ b/chart/templates/apps_dns.yaml
@@ -24,7 +24,6 @@ spec:
   selector:
     app: apps-dns
     app.kubernetes.io/name: {{ include "kubecf.fullname" . }}
-    app.kubernetes.io/version: {{ default .Chart.Version .Chart.AppVersion | quote }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/chart/templates/apps_dns.yaml
+++ b/chart/templates/apps_dns.yaml
@@ -64,7 +64,7 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: apps-dns
+  name: cf-apps-dns
   namespace: {{ .Release.Namespace | quote }}
   labels:
     app: apps-dns
@@ -87,7 +87,6 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name | quote }}
       app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
       app.kubernetes.io/name: {{ include "kubecf.fullname" . }}
-      helm.sh/chart: {{ include "kubecf.chart" . }}
   template:
     metadata:
       labels:
@@ -95,8 +94,6 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name | quote }}
         app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
         app.kubernetes.io/name: {{ include "kubecf.fullname" . }}
-        app.kubernetes.io/version: {{ default .Chart.Version .Chart.AppVersion | quote }}
-        helm.sh/chart: {{ include "kubecf.chart" . }}
     spec:
       {{- if $.Values.sizing.apps_dns.affinity }}
       affinity: {{ $.Values.sizing.apps_dns.affinity | toJson }}

--- a/chart/templates/apps_dns.yaml
+++ b/chart/templates/apps_dns.yaml
@@ -87,7 +87,6 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name | quote }}
       app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
       app.kubernetes.io/name: {{ include "kubecf.fullname" . }}
-      app.kubernetes.io/version: {{ default .Chart.Version .Chart.AppVersion | quote }}
       helm.sh/chart: {{ include "kubecf.chart" . }}
   template:
     metadata:


### PR DESCRIPTION
This PR fixes upgrades from KubeCF 2.5 to _next_.

```
Error: UPGRADE FAILED: cannot patch "apps-dns" with kind Deployment: Deployment.apps "apps-dns" is invalid: spec.selector: Invalid value: v1.LabelSelector{MatchLabels:map[string]string{"app":"apps-dns", "app.kubernetes.io/instance":"susecf-scf", "app.kubernetes.io/managed-by":"Helm", "app.kubernetes.io/name":"susecf-scf-kubecf", "app.kubernetes.io/version":"0.2.0-1952.g99e5ce80", "helm.sh/chart":"kubecf-0.2.0-1952.g99e5ce80"}, MatchExpressions:[]v1.LabelSelectorRequirement(nil)}: field is immutable
```