### PR TITLE
fix: locket readiness check

### DIFF
--- a/chart/assets/operations/instance_groups/diego-api.yaml
+++ b/chart/assets/operations/instance_groups/diego-api.yaml
@@ -42,14 +42,10 @@
               command:
               - /var/vcap/packages/cfdot/bin/cfdot
               - locks
-              - --locketAPILocation=localhost:8891
-              # We need to both give --skipCertVerify and provide a CA cert;
-              # skipping the former ends up with context deadline exceeded, and
-              # skipping the latter errors out failing to read file ""
-              - --skipCertVerify
-              - --caCertFile=/var/vcap/jobs/locket/config/certs/ca.crt
-              - --clientCertFile=/var/vcap/jobs/locket/config/certs/server.crt
-              - --clientKeyFile=/var/vcap/jobs/locket/config/certs/server.key
+              - --locketAPILocation=127.0.0.1:8891
+              - --caCertFile=/var/vcap/jobs/cfdot/config/certs/cfdot/ca.crt
+              - --clientCertFile=/var/vcap/jobs/cfdot/config/certs/cfdot/client.crt
+              - --clientKeyFile=/var/vcap/jobs/cfdot/config/certs/cfdot/client.key
 
 # Add quarks properties for bbs.
 - type: replace


### PR DESCRIPTION
## Description
This PR fixes two issues in the locket readiness check:
1. The `locketAPILocation` should be `127.0.0.1` instead of `localhost` as `localhost` is not set in the locket server certificate 
```
            X509v3 Subject Alternative Name:
                DNS:*.locket.service.cf.internal, DNS:locket.service.cf.internal, IP Address:127.0.0.1
```
After change to `127.0.0.1`, we can remove `--skipCertVerify` in the `cfdot` command

2. According to BOSH deployed CF, the `cfdot` command should use the certificates from itself, not from locket server.
See `/var/vcap/jobs/cfdot/bin/setup` which sets environment variables for `cfdot`
```
#!/usr/bin/env bash

if ! echo $PATH | grep -q 'cfdot'; then
  export PATH=/var/vcap/packages/cfdot/bin:$PATH
fi

export BBS_URL=https://bbs.service.cf.internal:8889
export LOCKET_API_LOCATION=locket.service.cf.internal:8891
export CA_CERT_FILE=/var/vcap/jobs/cfdot/config/certs/cfdot/ca.crt
export CLIENT_CERT_FILE=/var/vcap/jobs/cfdot/config/certs/cfdot/client.crt
export CLIENT_KEY_FILE=/var/vcap/jobs/cfdot/config/certs/cfdot/client.key
```

## Motivation and Context
This is to align with BOSH deployed CF and certificate verification is enabled.

## How Has This Been Tested?
In the `diego-api-0` pod, run the following `cfdot` command and it works
```
# /var/vcap/packages/cfdot/bin/cfdot locks \
>     --locketAPILocation=127.0.0.1:8891 \
>     --caCertFile=/var/vcap/jobs/cfdot/config/certs/cfdot/ca.crt \
>     --clientCertFile=/var/vcap/jobs/cfdot/config/certs/cfdot/client.crt \
>     --clientKeyFile=/var/vcap/jobs/cfdot/config/certs/cfdot/client.key
{"key":"auctioneer","owner":"auctioneer-0","type":"lock","type_code":1}
{"key":"cc-deployment-updater","owner":"scheduler-0","type":"lock","type_code":1}
{"key":"tps_watcher","owner":"tps-watcher-scheduler-0","type":"lock","type_code":1}
{"key":"bbs","owner":"diego-api-0","type":"lock","type_code":1}
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
