### PR TITLE
feat: chart: Error out on unsuported db configs

### DIFF
--- a/chart/config/unsupported.yaml
+++ b/chart/config/unsupported.yaml
@@ -9,3 +9,14 @@ unsupported:
   properties.diego-cell.garden.grootfs.reserved_space_for_other_jobs_in_mb: |
     Don't use properties.diego-cell.garden.grootfs.reserved_space_for_other_jobs_in_mb.
     Use sizing.diego_cell.ephemeral_disk.size to set the amount of disk available to the cell.
+
+  features.embedded_database.enabled && features.external_database.enabled: |
+    Cannot simultaneously activate both features.embedded_database and features.external_database.
+
+  # We must enable _some_ database, or this must be the cell segment in a multi-cluster deployment.
+  ? >
+    !features.embedded_database.enabled && !features.external_database.enabled
+    && !features.multiple_cluster_mode.cell_segment.enabled
+  : >
+    The database must be enabled via either features.embedded_database or
+    features.external_database, or this must be the cell segment in a multi-cluster deployment.

--- a/scripts/image_list.rb
+++ b/scripts/image_list.rb
@@ -282,6 +282,11 @@ permutations.each do |permutation|
   permutation.keys.each do |feature|
     values.features[feature]['enabled'] = permutation[feature]
   end
+  # embedded_database and external_database are mutually exclusive
+  # it is more likely that embedded database will require an additional
+  # image than external_database.
+  values.features['embedded_database']['enabled'] = true
+  values.features['external_database']['enabled'] = false
   deep_populate_nil_values(values.features)
 
   # Render the Helm chart.


### PR DESCRIPTION
## Description

Add explicit check for non-sensical database configurations (no database at all, or multiple database options).

This will need to be adjusted once we review our configuration options to reduce chances of creating unusable combinations.  This would be in an issue that will be spawned from #1086.

## Motivation and Context
While trying to implement #629 I was confused by our database configuration and wanted to make sure I'm covering the necessary cases.

## How Has This Been Tested?
Rendered the configuration in the following cases:

Config | Supported?
-- | --
embedded only | ✅ 
external only | ✅ 
embedded + external | 🚫 
none | 🚫 (except in multi-cluster cell mode)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

I expect I'll need to expand the documentation around our database options once #629 has progressed more.

## Additional Information
I don't particularly like the line folding around line 18, but the condition is long enough that trying to keep it in one line looks even worse.  Suggestions welcome.