### PR TITLE
fix: chart: update operator docs links

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -47,7 +47,7 @@ instructions.
 [1]: https://github.com/cloudfoundry-incubator/quarks-operator
 [2]: https://github.com/cloudfoundry-incubator/kubecf/releases
 [3]: https://github.com/cloudfoundry-incubator/kubecf/blob/master/doc/Contribute.md#customization
-[4]: https://github.com/cloudfoundry-incubator/quarks-operator/blob/master/README.md#explicit-variables
-[5]: https://github.com/cloudfoundry-incubator/quarks-operator/blob/master/README.md#implicit-variables
+[4]: https://quarks.suse.dev/docs/quarks-operator/concepts/variables/#explicit-variables
+[5]: https://quarks.suse.dev/docs/quarks-operator/concepts/variables/#implicit-variables
 [6]: https://kubecf.suse.dev/docs/getting-started/kubernetes-deploy/
 [7]: https://kubecf.suse.dev/docs/


### PR DESCRIPTION
## Description
The link to the operator docs is incorrect in the chart README.

## Motivation and Context
Encountered while doing #629 (because I tried to follow the link).

## How Has This Been Tested?
Navigated to the links.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
