### PR TITLE
fix: Consume kubecf-bundle tgz in upgrade, not kubecf tgz

### DIFF
--- a/.concourse/tasks/upgrade.sh
+++ b/.concourse/tasks/upgrade.sh
@@ -118,8 +118,8 @@ gcloud --quiet beta dns --project="${GKE_PROJECT}" record-sets transaction execu
        --zone="${GKE_DNS_ZONE}"
 
 # Now upgrade to whatever chart we built for commit-to-test
-# The chart should be in s3.kubecf-ci directory
-SCF_CHART="$(readlink -f ../s3.kubecf-ci/*.tgz)"
+# The chart should be in s3.kubecf-ci-bundle directory
+SCF_CHART="$(readlink -f ../s3.kubecf-ci-bundle/*.tgz)"
 export SCF_CHART
 
 make kubecf-chart


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Consume kubecf-bundle tgz in upgrade, not kubecf tgz

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix the upgrade job, which is missing the bumps of cf-o as it is not consuming the new kubecf-bundle.tgz for the upgrade.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- An important detail to include is the version of the used cf-operator -->

It hasn't been tested. Needs to be merged in master to be consumed by the pipeline.


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
