### PR TITLE
fix: Consume s3.kubecf-ci-bundle as input in upgrade task

### DIFF
--- a/.concourse/tasks/upgrade.yaml
+++ b/.concourse/tasks/upgrade.yaml
@@ -7,7 +7,7 @@ image_resource:
 inputs:
 - name: kubecf
 - name: catapult
-- name: s3.kubecf-ci
+- name: s3.kubecf-ci-bundle
 - name: kubecf-github-release
 - name: semver.gke-cluster
 run:


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Consume s3.kubecf-ci-bundle as input in upgrade task, instead of s3.kubecf-ci.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix upgrade job.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- An important detail to include is the version of the used cf-operator -->

It has not. Needs to be in master for it to run.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
