### PR TITLE
fix: Add missing data for the CF info endpoints.

### DIFF
--- a/chart/config/api.yaml
+++ b/chart/config/api.yaml
@@ -1,0 +1,11 @@
+properties:
+  api:
+    cloud_controller_ng:
+      name: KubeCF
+      version: 2
+      description: 'CloudFoundry KubeCF'
+      support_address: 'https://kubecf.io/'
+      build: {{ default .Chart.Version .Chart.AppVersion | quote }}
+
+# Note that the version information has to be a plain integer, as per the
+# Membrane::SchemaValidation occuring in `bosh-pre-start-cloud-controller-ng`.

--- a/chart/templates/_config.tpl
+++ b/chart/templates/_config.tpl
@@ -17,6 +17,10 @@
 | uppercase config filename, to be merged first. Obviously no config file can overwrite
 | an explict user choice from $.Values.
 |
+| __Note__ that while templates are allowed in config files, they only have access to
+| the global helm variables, and the user-provided values from `values.yaml`. They cannot
+| use the internal config data, as that has not been merged yet.
+|
 | The $.Values.release.$defaults are saved in $.kubecf.defaults because they are used
 | in templates to set the default and addon stemcells.
 |
@@ -46,7 +50,7 @@
 
     {{- $configs := dict }}
     {{- range $name, $bytes := $.Files.Glob "config/*" }}
-      {{- $config := $bytes | toString | fromYaml }}
+      {{- $config := tpl ($bytes | toString) $ | fromYaml }}
       {{- if hasKey $config "Error" }}
         {{- include "_config.fail" (printf "Config file %q is invalid:\n%s" $name $config.Error) }}
       {{- end }}

--- a/scripts/helmlint.sh
+++ b/scripts/helmlint.sh
@@ -17,9 +17,12 @@ helm lint "${TARGET_DIR}" --set system_domain=example.com
 # Running json schema validator a second time to also check the embedded config files.
 # Done in a separate run because the config files are merged here on top of values.yaml,
 # which will cause replacement of any arrays.
+#
+# NOTE: We exclude all config files which contain templating.
 
 # shellcheck disable=SC2046
 # We want word splitting with find.
 helm template "${TARGET_DIR}" --set system_domain=example.com \
-     --values "$(perl -e 'print join ",", @ARGV' -- $(find "${TARGET_DIR}/config" -type f))" \
+     --values "$(perl -e 'print join ",", @ARGV' -- \
+              $(grep -L '{{' $(find "${TARGET_DIR}/config" -type f)))" \
      > /dev/null


### PR DESCRIPTION
## Description

Added ops instructions setting the CAPI cc_ng properties controlling the values to be returned by the endpoints `info`, `v2/info`, and `v3/info`.

## Motivation and Context

See #1367 

## How Has This Been Tested?

Deployed on minikube, logged inot CF, then used `cf curl ENDPOINT` for the endpoints above and checked that the values are not empty anymore, and the expected.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
