### PR TITLE
fix: Add internal/external credhub url

### DIFF
--- a/chart/assets/operations/instance_groups/credhub.yaml
+++ b/chart/assets/operations/instance_groups/credhub.yaml
@@ -93,6 +93,13 @@
     secret: ((credhub_setup_client_secret))
 
 - type: replace
+  path: /instance_groups/name=credhub/jobs/name=credhub/properties/credhub/authentication?/uaa?/url?
+  value: "https://uaa.((system_domain))"
+- type: replace
+  path: /instance_groups/name=credhub/jobs/name=credhub/properties/credhub/authentication?/uaa?/internal_url?
+  value: "https://uaa.service.cf.internal:8443"
+
+- type: replace
   path: /variables/name=credhub_setup_client_secret?
   value:
     name: credhub_setup_client_secret


### PR DESCRIPTION
Credhub otherwise advertizes to the client the internal url that can't be resolved:

```
Setting the target url: https://credhub.172.18.0.2.xip.io
Warning: The targeted TLS certificate has not been verified for this connection.
Warning: The --skip-tls-validation flag is deprecated. Please use --ca-cert instead.
UAA error: Post https://uaa.service.cf.internal:8443/oauth/token: dial tcp: lookup uaa.service.cf.internal on 10.96.0.10:53: no such host
```

This problem doesn't seems to hit our test suites because they are bosh releases which are started with cfo, that injects the bosh dns server to the instances.

## Description
This changes sets the internal and external url of uaa in credhub correctly, so that the config yaml in the credhub pod results in the following:

```yaml
/:/var/vcap/jobs/credhub# cat config/application/auth-server.yml 
---
auth-server:
  url: https://uaa.172.18.0.2.xip.io
  trust_store: "/var/vcap/jobs/credhub/config/trust_store.jks"
  trust_store_password: "${TRUST_STORE_PASSWORD}"
  internal_url: https://uaa.kubecf.svc:8443
```

## Motivation and Context
Otherwise the pod running the tests for #840 fails for the above error 

## How Has This Been Tested?
Locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
