### PR TITLE
turn off GKE_PREEMPTIBLE, set GKE_INSTANCE_TYPE to n1-highcpu-32

### DIFF
--- a/.github/workflows/pull-request-ci.yaml
+++ b/.github/workflows/pull-request-ci.yaml
@@ -217,8 +217,8 @@ jobs:
           OWNER: ${{ github.repository_owner }}
           DEBUG_MODE: true
           GKE_NODE_COUNT: 1
-          GKE_PREEMPTIBLE: true
-          GKE_INSTANCE_TYPE: n1-highcpu-16
+          GKE_PREEMPTIBLE: false
+          GKE_INSTANCE_TYPE: n1-highcpu-32
 
       # Providing kubeconfig for debugging
       - name: export KUBECONFIG


### PR DESCRIPTION
turns off GKE_PREEMPTIBLE and sets GKE_INSTANCE_TYPE to n1-highcpu-32

## Motivation and Context
There are some failures in CI due to GKE_PREEMPTIBLE being set to true and GKE_PREEMPTIBLE set to n1-highcpu-16


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
