### PR TITLE
fix: add dns record for ssh_proxy (both diego and eirini)

### DIFF
--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -230,6 +230,9 @@ deploy_args: &deploy_args
   # Setup dns
   tcp_router_ip=$(kubectl get svc -n scf tcp-router-public -o json | jq -r .status.loadBalancer.ingress[].ip | head -n 1)
   public_router_ip=$(kubectl get svc -n scf router-public -o json | jq -r .status.loadBalancer.ingress[].ip | head -n 1)
+  # ssh-proxy service is named differently in diego and eirini
+  ssh_proxy_svc=$(kubectl get svc -n scf | grep ssh-proxy | awk '{print $1}' | head -n 1)
+  ssh_proxy_ip=$(kubectl get svc -n scf ${ssh_proxy_svc} -o json | jq -r .status.loadBalancer.ingress[].ip | head -n 1)
 
   gcloud --quiet beta dns --project=${GKE_PROJECT} record-sets transaction start \
     --zone=${GKE_DNS_ZONE}
@@ -237,6 +240,8 @@ deploy_args: &deploy_args
     --name=\*.${DOMAIN}. --ttl=300 --type=A --zone=${GKE_DNS_ZONE} $public_router_ip
   gcloud --quiet beta dns --project=${GKE_PROJECT} record-sets transaction add \
     --name=tcp.${DOMAIN}. --ttl=300 --type=A --zone=${GKE_DNS_ZONE} $tcp_router_ip
+  gcloud --quiet beta dns --project=${GKE_PROJECT} record-sets transaction add \
+    --name=ssh.${DOMAIN}. --ttl=300 --type=A --zone=${GKE_DNS_ZONE} $ssh_proxy_ip
   gcloud --quiet beta dns --project=${GKE_PROJECT} record-sets transaction execute \
     --zone=${GKE_DNS_ZONE}
 
@@ -633,6 +638,9 @@ jobs:
               pvcs=$(kubectl get pvc -n scf -o json | jq -r .items[].spec.volumeName | paste -sd "|")
               tcp_router_ip=$(kubectl get svc -n scf tcp-router-public -o json | jq -r .status.loadBalancer.ingress[].ip | head -n 1)
               public_router_ip=$(kubectl get svc -n scf router-public -o json | jq -r .status.loadBalancer.ingress[].ip | head -n 1)
+              # ssh-proxy service is named differently in diego and eirini
+              ssh_proxy_svc=$(kubectl get svc -n scf | grep ssh-proxy | awk '{print $1}' | head -n 1)
+              ssh_proxy_ip=$(kubectl get svc -n scf ${ssh_proxy_svc} -o json | jq -r .status.loadBalancer.ingress[].ip | head -n 1)
 
               # Delete cluster
               gcloud --quiet container --project "${GKE_PROJECT}" clusters delete "${GKE_CLUSTER_NAME}" \
@@ -662,6 +670,9 @@ jobs:
               gcloud --quiet beta dns --project=${GKE_PROJECT} record-sets \
                 transaction remove --name=tcp.${DOMAIN}. --ttl=300 --type=A \
                 --zone=${GKE_DNS_ZONE} $tcp_router_ip
+              gcloud --quiet beta dns --project=${GKE_PROJECT} record-sets \
+                transaction remove --name=ssh.${DOMAIN}. --ttl=300 --type=A \
+                --zone=${GKE_DNS_ZONE} $ssh_proxy_ip
               gcloud --quiet beta dns --project=${GKE_PROJECT} record-sets \
                 transaction execute --zone=${GKE_DNS_ZONE}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Concourse pipeline doesn't create a DNS record for the ssh-proxy service so all requests to ssh.$DOMAIN find the router instead. This should fix the failed ssh tests on Eirini CATs.

## Motivation and Context

We need green Eirini CATs

## How Has This Been Tested?
Pipeline already deployed here: https://concourse.suse.dev/teams/main/pipelines/kubecf/jobs/cf-acceptance-tests-eirini-master/builds/51

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
