### PR TITLE
fix: limit reuse of config values

### DIFF
--- a/chart/config/unsupported.yaml
+++ b/chart/config/unsupported.yaml
@@ -20,3 +20,9 @@ unsupported:
   : >
     The database must be enabled via either features.embedded_database or
     features.external_database, or this must be the cell segment in a multi-cluster deployment.
+
+  # This setting was in values.yaml in kubecf 2.4.0 and earlier; it no longer exists:
+  eirini.env.DOMAIN: |
+    You are reusing an old and incompatible configuration, either via a values.yaml file from an
+    older release, or by using the --reuse-values option. Please start with a fresh configuration,
+    only changing settings relative to the defaults in the current release.

--- a/chart/templates/_config.tpl
+++ b/chart/templates/_config.tpl
@@ -47,6 +47,9 @@
     {{- $_ := set $ "kubecf" dict }}
   {{- end }}
   {{- if not $.kubecf.manifest }}
+    {{- /* copy all structures under $.Values so our changes do not affect --reuse-values */}}
+    {{- $_ := set $ "Values" (deepCopy $.Values) }}
+
     {{- $_ := set $.kubecf "manifest" (fromYaml ($.Files.Get "assets/cf-deployment.yml")) }}
 
     {{- $configs := dict }}

--- a/chart/values.schema.yaml
+++ b/chart/values.schema.yaml
@@ -133,37 +133,19 @@ definitions:
   resources_definition:
     type: object
     properties:
-      # The "null" alternatives below are required because templates/_resources.tpl
-      # will fill in missing keys with a null value to simplify the code that accesses
-      # properties. These filled in values will be passed through the validator again
-      # when a chart is upgraded with the --reuse-values option.
       cpu:
         type: object
         properties:
           # The "minimum" exists to make sure users specify in millicpu units.
           # So validation will catch when they request 2 millicpus instead of 2000.
-          limit:
-            anyOf:
-            - type: integer
-              minimum: 50
-            - type: "null"
-          request:
-            anyOf:
-            - type: integer
-              minimum: 50
-            - type: "null"
+          limit: {type: integer, minimum: 50}
+          request: {type: integer, minimum: 50}
         additionalProperties: false
       memory:
         type: object
         properties:
-          limit:
-            anyOf:
-            - type: integer
-            - type: "null"
-          request:
-            anyOf:
-            - type: integer
-            - type: "null"
+          limit: {type: integer}
+          request: {type: integer}
         additionalProperties: false
     additionalProperties: false
 


### PR DESCRIPTION
## Description

This PR blocks the use of --reuse-values when upgrading from 2.5.0 or earlier because those release may include release-specific information (image names and versions etc), or may have persisted changes made by the templating code.

Upgrades from 2.4.0 and earlier are blocked via an `unsupported` rule that checks for the `eirini.env.DOMAIN` property that has been removed in 2.5.0.

Upgrades from 2.5.0 using `--reuse-values` are blocked via schema validation that does not allow limits or requests to be `nil`. Upgrades from 2.5.0 using the existing `values.yaml` file are not blocked and should be benign as the version specific settings have already been moved to `config/*.yaml` files.

## Motivation and Context

We have run into problems with `--reuse-values` in our own CI and we want prevent users from running into the same traps.

## How Has This Been Tested?

It has not yet been tested.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code has security implications.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
