### PR TITLE
fix: Increase default memory limit for addon processes from 32Mi to 64Mi

### DIFF
--- a/chart/config/resources.yaml
+++ b/chart/config/resources.yaml
@@ -14,7 +14,7 @@ features:
 # resource definitions for addons. It has the same schema as the `resources` tree.
 
 addon_resources:
-  '$defaults': 32
+  '$defaults': 64
 
 # `resources` contains a mapping of instance groups to jobs to processes.
 # The process then contains a resource definition with limits and requests


### PR DESCRIPTION
This is the same default we already use for all regular processes that don't have an explicit limit defined.

We've seen at least the syslog forwarder getting occasionally OOMKilled with the 32Mi limit.
