### PR TITLE
fix: Publish tgzs correctly in release job

### DIFF
--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -151,7 +151,7 @@ resources:
     access_key_id: ((aws-access-key))
     secret_access_key: ((aws-secret-key))
     region_name: {{ $config.s3_final_bucket_region }}
-    regexp: kubecf-([0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+)?).tgz
+    regexp: kubecf-v?([0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+)?).tgz
 
 - name: s3.kubecf-bundle
   type: s3
@@ -160,7 +160,7 @@ resources:
     access_key_id: ((aws-access-key))
     secret_access_key: ((aws-secret-key))
     region_name: {{ $config.s3_final_bucket_region }}
-    regexp: kubecf-bundle-([0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+)?).tgz
+    regexp: kubecf-bundle-v?([0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+)?).tgz
 
 deploy_args: &deploy_args
 - -ce
@@ -2052,13 +2052,13 @@ jobs:
     - {{ . -}}{{ end }}
     {{- end }}
     params:
-      file: output/kubecf-[0-9]*.tgz
+      file: output/kubecf-v[0-9]*.tgz
   - put: s3.kubecf-bundle
     {{- if $config.workertags }}
     tags: {{ range $config.workertags }}
     - {{ . -}}{{ end }}
     {{- end }}
     params:
-      file: output/kubecf-bundle-*.tgz
+      file: output/kubecf-bundle-v*.tgz
 {{ end }} # of publish
 {{ end }} # of branch


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Fix the files expected by s3 Concourse resources.
Artifacts get the `v` added, even if it isn't in semver, to be consistent with
the history of artifacts we have.



## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes https://github.com/cloudfoundry-incubator/kubecf/issues/1412.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- An important detail to include is the version of the used cf-operator -->

Already flown, see passing jobs: (I deleted artifacts manually to be able to retrigger the job)
https://concourse.suse.dev/teams/main/pipelines/kubecf/jobs/publish-master/builds/26.3

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
