### PR TITLE
fix: Revert "fix: Remove also the git part from the version of the artifacts"

### DIFF
--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -2015,11 +2015,9 @@ jobs:
         args:
         - -ce
         - |
-          # Revert to original name without the timestamp part, without the
-          # git part, then add back `v`
+          # Revert to original name without the timestamp part, then add back `v`
           for file in s3.kubecf-ci*/*.tgz; do
               new_filename=$(basename $file | sed  's/-[0-9]\+\.tgz/\.tgz/' \
-                                            | sed 's/\-[0-9].g.*\.tgz/\.tgz/' \
                                             | sed  's/\([0-9]\+\.[0-9]\+\.[0-9]\+\)/v\1/g')
               mv "$file" "output/${new_filename}"
           done


### PR DESCRIPTION
## Description

This reverts commit 994e34f780f7211e26a176163cc1085edc469958.

That commit was added because we mangled the semver for 2.5.0 and included a git
hash in it. Hence, for releasing the tar, we removed the `g<hash>` part too. We
should have not done that, and the job was failing correctly.

Now, with 2.5.1, the semver doesn't contain the git hash, so we shouldn't try to
remove it. This is the correct behaviour.


## Motivation and Context

Fix publish job on release-2.5 branch.

## How Has This Been Tested?

Already flown.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
