### PR TITLE
fix: doppler OOMKilled

### DIFF
--- a/chart/config/resources.yaml
+++ b/chart/config/resources.yaml
@@ -139,7 +139,7 @@ resources:
     rep:
       rep: {memory: {limit: 3072, request: 2048}}
   doppler:
-    doppler: 128
+    doppler: 256
   log-api: 128
   log-cache:
     log-cache: 2048


### PR DESCRIPTION
After running a cluster for 8+ hours, I noticed all doppler replicas getting restarted multiple times due to memory limit enforcement.