### PR TITLE
fix: CCDB  secret rotation: set explicit resource limits

### DIFF
--- a/chart/assets/operations/instance_groups/rotate-cc-database-key.yaml
+++ b/chart/assets/operations/instance_groups/rotate-cc-database-key.yaml
@@ -1,0 +1,3 @@
+- path: /instance_groups/name=rotate-cc-database-key/env?/bosh/agent/settings/disable_log_sidecar
+  type: replace
+  value: true

--- a/chart/config/resources.yaml
+++ b/chart/config/resources.yaml
@@ -144,6 +144,9 @@ resources:
   log-cache:
     log-cache: 2048
   nats: ~
+  rotate-cc-database-key:
+    rotate_cc_database_key:
+      rotate: {memory: {limit: 512, request: 192}}
   router: 200
   scheduler:
     cc_deployment_updater: 320

--- a/testing/ccdb_key_rotation/rotate-ccdb-keys-test.sh
+++ b/testing/ccdb_key_rotation/rotate-ccdb-keys-test.sh
@@ -85,7 +85,10 @@ wait_for_rotate_pod_to_end() {
 	if [[ -n "${exit_code}" ]]; then
             echo " $(blue "Completed")"
             echo Terminating job
-            kubectl delete --ignore-not-found=true --namespace "${KUBECF_NAMESPACE}" "$(rotate_job_name)"
+            job_name="$(rotate_job_name)"
+            if [ -n "${job_name}" ]; then
+                kubectl delete --ignore-not-found=true --namespace "${KUBECF_NAMESPACE}" "${job_name}"
+            fi
 	    # shellcheck disable=SC2005
 	    echo "$(green "OK")"
             exit "${exit_code}"

--- a/testing/ccdb_key_rotation/rotate-ccdb-keys-test.sh
+++ b/testing/ccdb_key_rotation/rotate-ccdb-keys-test.sh
@@ -84,11 +84,7 @@ wait_for_rotate_pod_to_end() {
 	exit_code="$(kubectl get "${pod_name}" --namespace "${KUBECF_NAMESPACE}" --output "jsonpath=${jsonpath}")"
 	if [[ -n "${exit_code}" ]]; then
             echo " $(blue "Completed")"
-            echo Terminating job
-            job_name="$(rotate_job_name)"
-            if [ -n "${job_name}" ]; then
-                kubectl delete --ignore-not-found=true --namespace "${KUBECF_NAMESPACE}" "${job_name}"
-            fi
+
 	    # shellcheck disable=SC2005
 	    echo "$(green "OK")"
             exit "${exit_code}"

--- a/testing/ccdb_key_rotation/rotate-ccdb-keys-test.sh
+++ b/testing/ccdb_key_rotation/rotate-ccdb-keys-test.sh
@@ -86,7 +86,7 @@ wait_for_rotate_pod_to_end() {
             echo " $(blue "Completed")"
 
 	    # shellcheck disable=SC2005
-	    echo "$(green "OK")"
+	    echo "$(green "OK [${exit_code}]")"
             exit "${exit_code}"
 	fi
 	sleep 1

--- a/testing/ccdb_key_rotation/rotate-ccdb-keys-test.sh
+++ b/testing/ccdb_key_rotation/rotate-ccdb-keys-test.sh
@@ -85,7 +85,7 @@ wait_for_rotate_pod_to_end() {
 	if [[ -n "${exit_code}" ]]; then
             echo " $(blue "Completed")"
             echo Terminating job
-            kubectl delete --namespace "${KUBECF_NAMESPACE}" "$(rotate_job_name)"
+            kubectl delete --ignore-not-found=true --namespace "${KUBECF_NAMESPACE}" "$(rotate_job_name)"
 	    # shellcheck disable=SC2005
 	    echo "$(green "OK")"
             exit "${exit_code}"


### PR DESCRIPTION
## Description
Set a memory limit on the CCDB key rotation job, so that it has enough resources to run.
From experimenting locally on a minikube:
- a limit of 128Mi is not enough to run
- a limit of 192Mi is enough to run.

So I'm picking a request of 192Mi, and a limit of 512Mi just in case (it should never get that high anyway).

I'm also disabling the log sidecar for that job, since it's a job and having the sidecar just means it'll never complete.

## Motivation and Context
CI was failing.  Not sure @viovanov ever filed a bug on it.

## How Has This Been Tested?
Ran the job locally (manually triggering the QJob) until it passed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
