### PR TITLE
fix: Remove allowance for old catapult cruft

### DIFF
--- a/chart/values.schema.yaml
+++ b/chart/values.schema.yaml
@@ -332,8 +332,7 @@ properties:
           default: {"$ref": "#/definitions/string_or_null"}
         additionalProperties: false
       storage_class: {"$ref": "#/definitions/string_or_null"}
-    # XXX Catapult sets additional (unused) properties; allow them for now to pass CI
-    additionalProperties: true
+    additionalProperties: false
 
   move_jobs:
     type: object


### PR DESCRIPTION
Catapult (used to) add additional properties under the `kube` key that are completely ignored by kubecf.

It is my understanding that these settings have been removed from catapult, so we should tighten the schema so it will catch misspelled property names provided by actual users.