### PR TITLE
fix: add GitHub issue as discussion place

### DIFF
--- a/doc/rfd/rfd/0000/README.md
+++ b/doc/rfd/rfd/0000/README.md
@@ -69,7 +69,8 @@ Some of these steps may have some script support in the future to make everyone'
 
 ### Find Next RFD Number
 
-Check for the next RFD number by going through the RFDs table.
+Check for the next RFD number by going through the RFDs table and on
+[GitHub](is:pr "feat: RFD" in:title) 
 
 ### Create a Branch & Placeholder
 

--- a/doc/rfd/rfd/0000/README.md
+++ b/doc/rfd/rfd/0000/README.md
@@ -113,7 +113,7 @@ and push it remotely.
 ```
 
 Do not forget to open a pull request (maybe later we will have a bot for this) with the title
-_RDF:num_ .
+_feat: RDF num title_ .
 
 With the pull request open anyone subscribed to the repository will be notified about the new RFD
 and it can gather feedback through pull request comments.

--- a/doc/rfd/rfd/0000/README.md
+++ b/doc/rfd/rfd/0000/README.md
@@ -16,6 +16,8 @@ document known by RFD.
 1. authors: owners of the RFD must be listed with their name and email address
 (John Doe <john.doe@wonder.land>).
 2. state: one of the states discussed below.
+3. discussion: GitHub filter link that list both the pull request and the issue related with the RFD
+(i.e. https://github.com/cloudfoundry-incubator/kubecf/issues?q=%22RFD+8%22+)
 
 ## State
 

--- a/doc/rfd/rfd/0000/README.md
+++ b/doc/rfd/rfd/0000/README.md
@@ -112,8 +112,8 @@ and push it remotely.
 # git push origin rfd-0010
 ```
 
-Do not forget to open a pull request (maybe later we will have a bot for this) with the title
-_feat: RDF num title_ .
+Do not forget to open a pull request and a GitHub issue where the discussion will happen with the
+title _feat: RDF num title_ .
 
 With the pull request open anyone subscribed to the repository will be notified about the new RFD
 and it can gather feedback through pull request comments.
@@ -127,4 +127,5 @@ master branch, but before that it must the state to ```published```. At this mom
 ready for implementation.
 
 If an RFD state is switched to ```abandoned``` the pull request must be merged into the master
-branch. If the RFD is in a ```draft``` state then a pull request must be opened and merged for future reference.
+branch. If the RFD is in a ```draft``` state then a pull request must be opened and merged for
+future reference.

--- a/doc/rfd/rfd/0000/README.md
+++ b/doc/rfd/rfd/0000/README.md
@@ -70,7 +70,7 @@ Some of these steps may have some script support in the future to make everyone'
 ### Find Next RFD Number
 
 Check for the next RFD number by going through the RFDs table and on
-[GitHub](is:pr "feat: RFD" in:title) 
+[GitHub](https://github.com/cloudfoundry-incubator/kubecf/pulls?q=is%3Apr+%22feat%3A+RFD%22+in%3Atitle) 
 
 ### Create a Branch & Placeholder
 


### PR DESCRIPTION
## Description

Define the RFD issue as the right place for discussion.

## Motivation and Context

We should separate the conversation about the topic that should happen in a GitHub _issue_, from the review of the document itself that should happen on a _pull request_ thread, since a _pull request_ intention is to review code changes or, like in this case, document modifications.