### PR TITLE
fix: brain tests for eirini

### DIFF
--- a/chart/assets/operations/instance_groups/brain-tests.yaml
+++ b/chart/assets/operations/instance_groups/brain-tests.yaml
@@ -40,10 +40,20 @@
         tests:
           autoscaler:
             enabled: {{ .Values.features.autoscaler.enabled }}
+{{/* DROP when eirini has proper tcp routing support
+**** See https://github.com/cloudfoundry-incubator/kubecf/issues/1371#issuecomment-702883321
+*/}}
+{{- if .Values.features.eirini.enabled }}
+          tcprouting:
+            enabled: false
+          insecure_registry:
+            enabled: false
+{{- else }}
           tcprouting:
             enabled: {{ .Values.features.routing_api.enabled }}
           insecure_registry:
             enabled: {{ .Values.features.routing_api.enabled }}
+{{- end }}
           credhub:
             enabled: {{ .Values.features.credhub.enabled }}
       release: brain-tests

--- a/chart/config/releases.yaml
+++ b/chart/config/releases.yaml
@@ -20,7 +20,7 @@ releases:
       tag: 0.1.0
   brain-tests:
     condition: testing.brain_tests.enabled
-    version: v0.0.14
+    version: v0.0.15
   bosh-dns-aliases:
     # not needed for kubecf; functionality provided by quarks-operator
     condition: false


### PR DESCRIPTION

## Description

- disable tcp routing tests, not supported
- bring in fix for metron test (brain test release 0.0.15)

## Motivation and Context

See #1371 

## How Has This Been Tested?

Local minikube deployment with eirini and diego. Latest master head, operator `6.1.10+0.g7b1a5f2f`.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
