### PR TITLE
feat: add case for rhel|centos during update-ca-certificates

### DIFF
--- a/bosh/releases/pre_render_scripts/uaa/uaa/jobs/patch_pre-start.sh
+++ b/bosh/releases/pre_render_scripts/uaa/uaa/jobs/patch_pre-start.sh
@@ -36,7 +36,7 @@ patch --verbose "${target}" <<'EOT'
 +        mv /var/lib/ca-certificates/ca-bundle.pem /etc/ssl/certs/"$(basename "${OS_CERTS_FILE}")"
 +      ;;
 +
-+      *rhel|centos*)
++      *rhel|centos|fedora*)
 +        timeout --signal=KILL 180s /usr/bin/update-ca-trust
 +        cp /etc/ssl/certs/ca-bundle.crt ${OS_CERTS_FILE}
 +      ;;

--- a/bosh/releases/pre_render_scripts/uaa/uaa/jobs/patch_pre-start.sh
+++ b/bosh/releases/pre_render_scripts/uaa/uaa/jobs/patch_pre-start.sh
@@ -16,7 +16,7 @@ fi
 patch --verbose "${target}" <<'EOT'
 --- pre-start.erb  2019-12-04 08:37:51.046503943 +0100
 +++ - 2019-12-04 08:41:36.055142488 +0100
-@@ -32,9 +32,24 @@
+@@ -32,9 +32,34 @@
      <% end %>
 
      log "Trying to run update-ca-certificates..."
@@ -34,6 +34,11 @@ patch --verbose "${target}" <<'EOT'
 +      *suse|sles*)
 +        timeout --signal=KILL 180s /usr/sbin/update-ca-certificates -f -v
 +        mv /var/lib/ca-certificates/ca-bundle.pem /etc/ssl/certs/"$(basename "${OS_CERTS_FILE}")"
++      ;;
++
++      *rhel|centos*)
++        timeout --signal=KILL 180s /usr/bin/update-ca-trust -f -v
++        cp /etc/ssl/certs/ca-bundle.crt ${OS_CERTS_FILE}
 +      ;;
 +
 +      *)

--- a/bosh/releases/pre_render_scripts/uaa/uaa/jobs/patch_pre-start.sh
+++ b/bosh/releases/pre_render_scripts/uaa/uaa/jobs/patch_pre-start.sh
@@ -16,7 +16,7 @@ fi
 patch --verbose "${target}" <<'EOT'
 --- pre-start.erb  2019-12-04 08:37:51.046503943 +0100
 +++ - 2019-12-04 08:41:36.055142488 +0100
-@@ -32,9 +32,34 @@
+@@ -32,9 +32,29 @@
      <% end %>
 
      log "Trying to run update-ca-certificates..."

--- a/bosh/releases/pre_render_scripts/uaa/uaa/jobs/patch_pre-start.sh
+++ b/bosh/releases/pre_render_scripts/uaa/uaa/jobs/patch_pre-start.sh
@@ -37,7 +37,7 @@ patch --verbose "${target}" <<'EOT'
 +      ;;
 +
 +      *rhel|centos*)
-+        timeout --signal=KILL 180s /usr/bin/update-ca-trust -f -v
++        timeout --signal=KILL 180s /usr/bin/update-ca-trust
 +        cp /etc/ssl/certs/ca-bundle.crt ${OS_CERTS_FILE}
 +      ;;
 +


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Allow for rhel/centos distributions to be able to run update-ca-certificates.

## Description
A case entry:
```
+ *rhel|centos*) 
+ timeout --signal=KILL 180s /usr/bin/update-ca-trust -f -v 
+ cp /etc/ssl/certs/ca-bundle.crt ${OS_CERTS_FILE} 
+ ;;
```
to be added to:

https://github.com/cloudfoundry-incubator/kubecf/blob/master/bosh/releases/pre_render_scripts/uaa/uaa/jobs/patch_pre-start.sh

## Motivation and Context
At the moment in order to be able to run on OpenShift, we are manually updating `uaa_uaa_patch_pre-start_sh.yaml` to include a case for `rhel|centos` during update-ca-certificates. For every release of kubecf, this requires us to unpackage kubecf artifact, apply the fix, and repackage it back up again.

Related issue: https://github.com/cloudfoundry-incubator/kubecf/issues/1447

## How Has This Been Tested?
After manually adding the patch, we are able to deploy into an OpenShift environment.

## Screenshots (if appropriate):
Manually added entry to `uaa_uaa_patch_pre-start_sh.yaml`
<img width="1440" alt="Screenshot 2020-10-06 at 11 17 15" src="https://user-images.githubusercontent.com/47635090/95189680-14ded900-07c6-11eb-92d3-0bc1eee22db9.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [ x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
