### PR TITLE
fix: set diego-cell ephemeral PVC disk size

### DIFF
--- a/chart/assets/operations/instance_groups/diego-cell.yaml
+++ b/chart/assets/operations/instance_groups/diego-cell.yaml
@@ -28,15 +28,7 @@
   value: true
 
 # Configure the size of the diego cell grootfs store
-# We are repurposing reserved_space_for_other_jobs_in_mb as the size of the grootfs store 
-- type: replace
-  path: /instance_groups/name=diego-cell/jobs/name=garden/properties/grootfs?/reserved_space_for_other_jobs_in_mb
-  value: {{ .Values.sizing.diego_cell.ephemeral_disk.size }}
-
-- type: replace
-  path: /instance_groups/name=diego-cell/jobs/name=rep/properties/diego?/executor/disk_capacity_mb
-  value: {{ .Values.sizing.diego_cell.ephemeral_disk.size }}
-
+{{- $ephemeral_disk_size := .Values.sizing.diego_cell.ephemeral_disk.size }}
 {{- if .Values.sizing.diego_cell.ephemeral_disk.storage_class }}
 # Use a PVC for garden data
 - type: replace
@@ -47,9 +39,19 @@
   value: {{ .Values.sizing.diego_cell.ephemeral_disk.storage_class | quote }}
 - type: replace
   path: /instance_groups/name=diego-cell/vm_resources?/ephemeral_disk_size
-  # This needs to contain the grootfs + other stuff, so it's slightly larger
-  value: {{ .Values.sizing.diego_cell.ephemeral_disk.size | add 5120 }}
+  value: {{ .Values.sizing.diego_cell.ephemeral_disk.size }}
+{{- /* When using a storage class / PVC, reserve some room for other uses */}}
+{{- $ephemeral_disk_size = sub $ephemeral_disk_size 2048 }}
 {{- end }}
+
+# We are repurposing reserved_space_for_other_jobs_in_mb as the size of the grootfs store
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=garden/properties/grootfs?/reserved_space_for_other_jobs_in_mb
+  value: {{ $ephemeral_disk_size }}
+
+- type: replace
+  path: /instance_groups/name=diego-cell/jobs/name=rep/properties/diego?/executor/disk_capacity_mb
+  value: {{ $ephemeral_disk_size }}
 
 # The loggr UDP forwarder needs some env vars specific to the container they're running in
 # The INDEX env var cannot be rendered properly as part of BPM rendering, it can only be set

--- a/chart/assets/operations/instance_groups/diego-cell.yaml
+++ b/chart/assets/operations/instance_groups/diego-cell.yaml
@@ -45,6 +45,10 @@
 - type: replace
   path: /instance_groups/name=diego-cell/persistent_disk_type?
   value: {{ .Values.sizing.diego_cell.ephemeral_disk.storage_class | quote }}
+- type: replace
+  path: /instance_groups/name=diego-cell/vm_resources?/ephemeral_disk_size
+  # This needs to contain the grootfs + other stuff, so it's slightly larger
+  value: {{ .Values.sizing.diego_cell.ephemeral_disk.size | add 5120 }}
 {{- end }}
 
 # The loggr UDP forwarder needs some env vars specific to the container they're running in

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -19,6 +19,10 @@
     {{- if not .Values.features.eirini.enabled }}
     {{- $cell_count := .Values.sizing.diego_cell.instances | default 1 }}
     {{- $disk_size := .Values.sizing.diego_cell.ephemeral_disk.size }}
+    {{- if .Values.sizing.diego_cell.storage_class }}
+        {{- /* when using a storage class, we will reserve space for other uses. */}}
+        {{- $disk_size = sub $disk_size 2048 }}
+    {{- end }}
     {{- $app_disk_quota := 1024 }}
 
     {{- include "_config.lookup" (list $ "properties.api.cloud_controller_ng.cc.default_app_disk_in_mb") }}


### PR DESCRIPTION
## Description
When we're using PVCs for ephemeral disks for diego-cell, we will need to set the disk size.  The default size of 10Gi is too small to hold the default (grootfs) disk size.  Calculate it based on the user-specified ephemeral disk size, so that it can adjust according to user needs.

It needs to be slightly larger than the user specified size, as it is also used to hold other internal data; as an initial estimate, make it 5Gi larger than requested.  We may be able to adjust this down later, as for initial deployment we appear to only need <300Mi extra.

## Motivation and Context
Fixes #1451

## How Has This Been Tested?
Deployed on AKS in a situation that lead to the discovery of #1451 in the first place.
Checked that we have a generated PVC of 45Gi (when the default is 40Gi).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
  - By basing it on the existing size, we do not need to change the documentation.
- [ ] I have updated the documentation accordingly.
