### PR TITLE
feat: GitHub Actions: disable automatic triggers

### DIFF
--- a/.github/workflows/pull-request-queue.yaml
+++ b/.github/workflows/pull-request-queue.yaml
@@ -1,8 +1,9 @@
 name: enqueue-pr-test
 on:
   # When a PR is approved, add the queue label
-  pull_request_review:
-    types: [submitted]
+  #pull_request_review:
+  #  types: [submitted]
+  workflow_dispatch: {}
 
 jobs:
   enqueue:


### PR DESCRIPTION
## Description

This temporarily disables the automatic triggering of builds / tests; we are currently not using them to block merges.  Leave it possible to manually trigger runs, so that we can continue to develop GitHub Actions until we can require them to pass before merging (replacing Concourse).

We can revert this once GHA can be used as the only CI.

## Motivation and Context
We're running out of GKE quota for CI we need for releasing.  We're not currently blocking merges on GHA anyways.

## How Has This Been Tested?
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.