### PR TITLE
fix: Add NET_ADMIN and NET_RAW to PSP

### DIFF
--- a/chart/templates/rbac.yaml
+++ b/chart/templates/rbac.yaml
@@ -10,7 +10,9 @@ metadata:
 spec:
   allowPrivilegeEscalation: true
   allowedCapabilities:
+  - NET_ADMIN
   - NET_BIND_SERVICE
+  - NET_RAW
   - SYS_ADMIN
   - SYS_RESOURCE
   defaultAllowPrivilegeEscalation: true


### PR DESCRIPTION
Both are used by the rep in the diego-cell.

Fixes #1423