### PR TITLE
feat: chart: add labels to QuarksStatefulSets

### DIFF
--- a/chart/assets/operations/instance_groups.yaml
+++ b/chart/assets/operations/instance_groups.yaml
@@ -1,0 +1,18 @@
+{{/*
+ This sets labels on the generated StatefulSets to include the information about
+ the helm chart.
+*/}}
+{{- include "_config.load" $ }}
+{{- range $ig_name, $ig := .Values.jobs }}
+  {{- $included := false }}
+  {{- range $job := $ig }}
+    {{- $included = list $ $job.condition | include "_config.condition" | eq "true" | or $included }}
+  {{- end }}
+  {{- if $included }}
+    {{- range $key, $value := list $ $ig_name | include "component.labels" | fromYaml }}
+- type: replace
+  path: /instance_groups/name={{ $ig_name }}/env?/bosh/agent/settings/labels/{{ $key | replace "/" "~1" }}
+  value: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
+{{- end }}


### PR DESCRIPTION
## Description
Add the standard labels to the generated QuarksStatefulSets, so that we can see the version when examining a live deployment easier.  The selector are unaffected, as we want to be able to use the previous version for a bit during an upgrade.

## Motivation and Context
When examining an upgrade, it is difficult to figure out what version of KubeCF corresponds to each pod.

## How Has This Been Tested?
Deployed during an upgrade (HA). I have confirmed that:
- The StatefulSets are updated, not recreated (their creation timestamp is from before the upgrade took place).
- The existing pods are rolling as expected — `api-1` is upgraded and ready before `api-0` is upgraded.

(Actually, the upgrade never completes because `api-1` is not counted for bootstrap, so DB migration never takes place, and therefore `api-1` can never get ready.  But that's an existing issue outside this PR.)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
