### PR TITLE
fix: bump brain test release to v0.0.15

### DIFF
--- a/chart/config/releases.yaml
+++ b/chart/config/releases.yaml
@@ -20,7 +20,7 @@ releases:
       tag: 0.1.0
   brain-tests:
     condition: testing.brain_tests.enabled
-    version: v0.0.14
+    version: v0.0.15
   bosh-dns-aliases:
     # not needed for kubecf; functionality provided by quarks-operator
     condition: false


### PR DESCRIPTION
## Description

Brings in a fix for the 005/metron test to handle the differences
between diego and eirini app logs.

## Motivation and Context

See #1371 

## How Has This Been Tested?

Local minikube.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
