### PR TITLE
fix: disable routing api under eirini, not supported

### DIFF
--- a/chart/config/unsupported.yaml
+++ b/chart/config/unsupported.yaml
@@ -10,6 +10,9 @@ unsupported:
     Don't use properties.diego-cell.garden.grootfs.reserved_space_for_other_jobs_in_mb.
     Use sizing.diego_cell.ephemeral_disk.size to set the amount of disk available to the cell.
 
+  features.routing_api.enabled && features.eirini.enabled: |
+    Cannot activate routing-api for eirini. It is not yet supported by this scheduler.
+
   features.embedded_database.enabled && features.external_database.enabled: |
     Cannot simultaneously activate both features.embedded_database and features.external_database.
 

--- a/chart/templates/_features.tpl
+++ b/chart/templates/_features.tpl
@@ -13,4 +13,8 @@
   {{- else }}
     {{- $_ := merge $.Values (dict "features" (dict "external_blobstore" (dict "enabled" false))) }}
   {{- end}}
+  {{- /* Fix routing_api to proper (per-scheduler) default when not overriden by user */}}
+  {{- if kindIs "invalid" $.Values.features.routing_api.enabled }}
+    {{- $_ := set $.Values.features.routing_api "enabled" (not $.Values.features.eirini.enabled) }}
+  {{- end }}
 {{- end }}

--- a/chart/values.schema.yaml
+++ b/chart/values.schema.yaml
@@ -306,6 +306,15 @@ properties:
                   password: {type: string}
                 additionalProperties: false
           additionalProperties: false
+
+      routing_api:
+        type: object
+        properties:
+          enabled:
+            oneOf:
+            - type: boolean
+            - type: 'null'
+
     additionalProperties:
       type: object
       properties:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -348,7 +348,8 @@ features:
   routing_api:
     # Enable the routing API.  Disabling this will also disable TCP routing, which is used for TCP
     # port forwarding.
-    enabled: true
+    # Enabled by default, except under Eirini, where the routing-api is not (yet) supported.
+    enabled: ~
   embedded_database:
     # Enable the embedded database.  If this is disabled, then features.external_database should be
     # configured to use an external database.

--- a/scripts/image_list.rb
+++ b/scripts/image_list.rb
@@ -93,6 +93,9 @@ class HelmRenderer
     # Eirini will throw an error unless a compatible stack is selected
     if values['features']['eirini']['enabled']
       values['install_stacks'] = ['sle15']
+      # Chart will throw an error when trying to use both eirini and
+      # routing_api. Avoid.
+      values['features']['routing_api']['enabled'] = false
     end
     Tempfile.open(['values-', '.yaml']) do |values_file|
       values_file.write values.to_yaml


### PR DESCRIPTION
## Description

- `routing_api.enabled` flag defaults to `nil` now.
- Feature config handling now sets proper default per chosen scheduler.
- Rejects user trying to force `eirini` + `routing_api`.
- Values schema updated (now allowing `nil` for the enabled flag)
- `image_list.rb` script skips the forbidden permutation.

## Motivation and Context

See #1371 and discussion in #1445 

## How Has This Been Tested?

Local minikube

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
