### PR TITLE
fix: Don't allow upgrades unless the embedded database is a singleton

### DIFF
--- a/chart/templates/_config.tpl
+++ b/chart/templates/_config.tpl
@@ -78,6 +78,14 @@
         {{- include "_config.fail" $message }}
       {{- end }}
     {{- end }}
+
+    {{- if and $.Release.IsUpgrade $.Values.features.embedded_database.enabled }}
+      {{- $database := lookup "apps/v1" "StatefulSet" $.Release.Namespace "database" }}
+      {{- if gt $database.spec.replicas 1 }}
+        {{- include "_config.fail" "Cannot upgrade until database has been scaled down to single instance" }}
+      {{- end }}
+    {{- end }}
+
   {{- end }}
 {{- end }}
 


### PR DESCRIPTION
There is a chance of dataloss when we upgrade from HA to SA while also changing the chart version. And we no longer support an embedded HA database, so the user has to scale down before performing the upgrade.

Eventually this code (together with the "unsupported" logic) should be moved to its own template file.
