### PR TITLE
fix: Add sle15 stack to stemcell-pipeline

### DIFF
--- a/.concourse/suse-buildpacks-ci/releases.yaml
+++ b/.concourse/suse-buildpacks-ci/releases.yaml
@@ -48,3 +48,8 @@ releases:
   uri: "git@github.com:SUSE/cf-binary-buildpack-release.git"
   repo: "cf-binary-buildpack-release"
   name_in_values_yaml: "suse-binary-buildpack"
+
+- name: "sle15"
+  uri: "git@github.com:SUSE/cf-sle15-release.git"
+  repo: "cf-sle15-release"
+  name_in_values_yaml: "sle15"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The sle15 stack was not automatically updated. The buildpack releases are handled the same way as the stack so we can reuse the buildpack pipeline to update the stack automatically in the future.

## How Has This Been Tested?
The pipeline was updated and the resulting pr branch #1473 works locally. Only the Docker registry needs to changed once because we will not use dockerhub anymore.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
