### PR TITLE
feat: pull kubecf from a private registry requiring authentication

### DIFF
--- a/chart/config/releases.yaml
+++ b/chart/config/releases.yaml
@@ -18,6 +18,8 @@ releases:
     image:
       repository: ghcr.io/cfcontainerizationbot/kubecf-apps-dns
       tag: 0.1.0
+  # Can also use image `google/cloud-sdk` as an alternative image to provide
+  # kubectl capability
   kubecf_kubectl:
     image:
       repository: ghcr.io/cfcontainerizationbot/kubecf-kubectl

--- a/chart/config/releases.yaml
+++ b/chart/config/releases.yaml
@@ -18,6 +18,10 @@ releases:
     image:
       repository: ghcr.io/cfcontainerizationbot/kubecf-apps-dns
       tag: 0.1.0
+  kubecf_kubectl:
+    image:
+      repository: ghcr.io/cfcontainerizationbot/kubecf-kubectl
+      tag: v1.19.2
   brain-tests:
     condition: testing.brain_tests.enabled
     version: v0.0.15

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -86,16 +86,13 @@ helm.sh/chart: {{ include "kubecf.chart" $root }}
 
 {{- /*
 ==========================================================================================
-| kubecf.imagePullSecrets (list $ $component)
-+-----------------------------------------------------------------------------------------
 | Add imagePullSecrets to service accounts.
 ==========================================================================================
 */ -}}
 {{- define "kubecf.imagePullSecrets" }}
-{{- $root := first . }}
-{{- range $secret_name := $root.Values.kube.image_pull_secrets }}
-- name: {{ $secret_name | quote }}
-{{- end }}
+  {{- range $secret_name := .Values.kube.image_pull_secrets }}
+    - name: {{ $secret_name | quote }}
+  {{- end }}
 {{- end }}
 
 {{- /*

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -85,6 +85,20 @@ helm.sh/chart: {{ include "kubecf.chart" $root }}
 {{- end }}
 
 {{- /*
+==========================================================================================
+| kubecf.imagePullSecrets (list $ $component)
++-----------------------------------------------------------------------------------------
+| Add imagePullSecrets to service accounts.
+==========================================================================================
+*/ -}}
+{{- define "kubecf.imagePullSecrets" }}
+{{- $root := first . }}
+{{- range $secret_name := $root.Values.kube.image_pull_secrets }}
+- name: {{ $secret_name | quote }}
+{{- end }}
+{{- end }}
+
+{{- /*
   Template "kubecf.dig" takes a dict and a list; it indexes the dict with each
   successive element of the list.
 

--- a/chart/templates/patch_serviceaccount.yaml
+++ b/chart/templates/patch_serviceaccount.yaml
@@ -1,5 +1,5 @@
 {{- include "_config.load" $ }}
-{{- if gt (len .Values.kube.image_pull_secrets) 0 }}
+{{- if .Values.kube.image_pull_secrets }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -7,7 +7,7 @@ metadata:
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "-5"
     "helm.sh/hook-delete-policy": hook-succeeded
-  name: default
+  name: patch-sa
   namespace: {{ .Release.Namespace | quote }}
 rules:
 - apiGroups:
@@ -25,12 +25,12 @@ metadata:
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "-5"
     "helm.sh/hook-delete-policy": hook-succeeded
-  name: default
+  name: patch-sa
   namespace: {{ .Release.Namespace | quote }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: default
+  name: patch-sa
 subjects:
 - kind: ServiceAccount
   name: default
@@ -50,15 +50,17 @@ spec:
       restartPolicy: Never
       containers:
       - name: sa
-        image: google/cloud-sdk
+        {{- with $image := $.Values.releases.kubecf_kubectl.image }}
+        image: {{ printf "%s:%s" $image.repository $image.tag | quote }}
+        {{- end }}
         imagePullPolicy: IfNotPresent
 # set image_pull_secrets list
-{{- $image_pull_secret_names := "" }}
+{{- $image_pull_secret_names := list }}
 {{- range $secret_name := $.Values.kube.image_pull_secrets }}
-  {{- $image_pull_secret_names = cat $image_pull_secret_names (printf "{\"name\":%s}," ($secret_name | quote)) }}
+  {{- $image_pull_secret_names = append $image_pull_secret_names (dict "name" $secret_name) }}
 {{- end }}
         command: ["/bin/sh", "-c"]
         args:
         - |
-          kubectl patch serviceaccount default -p '{"imagePullSecrets": [{{ $image_pull_secret_names | trimSuffix "," }} ] }' -n {{ .Release.Namespace }}
+          kubectl patch serviceaccount default -p '{"imagePullSecrets": {{ $image_pull_secret_names | toJson }} }' -n {{ .Release.Namespace }}
 {{- end }}

--- a/chart/templates/patch_serviceaccount.yaml
+++ b/chart/templates/patch_serviceaccount.yaml
@@ -54,11 +54,11 @@ spec:
         image: {{ printf "%s:%s" $image.repository $image.tag | quote }}
         {{- end }}
         imagePullPolicy: IfNotPresent
-# set image_pull_secrets list
-{{- $image_pull_secret_names := list }}
-{{- range $secret_name := $.Values.kube.image_pull_secrets }}
-  {{- $image_pull_secret_names = append $image_pull_secret_names (dict "name" $secret_name) }}
-{{- end }}
+        # set image_pull_secrets list
+        {{- $image_pull_secret_names := list }}
+        {{- range $secret_name := $.Values.kube.image_pull_secrets }}
+          {{- $image_pull_secret_names = append $image_pull_secret_names (dict "name" $secret_name) }}
+        {{- end }}
         command: ["/bin/sh", "-c"]
         args:
         - |

--- a/chart/templates/patch_serviceaccount.yaml
+++ b/chart/templates/patch_serviceaccount.yaml
@@ -54,7 +54,8 @@ spec:
         image: {{ printf "%s:%s" $image.repository $image.tag | quote }}
         {{- end }}
         imagePullPolicy: IfNotPresent
-        # set image_pull_secrets list
+        # Patch serviceaccount with image_pull_secret_name list. If imagepullsecrets
+        # exists within a serviceaccount, a patch just adds the rest in.
         {{- $image_pull_secret_names := list }}
         {{- range $secret_name := $.Values.kube.image_pull_secrets }}
           {{- $image_pull_secret_names = append $image_pull_secret_names (dict "name" $secret_name) }}

--- a/chart/templates/patch_serviceaccount.yaml
+++ b/chart/templates/patch_serviceaccount.yaml
@@ -34,7 +34,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: default
-  namespace: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace | quote }}
 ---
 apiVersion: batch/v1
 kind: Job
@@ -53,9 +53,12 @@ spec:
         image: google/cloud-sdk
         imagePullPolicy: IfNotPresent
 # set image_pull_secrets list
-{{- $image_pull_secret_names := list }}
+{{- $image_pull_secret_names := "" }}
 {{- range $secret_name := $.Values.kube.image_pull_secrets }}
-  {{- $image_pull_secret_names = append $stacks (dict "name" $secret_name) }}
+  {{- $image_pull_secret_names = cat $image_pull_secret_names (printf "{\"name\":%s}," ($secret_name | quote)) }}
 {{- end }}
-        command: ["/bin/sh", "-c", "kubectl patch serviceaccount default -p '{\"imagePullSecrets\": [ {{ $image_pull_secret_names }} ]}'"]
+        command: ["/bin/sh", "-c"]
+        args:
+        - |
+          kubectl patch serviceaccount default -p '{"imagePullSecrets": [{{ $image_pull_secret_names | trimSuffix "," }} ] }' -n {{ .Release.Namespace }}
 {{- end }}

--- a/chart/templates/patch_serviceaccount.yaml
+++ b/chart/templates/patch_serviceaccount.yaml
@@ -1,0 +1,61 @@
+{{- include "_config.load" $ }}
+{{- if gt (len .Values.kube.image_pull_secrets) 0 }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": hook-succeeded
+  name: default
+  namespace: {{ .Release.Namespace | quote }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": hook-succeeded
+  name: default
+  namespace: {{ .Release.Namespace | quote }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: default
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: {{ .Release.Name }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: patch-sa
+  namespace: {{ .Release.Namespace | quote }}
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: sa
+        image: google/cloud-sdk
+        imagePullPolicy: IfNotPresent
+    # set image_pull_secrets list
+    {{- $image_pull_secret_names := list }}
+    {{- range $secret_name := $.Values.kube.image_pull_secrets }}
+      {{- $image_pull_secret_names = append $image_pull_secret_names "{ name: $secret_name }" }}
+        command: ["/bin/sh", "-c", "kubectl patch serviceaccount default -p '{\"imagePullSecrets\": [{\"name\": \"secret-key\"}]}'"]
+    {{- end }}
+{{- end }}

--- a/chart/templates/patch_serviceaccount.yaml
+++ b/chart/templates/patch_serviceaccount.yaml
@@ -52,10 +52,10 @@ spec:
       - name: sa
         image: google/cloud-sdk
         imagePullPolicy: IfNotPresent
-    # set image_pull_secrets list
-    {{- $image_pull_secret_names := list }}
-    {{- range $secret_name := $.Values.kube.image_pull_secrets }}
-      {{- $image_pull_secret_names = append $image_pull_secret_names "{ name: $secret_name }" }}
-        command: ["/bin/sh", "-c", "kubectl patch serviceaccount default -p '{\"imagePullSecrets\": [{\"name\": \"secret-key\"}]}'"]
-    {{- end }}
+# set image_pull_secrets list
+{{- $image_pull_secret_names := list }}
+{{- range $secret_name := $.Values.kube.image_pull_secrets }}
+  {{- $image_pull_secret_names = append $stacks (dict "name" $secret_name) }}
+{{- end }}
+        command: ["/bin/sh", "-c", "kubectl patch serviceaccount default -p '{\"imagePullSecrets\": [ {{ $image_pull_secret_names }} ]}'"]
 {{- end }}

--- a/chart/values.schema.yaml
+++ b/chart/values.schema.yaml
@@ -335,6 +335,11 @@ properties:
   kube:
     type: object
     properties:
+      image_pull_secrets:
+        type: array
+        items: {type: string}
+        minItems: 0
+        uniqueItems: true
       psp:
         type: object
         properties:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -44,6 +44,9 @@ kube:
   # prevent KubeCF from creating a new one, set the kube.psp.default with the PSP name.
   psp:
     default: ~
+  # The global list of image pull secret names. The secrets themselves will have to be created by
+  # the user before installing kubecf.
+  image_pull_secrets: []
 
 # Set to true to enable support for multiple availability zones.
 multi_az: false

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -46,7 +46,7 @@ kube:
     default: ~
   # The global list of image pull secret names. The secrets themselves will have to be created by
   # the user before installing kubecf.
-  image_pull_secrets: [foo, bar]
+  image_pull_secrets: []
 
 # Set to true to enable support for multiple availability zones.
 multi_az: false

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -46,7 +46,7 @@ kube:
     default: ~
   # The global list of image pull secret names. The secrets themselves will have to be created by
   # the user before installing kubecf.
-  image_pull_secrets: []
+  image_pull_secrets: [foo, bar]
 
 # Set to true to enable support for multiple availability zones.
 multi_az: false

--- a/mixins/bits/templates/bits-service-account.yml
+++ b/mixins/bits/templates/bits-service-account.yml
@@ -6,6 +6,12 @@ kind: ServiceAccount
 metadata:
   name: bits-service
   namespace: {{ .Release.Namespace }}
+{{- if gt (len .Values.kube.image_pull_secrets) 0 }}
+imagePullSecrets:
+  {{- range $secret_name := $.Values.kube.image_pull_secrets }}
+  - name: "{{ $secret_name }}"
+  {{- end }}
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/mixins/bits/templates/bits-service-account.yml
+++ b/mixins/bits/templates/bits-service-account.yml
@@ -8,7 +8,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 {{- if .Values.kube.image_pull_secrets }}
 imagePullSecrets:
-{{- list . "" | include "kubecf.imagePullSecrets" }}
+{{- include "kubecf.imagePullSecrets" }}
 {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/mixins/bits/templates/bits-service-account.yml
+++ b/mixins/bits/templates/bits-service-account.yml
@@ -8,7 +8,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 {{- if .Values.kube.image_pull_secrets }}
 imagePullSecrets:
-{{- include "kubecf.imagePullSecrets" }}
+{{- include "kubecf.imagePullSecrets" $ }}
 {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/mixins/bits/templates/bits-service-account.yml
+++ b/mixins/bits/templates/bits-service-account.yml
@@ -6,11 +6,9 @@ kind: ServiceAccount
 metadata:
   name: bits-service
   namespace: {{ .Release.Namespace }}
-{{- if gt (len .Values.kube.image_pull_secrets) 0 }}
+{{- if .Values.kube.image_pull_secrets }}
 imagePullSecrets:
-  {{- range $secret_name := $.Values.kube.image_pull_secrets }}
-  - name: "{{ $secret_name }}"
-  {{- end }}
+{{- list . "" | include "kubecf.imagePullSecrets" }}
 {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/mixins/eirini/templates/events-service-account.yml
+++ b/mixins/eirini/templates/events-service-account.yml
@@ -7,6 +7,12 @@ kind: ServiceAccount
 metadata:
   name: eirini-events
   namespace: {{ .Release.Namespace }}
+{{- if gt (len .Values.kube.image_pull_secrets) 0 }}
+imagePullSecrets:
+  {{- range $secret_name := $.Values.kube.image_pull_secrets }}
+  - name: "{{ $secret_name }}"
+  {{- end }}
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/mixins/eirini/templates/events-service-account.yml
+++ b/mixins/eirini/templates/events-service-account.yml
@@ -9,7 +9,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 {{- if .Values.kube.image_pull_secrets }}
 imagePullSecrets:
-{{- list . "" | include "kubecf.imagePullSecrets" }}
+{{- include "kubecf.imagePullSecrets" }}
 {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/mixins/eirini/templates/events-service-account.yml
+++ b/mixins/eirini/templates/events-service-account.yml
@@ -9,7 +9,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 {{- if .Values.kube.image_pull_secrets }}
 imagePullSecrets:
-{{- include "kubecf.imagePullSecrets" }}
+{{- include "kubecf.imagePullSecrets" $ }}
 {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/mixins/eirini/templates/events-service-account.yml
+++ b/mixins/eirini/templates/events-service-account.yml
@@ -7,11 +7,9 @@ kind: ServiceAccount
 metadata:
   name: eirini-events
   namespace: {{ .Release.Namespace }}
-{{- if gt (len .Values.kube.image_pull_secrets) 0 }}
+{{- if .Values.kube.image_pull_secrets }}
 imagePullSecrets:
-  {{- range $secret_name := $.Values.kube.image_pull_secrets }}
-  - name: "{{ $secret_name }}"
-  {{- end }}
+{{- list . "" | include "kubecf.imagePullSecrets" }}
 {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/mixins/eirini/templates/metrics-service-account.yml
+++ b/mixins/eirini/templates/metrics-service-account.yml
@@ -7,6 +7,12 @@ kind: ServiceAccount
 metadata:
   name: eirini-metrics
   namespace: {{ .Release.Namespace }}
+{{- if gt (len .Values.kube.image_pull_secrets) 0 }}
+imagePullSecrets:
+  {{- range $secret_name := $.Values.kube.image_pull_secrets }}
+  - name: "{{ $secret_name }}"
+  {{- end }}
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/mixins/eirini/templates/metrics-service-account.yml
+++ b/mixins/eirini/templates/metrics-service-account.yml
@@ -9,7 +9,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 {{- if .Values.kube.image_pull_secrets }}
 imagePullSecrets:
-{{- include "kubecf.imagePullSecrets" }}
+{{- include "kubecf.imagePullSecrets" $ }}
 {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/mixins/eirini/templates/metrics-service-account.yml
+++ b/mixins/eirini/templates/metrics-service-account.yml
@@ -7,12 +7,10 @@ kind: ServiceAccount
 metadata:
   name: eirini-metrics
   namespace: {{ .Release.Namespace }}
-{{- if gt (len .Values.kube.image_pull_secrets) 0 }}
+{{- if .Values.kube.image_pull_secrets }}
 imagePullSecrets:
-  {{- range $secret_name := $.Values.kube.image_pull_secrets }}
-  - name: "{{ $secret_name }}"
+{{- list . "" | include "kubecf.imagePullSecrets" }}
   {{- end }}
-{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/mixins/eirini/templates/metrics-service-account.yml
+++ b/mixins/eirini/templates/metrics-service-account.yml
@@ -9,8 +9,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
 {{- if .Values.kube.image_pull_secrets }}
 imagePullSecrets:
-{{- list . "" | include "kubecf.imagePullSecrets" }}
-  {{- end }}
+{{- include "kubecf.imagePullSecrets" }}
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/mixins/eirini/templates/routing-service-account.yml
+++ b/mixins/eirini/templates/routing-service-account.yml
@@ -7,6 +7,12 @@ kind: ServiceAccount
 metadata:
   name: eirini-routing
   namespace: {{ .Release.Namespace }}
+{{- if gt (len .Values.kube.image_pull_secrets) 0 }}
+imagePullSecrets:
+  {{- range $secret_name := $.Values.kube.image_pull_secrets }}
+  - name: "{{ $secret_name }}"
+  {{- end }}
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/mixins/eirini/templates/routing-service-account.yml
+++ b/mixins/eirini/templates/routing-service-account.yml
@@ -9,7 +9,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 {{- if .Values.kube.image_pull_secrets }}
 imagePullSecrets:
-{{- list . "" | include "kubecf.imagePullSecrets" }}
+{{- include "kubecf.imagePullSecrets" }}
 {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/mixins/eirini/templates/routing-service-account.yml
+++ b/mixins/eirini/templates/routing-service-account.yml
@@ -9,7 +9,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 {{- if .Values.kube.image_pull_secrets }}
 imagePullSecrets:
-{{- include "kubecf.imagePullSecrets" }}
+{{- include "kubecf.imagePullSecrets" $ }}
 {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/mixins/eirini/templates/routing-service-account.yml
+++ b/mixins/eirini/templates/routing-service-account.yml
@@ -7,11 +7,9 @@ kind: ServiceAccount
 metadata:
   name: eirini-routing
   namespace: {{ .Release.Namespace }}
-{{- if gt (len .Values.kube.image_pull_secrets) 0 }}
+{{- if .Values.kube.image_pull_secrets }}
 imagePullSecrets:
-  {{- range $secret_name := $.Values.kube.image_pull_secrets }}
-  - name: "{{ $secret_name }}"
-  {{- end }}
+{{- list . "" | include "kubecf.imagePullSecrets" }}
 {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/mixins/eirini/templates/serviceaccount.yaml
+++ b/mixins/eirini/templates/serviceaccount.yaml
@@ -6,4 +6,10 @@ kind: ServiceAccount
 metadata:
   name: opi
   namespace: {{ .Release.Namespace }}
+{{- if gt (len .Values.kube.image_pull_secrets) 0 }}
+imagePullSecrets:
+  {{- range $secret_name := $.Values.kube.image_pull_secrets }}
+  - name: "{{ $secret_name }}"
+  {{- end }}
+{{- end }}
 {{- end }}

--- a/mixins/eirini/templates/serviceaccount.yaml
+++ b/mixins/eirini/templates/serviceaccount.yaml
@@ -8,6 +8,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
 {{- if .Values.kube.image_pull_secrets }}
 imagePullSecrets:
-{{- list . "" | include "kubecf.imagePullSecrets" }}
+{{- include "kubecf.imagePullSecrets" }}
 {{- end }}
 {{- end }}

--- a/mixins/eirini/templates/serviceaccount.yaml
+++ b/mixins/eirini/templates/serviceaccount.yaml
@@ -6,10 +6,8 @@ kind: ServiceAccount
 metadata:
   name: opi
   namespace: {{ .Release.Namespace }}
-{{- if gt (len .Values.kube.image_pull_secrets) 0 }}
+{{- if .Values.kube.image_pull_secrets }}
 imagePullSecrets:
-  {{- range $secret_name := $.Values.kube.image_pull_secrets }}
-  - name: "{{ $secret_name }}"
-  {{- end }}
+{{- list . "" | include "kubecf.imagePullSecrets" }}
 {{- end }}
 {{- end }}

--- a/mixins/eirini/templates/serviceaccount.yaml
+++ b/mixins/eirini/templates/serviceaccount.yaml
@@ -8,6 +8,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
 {{- if .Values.kube.image_pull_secrets }}
 imagePullSecrets:
-{{- include "kubecf.imagePullSecrets" }}
+{{- include "kubecf.imagePullSecrets" $ }}
 {{- end }}
 {{- end }}

--- a/mixins/eirini/templates/staging-reporter-service-account.yml
+++ b/mixins/eirini/templates/staging-reporter-service-account.yml
@@ -7,6 +7,12 @@ kind: ServiceAccount
 metadata:
   name: eirini-staging-reporter
   namespace: {{ .Release.Namespace }}
+{{- if gt (len .Values.kube.image_pull_secrets) 0 }}
+imagePullSecrets:
+  {{- range $secret_name := $.Values.kube.image_pull_secrets }}
+  - name: "{{ $secret_name }}"
+  {{- end }}
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/mixins/eirini/templates/staging-reporter-service-account.yml
+++ b/mixins/eirini/templates/staging-reporter-service-account.yml
@@ -9,7 +9,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 {{- if .Values.kube.image_pull_secrets }}
 imagePullSecrets:
-{{- list . "" | include "kubecf.imagePullSecrets" }}
+{{- include "kubecf.imagePullSecrets" }}
 {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/mixins/eirini/templates/staging-reporter-service-account.yml
+++ b/mixins/eirini/templates/staging-reporter-service-account.yml
@@ -9,7 +9,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 {{- if .Values.kube.image_pull_secrets }}
 imagePullSecrets:
-{{- include "kubecf.imagePullSecrets" }}
+{{- include "kubecf.imagePullSecrets" $ }}
 {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/mixins/eirini/templates/staging-reporter-service-account.yml
+++ b/mixins/eirini/templates/staging-reporter-service-account.yml
@@ -7,11 +7,9 @@ kind: ServiceAccount
 metadata:
   name: eirini-staging-reporter
   namespace: {{ .Release.Namespace }}
-{{- if gt (len .Values.kube.image_pull_secrets) 0 }}
+{{- if .Values.kube.image_pull_secrets }}
 imagePullSecrets:
-  {{- range $secret_name := $.Values.kube.image_pull_secrets }}
-  - name: "{{ $secret_name }}"
-  {{- end }}
+{{- list . "" | include "kubecf.imagePullSecrets" }}
 {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/mixins/eirinix/templates/eirinix-serviceaccount.yaml
+++ b/mixins/eirinix/templates/eirinix-serviceaccount.yaml
@@ -6,6 +6,12 @@ kind: ServiceAccount
 metadata:
   name: {{ .Values.eirinix.service_account.name | quote }}
   namespace: {{ .Release.Namespace | quote }}
+{{- if gt (len .Values.kube.image_pull_secrets) 0 }}
+imagePullSecrets:
+  {{- range $secret_name := $.Values.kube.image_pull_secrets }}
+  - name: "{{ $secret_name }}"
+  {{- end }}
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/mixins/eirinix/templates/eirinix-serviceaccount.yaml
+++ b/mixins/eirinix/templates/eirinix-serviceaccount.yaml
@@ -8,7 +8,7 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
 {{- if .Values.kube.image_pull_secrets }}
 imagePullSecrets:
-{{- list . "" | include "kubecf.imagePullSecrets" }}
+{{- include "kubecf.imagePullSecrets" }}
 {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/mixins/eirinix/templates/eirinix-serviceaccount.yaml
+++ b/mixins/eirinix/templates/eirinix-serviceaccount.yaml
@@ -8,7 +8,7 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
 {{- if .Values.kube.image_pull_secrets }}
 imagePullSecrets:
-{{- include "kubecf.imagePullSecrets" }}
+{{- include "kubecf.imagePullSecrets" $ }}
 {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/mixins/eirinix/templates/eirinix-serviceaccount.yaml
+++ b/mixins/eirinix/templates/eirinix-serviceaccount.yaml
@@ -6,11 +6,9 @@ kind: ServiceAccount
 metadata:
   name: {{ .Values.eirinix.service_account.name | quote }}
   namespace: {{ .Release.Namespace | quote }}
-{{- if gt (len .Values.kube.image_pull_secrets) 0 }}
+{{- if .Values.kube.image_pull_secrets }}
 imagePullSecrets:
-  {{- range $secret_name := $.Values.kube.image_pull_secrets }}
-  - name: "{{ $secret_name }}"
-  {{- end }}
+{{- list . "" | include "kubecf.imagePullSecrets" }}
 {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Allow users to define a list of imagepullsecret names allowing kubecf to pull from private registries requiring authentication.

## Description
Allow users to define a list of imagepullsecret names. Secrets would have to be created prior. These imagepullsecret names are then added to the serviceaccounts used by kubecf, allowing kubecf pods to pull from private registries requiring authentication. The serviceaccounts updated are:
```
default (namespace kubecf)
eirinix
opi
eirini-events
eirini-metrics
eirini-routing
eirini-staging-reporter
```
The `default` serviceaccount is updated with imagepullsecrets using helm/pre-install method. While the rest are updated by adding the entries to each of the corresponding template serviceaccount.

## Motivation and Context
Allows kubecf to pull from private registries requiring authentication.
Related issue: https://github.com/cloudfoundry-incubator/kubecf/issues/1421

## How Has This Been Tested?
Tested locally using kubecf version `2.5.8` and cf-operator version `6.1.14+0.g22ccdd3a` on GKE. Details about creating the docker-registry secret, updating serviceaccounts with imagepullsecrets, doing kubecf helm install, and proof of kubecf pods pulling from a private registry are here:
[test-kubecf-install-with-imagepullsecrets.txt](https://github.com/cloudfoundry-incubator/kubecf/files/5377464/test-kubecf-install-with-imagepullsecrets.txt)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
