### PR TITLE
feat: added capability to configure staging serviceaccount name

### DIFF
--- a/mixins/eirini/config/eirini.yaml
+++ b/mixins/eirini/config/eirini.yaml
@@ -89,6 +89,8 @@ eirini:
 
     staging:
       enable: true
+      application_service_account: "eirini"
+      staging_service_account: "eirini"
       downloader_image: registry.suse.com/cap-staging/recipe-downloader
       downloader_image_tag: "1.8.0-24.56"
       executor_image: registry.suse.com/cap-staging/recipe-executor

--- a/mixins/eirini/templates/configmap.yaml
+++ b/mixins/eirini/templates/configmap.yaml
@@ -60,7 +60,8 @@ data:
       server_key_path: "/workspace/jobs/opi/secrets/eirini-server.key"
       tls_port: 8085
       disk_limit_mb: {{ .Values.eirini.opi.disk_limit_mb }}
-      application_service_account: eirini
+      application_service_account: {{ .Values.eirini.opi.staging.application_service_account }}
+      staging_service_account: {{ .Values.eirini.opi.staging.staging_service_account }}
       allow_run_image_as_root: false
   routing.yml: |
     app_namespace: {{ .Values.eirini.opi.namespace }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added the capability to configure servicaccountname for eirini staging job and eirini apps.

## Description
Add to default eirini configuration the entry `staging_service_account` for configuring eirini staging job serviceaccount name. Also updated to allow same configuration for `application_service_account` in default eirini configuration for consistency.

## Motivation and Context
We’ve been trying to test kubecf 2.5.8 and noticed that the eirini staging jobs doesn’t use `serviceAccountName: eirini` anymore and also annotation `seccomp.security.alpha.kubernetes.io/pod: runtime/default` has been added. Since we’re running on OpenShift, the setting of the annotation causes permission denied errors and we can’t fix this because there’s no `serviceAccountName` to configure/attach a SecurityContextConstraints for.

It was suggested by eirini-dev to configure field `staging_service_account` in order to fix this.

## How Has This Been Tested?
Tested locally using kubecf version `2.5.8` and cf-operator version `6.1.17+0.gec409fd7`.

Screenshot of serviceaccountname in staging job:
<img width="1154" alt="Screenshot 2020-10-19 at 15 34 37" src="https://user-images.githubusercontent.com/47635090/96467394-c4826500-1222-11eb-8856-bb662f0edb73.png">

Which allows us to configure a SecurityContextConstraints and push an app:
```
cf push nodejs-sample-1
Pushing app nodejs-sample-1 to org demo-org / space demo-space as admin...
Applying manifest file ../nodejs/manifest.yml...
Manifest applied
Packaging files to upload...
Uploading files...
 968 B / 968 B [======================================================================================================================================================] 100.00% 1s

Waiting for API to complete processing files...

Staging app and tracing logs...
   2020/10/19 14:34:25 Installing dependencies
   2020/10/19 14:35:27 Cleaning cache dir
   2020/10/19 14:35:27 Detecting buildpack
   -----> Nodejs Buildpack version 1.7.25
   -----> Installing binaries
   engines.node (package.json): 10.x
   engines.npm (package.json): 6.x
   -----> Installing node 10.22.0
   Download [https://buildpacks.cloudfoundry.org/dependencies/node/node_10.22.0_linux_x64_cflinuxfs3_43616969.tgz]
   npm 6.14.6 already installed with node
   -----> Installing yarn 1.22.4
   Download [https://buildpacks.cloudfoundry.org/dependencies/yarn/yarn-1.22.4-any-stack-24ca2294.tgz]
   Installed yarn 1.22.4
   -----> Creating runtime environment
   PRO TIP: It is recommended to vendor the application's Node.js dependencies
   Visit http://docs.cloudfoundry.org/buildpacks/node/index.html#vendoring
   NODE_ENV=production
   NODE_HOME=/tmp/contents812490370/deps/0/node
   NODE_MODULES_CACHE=true
   NODE_VERBOSE=false
   NPM_CONFIG_LOGLEVEL=error
   NPM_CONFIG_PRODUCTION=true
   -----> Building dependencies
   Installing node modules (package.json + package-lock.json)
   up to date in 0.4s
   found 0 vulnerabilities
   
   Contrast Security no credentials found. Will not write environment files.
   2020/10/19 14:35:34 Building droplet release
   2020/10/19 14:35:34 Creating app artifact

Waiting for app nodejs-sample-1 to start...

Instances starting...

name:                nodejs-sample-1
requested state:     started
isolation segment:   placeholder
routes:              nodejs-sample-1-hilarious-bandicoot-qb.169.55.130.195.nip.io
last uploaded:       Mon 19 Oct 15:35:52 BST 2020
stack:               cflinuxfs3
buildpacks:          
isolation segment:   placeholder
	name               version   detect output   buildpack name
	nodejs_buildpack   1.7.25    nodejs          nodejs

type:            web
sidecars:        
instances:       1/1
memory usage:    256M
start command:   node web.js
     state     since                  cpu    memory      disk       details
#0   running   2020-10-19T14:36:01Z   0.0%   0 of 256M   4K of 1G  
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [ x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
