### PR TITLE
fix: Inline helm_ls and helm_delete

### DIFF
--- a/scripts/cf-operator-delete.sh
+++ b/scripts/cf-operator-delete.sh
@@ -3,8 +3,8 @@ source scripts/include/setup.sh
 
 require_tools kubectl helm
 
-if helm_ls 2>/dev/null | grep -qi cf-operator ; then
-    helm_delete cf-operator --namespace cf-operator
+if helm ls --namespace "${CF_OPERATOR_NS}" 2>/dev/null | grep -qi cf-operator ; then
+    helm delete cf-operator --namespace "${CF_OPERATOR_NS}"
 fi
 
 kubectl delete --ignore-not-found ns "${CF_OPERATOR_NS}"


### PR DESCRIPTION
These are catapult functions that are not defined in kubecf. They are wrappers that work with both helm 2 and helm 3, but the kubecf scripts all require helm 3, so this isn't necessary.

Also don't hardcode the operator namespace, but use the proper config variable.
