### PR TITLE
feat: Improvements to GitHub Actions workflow

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,46 @@
+# GitHub Workflows
+
+This directory contains the definitions for [GitHub Actions workflows].
+
+[GitHub Actions workflows]: https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions
+
+<!-- omit in toc -->
+## Table of Contents
+- [Building & Testing](#building--testing)
+- [Pull Request Summary Linting](#pull-request-summary-linting)
+
+## Building & Testing
+
+The pull request & continuous integration workflow is:
+
+- On pull requests approval, [`pull-request-queue.yaml`] adds a [`pr-test-queue`]
+  label to pull requests that are eligible for building.
+- Humans may also manually attach the [`pr-test-queue`] label to pull requests
+  to trigger builds without approval or to re-trigger builds.
+- Every 10 minutes, [`pull-request-schedule.yaml`] will check for capacity to
+  run tests:
+  - Check for clusters that are labelled as being triggered by GitHub PRs, but
+    which do not have matching PR runs, and initiate deletion.
+  - If we do not have capacity for additional clusters, abort and wait to be
+    triggered again next time.
+  - For each cluster we have capacity for:
+    - Locate the issue with the oldest [`pr-test-queue`] label, and:
+      - Remove the label
+      - Apply a [`pr-test-trigger`] label
+- Upon the [`pr-test-trigger`] label being applied, [`pull-request-ci.yaml`]
+  will remove the label again and run tests.
+
+[`pull-request-queue.yaml`]: pull-request-queue.yaml
+[`pr-test-queue`]: https://github.com/cloudfoundry-incubator/kubecf/issues?q=label%3Apr-test-queue
+[`pull-request-schedule.yaml`]: pull-request-schedule.yaml
+[`pr-test-trigger`]: https://github.com/cloudfoundry-incubator/kubecf/issues?q=label%3Apr-test-trigger
+[`pull-request-ci.yaml`]: pull-request-ci.yaml
+
+## Pull Request Summary Linting
+
+[`conventional-commits-lint.yml`] checks that pull requests have a summary that
+follows [Conventional Commits], as specified in [RFD 002].
+
+[`conventional-commits-lint.yml`]: conventional-commits-lint.yml
+[Conventional Commits]: https://www.conventionalcommits.org/en/v1.0.0/
+[RFD 002]: /doc/rfd/rfd/0002/README.md

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -8,6 +8,7 @@ This directory contains the definitions for [GitHub Actions workflows].
 ## Table of Contents
 - [Building & Testing](#building--testing)
 - [Pull Request Summary Linting](#pull-request-summary-linting)
+- [Pull Request Linting](#pull-request-linting)
 
 ## Building & Testing
 
@@ -44,3 +45,11 @@ follows [Conventional Commits], as specified in [RFD 002].
 [`conventional-commits-lint.yml`]: conventional-commits-lint.yml
 [Conventional Commits]: https://www.conventionalcommits.org/en/v1.0.0/
 [RFD 002]: /doc/rfd/rfd/0002/README.md
+
+## Pull Request Linting
+
+[`pull-request-lint.yaml`] checks that pull requests pass the basic linting
+target in KubeCF.  This is run for every PR targeting `master`, before they have
+been reviewed.
+
+[`pull-request-lint.yaml`]: pull-request-lint.yaml

--- a/.github/workflows/pull-request-ci.yaml
+++ b/.github/workflows/pull-request-ci.yaml
@@ -1,4 +1,4 @@
-name: CI
+name: Pull Request Tests
 on:
   # Trigger the workflow when PRs are labeled
   pull_request_target:
@@ -10,11 +10,11 @@ env:
 
 jobs:
 
-  # The first thing we do is to check that the PR has the pr-test-queue label
+  # The first thing we do is to check that the PR has the pr-test-trigger label
   # If it doesn't have it, the flow stops. If it does, we remove it (approval is good for one run only).
   dequeue:
-    name: dequeue
-    if: contains(github.event.pull_request.labels.*.name, 'pr-test-queue')
+    name: Dequeue
+    if: contains(github.event.pull_request.labels.*.name, 'pr-test-trigger')
     runs-on: ubuntu-20.04
     steps:
       - uses: actions-ecosystem/action-remove-labels@556e306
@@ -22,48 +22,9 @@ jobs:
           github_token: ${{ secrets.github_token }}
           labels: pr-test-queue
 
-  lint:
-    name: lint
-    needs: [dequeue]
-    runs-on: ubuntu-20.04
-    env:
-      PINNED_TOOLS: true
-      TOOLS_DIR: ${{ github.workspace }}/tools
-    defaults:
-      run:
-        working-directory: kubecf
-
-    steps:
-      # Checkout kubecf
-      - name: Checkout KubeCF
-        uses: actions/checkout@v2
-        with:
-          path: kubecf
-          fetch-depth: 0
-          submodules: recursive
-
-      # Python setup
-      - uses: actions/setup-python@v2
-        with:
-          python-version: '3.x'
-
-      # Caching tools like helm, jq, git, y2j, yamllint etc
-      - name: cache.tools
-        uses: actions/cache@v2
-        with:
-          path: ${{ github.workspace }}/tools
-          key: ${{ runner.os }}-tools
-
-      # Install tools
-      - run: make tools-install
-
-      # Check lint
-      - run: make lint
-
   build:
-    name: build
+    name: Build
     runs-on: ubuntu-20.04
-    needs: lint
     env:
       PINNED_TOOLS: true
       TOOLS_DIR: ${{ github.workspace }}/tools
@@ -114,7 +75,7 @@ jobs:
           path: ${{ github.workspace }}/bundle
 
   tests:
-    name: tests
+    name: Tests
     runs-on: ubuntu-20.04
     continue-on-error: ${{ matrix.experimental }}
     needs: build
@@ -281,7 +242,6 @@ jobs:
           {{- $ | toYAML }}
           EOF
         env:
-          BACKEND: gke
           AUTOSCALER: "true"
 
       # Helm install cf-operator

--- a/.github/workflows/pull-request-ci.yaml
+++ b/.github/workflows/pull-request-ci.yaml
@@ -186,6 +186,7 @@ jobs:
           GKE_NODE_COUNT: 1
           GKE_PREEMPTIBLE: true
           GKE_INSTANCE_TYPE: n1-highcpu-16
+          EXTRA_LABELS: '{"ci": "${{ github.run_id }}"}'
 
       # Providing kubeconfig for debugging
       - name: export KUBECONFIG

--- a/.github/workflows/pull-request-lint.yaml
+++ b/.github/workflows/pull-request-lint.yaml
@@ -1,0 +1,38 @@
+name: Pull Request Linting
+on:
+  # Trigger the workflow when PRs pushed; we still run the workflow files from
+  # the master branch, to ensure that malicious actors cannot exfiltrate any
+  # secrets.
+  pull_request_target:
+    branches: [master]
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-20.04
+    env:
+      PINNED_TOOLS: true
+      TOOLS_DIR: ${{ github.workspace }}/tools
+    defaults:
+      run:
+        working-directory: kubecf
+
+    steps:
+      # Python setup
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      # Checkout kubecf
+      - name: Checkout KubeCF
+        uses: actions/checkout@v2
+        with:
+          path: kubecf
+          fetch-depth: 0
+          submodules: recursive
+
+      # Install tools
+      - run: make tools-install
+
+      # Check lint
+      - run: make lint

--- a/.github/workflows/pull-request-lint.yaml
+++ b/.github/workflows/pull-request-lint.yaml
@@ -30,6 +30,7 @@ jobs:
           path: kubecf
           fetch-depth: 0
           submodules: recursive
+          persist-credentials: false
 
       # Install tools
       - run: make tools-install

--- a/.github/workflows/pull-request-lint.yaml
+++ b/.github/workflows/pull-request-lint.yaml
@@ -2,7 +2,9 @@ name: Pull Request Linting
 on:
   # Trigger the workflow when PRs pushed; we still run the workflow files from
   # the master branch, to ensure that malicious actors cannot exfiltrate any
-  # secrets.
+  # secrets.  It is important that we don't expose any secrets to the checked-
+  # out code, both in the environment as well as on disk (i.e. we must run
+  # actions/checkout with persist-credentials: false).
   pull_request_target:
     branches: [master]
 

--- a/.github/workflows/pull-request-schedule.yaml
+++ b/.github/workflows/pull-request-schedule.yaml
@@ -1,0 +1,103 @@
+name: Pull Request Scheduler
+on:
+  schedule:
+  - cron: '*/15 * * * *'
+  workflow_dispatch: {}
+
+env:
+  BACKEND: gke
+  CLUSTERS_PER_PR: "2"
+  MAX_CLUSTERS: "5"
+  OWNER: ${{ github.repository_owner }}
+  LABEL_QUEUE: pr-test-queue
+  LABEL_TRIGGER: pr-test-trigger
+
+jobs:
+  determine-capacity:
+    name: Determine Capacity
+    runs-on: ubuntu-latest
+    outputs:
+      # The number of pull requests we can start testing now.
+      capacity: ${{ steps.calculate-capacity.outputs.capacity }}
+    env:
+      GKE_PROJECT: ${{ secrets.GKE_PROJECT }}
+    steps:
+    - name: Checkout KubeCF
+      # This is only needed to find the GitHub script in the find-jobs step.
+      uses: actions/checkout@v2
+    - name: Checkout catapult
+      uses: actions/checkout@v2
+      with:
+        repository: SUSE/catapult
+        path: catapult
+
+    # set GKE secret. TBD: use vault instead
+    - name: Setup Cloud Provider Credentials
+      run: |
+        json_file="$(mktemp)"
+        cat > "${json_file}" <<< "${GKE_CRED_JSON}"
+        echo "GKE_CRED_JSON=${json_file}" >> "${GITHUB_ENV}"
+      env:
+        GKE_CRED_JSON: ${{ secrets.GKE_CRED_JSON }}
+
+    - name: Find Clusters
+      run: make find-resources
+      working-directory: catapult
+      env:
+        GKE_LOCATION: ${{ secrets.GKE_LOCATION }}
+        GKE_PROJECT: ${{ secrets.GKE_PROJECT }}
+        OUTPUT_FILE: ${{ github.workspace }}/resources.json
+
+    - name: Find Running Jobs
+      id: find-jobs
+      uses: actions/github-script@v3
+      with:
+        result-encoding: string
+        script: |
+          const script_path = ".github/workflows/pull-request-schedule/find-jobs.js";
+          const script = require(`${process.env.GITHUB_WORKSPACE}/${script_path}`);
+          return await script({github, context});
+
+    - name: Clean Up Unused Clusters
+      run: make force-clean-cluster
+      working-directory: catapult
+      env:
+        GKE_LOCATION: ${{ secrets.GKE_LOCATION }}
+        GKE_PROJECT: ${{ secrets.GKE_PROJECT }}
+        RESOURCE_LIST: ${{ github.workspace }}/resources.json
+        CLUSTER_SELECTOR: ${{ steps.find-jobs.outputs.result }}
+        ACTUALLY_DELETE: "true"
+
+    - name: Calculate Capacity
+      id: calculate-capacity
+      run: |
+        set -o errexit -o pipefail -o nounset
+        in_use="$(jq -r ".clusters | length" "${RESOURCE_LIST}")"
+        capacity="$(( (MAX_CLUSTERS - in_use) / CLUSTERS_PER_PR ))"
+        echo "::set-output name=capacity::${capacity}"
+        if [[ "${capacity}" -gt 0 ]]; then
+          echo "We have capacity for ${capacity} more clusters."
+        else
+          echo "We do not have capacity to create more clusters."
+        fi
+      env:
+        RESOURCE_LIST: ${{ github.workspace }}/resources.json
+
+  trigger-builds:
+    name: Trigger Builds
+    runs-on: ubuntu-latest
+    needs: determine-capacity
+    if: needs.determine-capacity.outputs.capacity > 0
+    steps:
+    - name: Checkout KubeCF
+      # This is only needed to find the GitHub script in the next step.
+      uses: actions/checkout@v2
+    - name: Trigger Builds
+      uses: actions/github-script@v3
+      with:
+        script: |
+          const script_path = ".github/workflows/pull-request-schedule/trigger-builds.js";
+          const script = require(`${process.env.GITHUB_WORKSPACE}/${script_path}`);
+          await script({github, context});
+      env:
+        CAPACITY: ${{ needs.determine-capacity.outputs.capacity }}

--- a/.github/workflows/pull-request-schedule.yaml
+++ b/.github/workflows/pull-request-schedule.yaml
@@ -1,7 +1,7 @@
 name: Pull Request Scheduler
 on:
   schedule:
-  - cron: '*/15 * * * *'
+  - cron: '*/10 * * * *'
   workflow_dispatch: {}
 
 env:

--- a/.github/workflows/pull-request-schedule.yaml
+++ b/.github/workflows/pull-request-schedule.yaml
@@ -41,7 +41,7 @@ jobs:
         GKE_CRED_JSON: ${{ secrets.GKE_CRED_JSON }}
 
     - name: Find Clusters
-      run: make find-resources
+      run: make buildir find-resources
       working-directory: catapult
       env:
         GKE_LOCATION: ${{ secrets.GKE_LOCATION }}
@@ -59,7 +59,7 @@ jobs:
           return await script({github, context});
 
     - name: Clean Up Unused Clusters
-      run: make force-clean-cluster
+      run: make buildir force-clean-cluster
       working-directory: catapult
       env:
         GKE_LOCATION: ${{ secrets.GKE_LOCATION }}

--- a/.github/workflows/pull-request-schedule/find-jobs.js
+++ b/.github/workflows/pull-request-schedule/find-jobs.js
@@ -1,0 +1,17 @@
+module.exports = async ({ github, context }) => {
+    console.log(`Looking up runs for ${context.repo.owner}/${context.repo.repo}`);
+    const promises = ["queued", "in_progress"]
+        .map((status) => github.actions.listWorkflowRunsForRepo({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            status: status
+        }));
+    const runs = (await Promise.all(promises))
+        .map((request) => request.data.workflow_runs)
+        .reduce((a, v) => a.concat(v), [])
+        .map((run) => run.id.toString());
+    console.log(`Active/pending runs: ${runs.join(", ")}`);
+    const selector = `.labels.ci and ([.labels.ci] | inside(${JSON.stringify(runs)}) | not)`;
+    console.log(`Cluster filter selector: ${selector}`);
+    return selector;
+};

--- a/.github/workflows/pull-request-schedule/trigger-builds.js
+++ b/.github/workflows/pull-request-schedule/trigger-builds.js
@@ -1,0 +1,65 @@
+module.exports = async ({ github, context }) => {
+    // PullRequestQuery is a GraphQL query to find pull requests with the proper
+    // label
+    const PullRequestQuery = `
+        query($owner: String!, $repo: String!, $label: String!) {
+            repository(owner: $owner, name: $repo) {
+                labels(first: 10, query: $label) {
+                    nodes {
+                        name
+                        pullRequests(states: OPEN, last: 10) {
+                            nodes {
+                                number
+                                timelineItems(last: 100, itemTypes: LABELED_EVENT) {
+                                    nodes {
+                                        ... on LabeledEvent {
+                                            label { name }
+                                            createdAt
+                                            actor { login }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    `;
+
+    console.log(`Looking up queued items for ${context.repo.owner}/${context.repo.repo}`);
+
+    // queryResult is the result of the GraphQL query
+    const queryResult = await github.graphql(PullRequestQuery, {
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        label: process.env.LABEL_QUEUE,
+    });
+
+    // pulls is an array of PR information (with `number` and `timestamp` keys),
+    // sorted oldest first.
+    const pulls = queryResult.repository.labels.nodes.reduce((pulls, label) => {
+        return pulls.concat(label.pullRequests.nodes.map((pr) => {
+            const event = pr.timelineItems.nodes.reverse()
+                .find((event) => event.label.name == process.env.LABEL_QUEUE);
+            console.log(`Found event for PR#${pr.number}: queued at ${event.createdAt} by ${event.actor.login}`);
+            return { number: pr.number, timestamp: Date.parse(event.createdAt) };
+        }));
+    }, []).sort((a, b) => a.timestamp - b.timestamp);
+
+    for (let pr of pulls.slice(0, process.env.CAPACITY)) {
+        console.log(`Queuing PR#${pr.number}`);
+        github.issues.addLabels({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: pr.number,
+            labels: [process.env.LABEL_TRIGGER]
+        });
+        github.issues.removeLabel({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: pr.number,
+            name: process.env.LABEL_QUEUE
+        });
+    }
+};

--- a/.github/workflows/pull-request-schedule/trigger-builds.js
+++ b/.github/workflows/pull-request-schedule/trigger-builds.js
@@ -2,50 +2,60 @@ module.exports = async ({ github, context }) => {
     // PullRequestQuery is a GraphQL query to find pull requests with the proper
     // label
     const PullRequestQuery = `
-        query($owner: String!, $repo: String!, $label: String!) {
+        query($owner: String!, $repo: String!, $label: String!, $cursor: String) {
             repository(owner: $owner, name: $repo) {
-                labels(first: 10, query: $label) {
+                pullRequests(labels: [$label], first: 100, states:OPEN, after: $cursor) {
                     nodes {
-                        name
-                        pullRequests(states: OPEN, last: 10) {
+                        number
+                        timelineItems(last: 100, itemTypes: LABELED_EVENT) {
                             nodes {
-                                number
-                                timelineItems(last: 100, itemTypes: LABELED_EVENT) {
-                                    nodes {
-                                        ... on LabeledEvent {
-                                            label { name }
-                                            createdAt
-                                            actor { login }
-                                        }
-                                    }
+                                ... on LabeledEvent {
+                                    label { name }
+                                    createdAt
+                                    actor { login }
                                 }
                             }
                         }
                     }
+                    pageInfo { endCursor }
                 }
             }
         }
     `;
 
-    console.log(`Looking up queued items for ${context.repo.owner}/${context.repo.repo}`);
+    console.log(`Looking up queued items for ${context.repo.owner}/${context.repo.repo} label ${process.env.LABEL_QUEUE}`);
 
-    // queryResult is the result of the GraphQL query
-    const queryResult = await github.graphql(PullRequestQuery, {
-        owner: context.repo.owner,
-        repo: context.repo.repo,
-        label: process.env.LABEL_QUEUE,
-    });
+    // nextPage is a generator function that yields the successive query results
+    // of the GraphQL query, limited to just the pull request nodes (as an array).
+    const nextPage = async function* () {
+        let cursor = null;
+        do {
+            // queryResult is the result of the GraphQL query
+            let queryResult = await github.graphql(PullRequestQuery, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                label: process.env.LABEL_QUEUE,
+                cursor: cursor,
+            });
+            cursor = queryResult.repository.pullRequests.pageInfo.endCursor;
+            yield queryResult.repository.pullRequests.nodes;
+        } while (cursor !== null);
+    }
 
     // pulls is an array of PR information (with `number` and `timestamp` keys),
     // sorted oldest first.
-    const pulls = queryResult.repository.labels.nodes.reduce((pulls, label) => {
-        return pulls.concat(label.pullRequests.nodes.map((pr) => {
+    let pulls = [];
+    for await (let nodes of nextPage()) {
+        pulls.push(...nodes.map((pr) => {
             const event = pr.timelineItems.nodes.reverse()
                 .find((event) => event.label.name == process.env.LABEL_QUEUE);
             console.log(`Found event for PR#${pr.number}: queued at ${event.createdAt} by ${event.actor.login}`);
             return { number: pr.number, timestamp: Date.parse(event.createdAt) };
         }));
-    }, []).sort((a, b) => a.timestamp - b.timestamp);
+    }
+    pulls = pulls.sort((a, b) => a.timestamp - b.timestamp);
+
+    console.log(`Found ${pulls.length} PRs.`);
 
     for (let pr of pulls.slice(0, process.env.CAPACITY)) {
         console.log(`Queuing PR#${pr.number}`);


### PR DESCRIPTION
## Description
~This pull request will change our GitHub Actions workflow to include at least the basic tests, to the point where we might start deprecating our Concourse pipelines.~

~For now, though, I just have a design of how we might handle the build triggering and cluster allocation; I'd like some feedback before actually implementing things.   Hence, this is a draft with just markdown changes.  I'll edit the description once we agree and I've implemented it reasonably.~

I am now rescoping this to _just_ the changes described to scheduling the runs; this is already enough of a change that it's a good chunk to review.  Also, I can work on the tests independently of this PR (in my fork, manually triggering runs).

## Motivation and Context
Part of #1144 (but will no longer fix it by itself).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- An important detail to include is the version of the used cf-operator -->
I have been running this in my fork; [sample run](https://github.com/mook-as/kubecf/actions/runs/338099108).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

This has security implications in the sense of this may trigger runs on CI of potentially untrusted code.  So it's security of our infrastructure (and from there our code), not of the product (unless they manage to change our code).
