### PR TITLE
fix: Build updated buildpacks against the stemcell specified in sle15.yaml

### DIFF
--- a/.concourse/suse-buildpacks-ci/buildpack-version-bump/pipeline.yaml.gomplate
+++ b/.concourse/suse-buildpacks-ci/buildpack-version-bump/pipeline.yaml.gomplate
@@ -77,6 +77,7 @@ jobs:
       params:
         STEMCELL_REPOSITORY: {{ $root.stemcell_repository }}
         STEMCELL_VERSIONED_FILE: {{ $root.stemcell_version_file }}
+        KUBECF_VALUES: {{ $root.kubecf_values }}
         REGISTRY_NAME: ((suse-public-staging.registry))
         REGISTRY_ORG: ((suse-public-staging.org))
         REGISTRY_USER: ((suse-public-staging.username))

--- a/.concourse/suse-buildpacks-ci/buildpack-version-bump/pipeline.yaml.gomplate
+++ b/.concourse/suse-buildpacks-ci/buildpack-version-bump/pipeline.yaml.gomplate
@@ -85,7 +85,6 @@ jobs:
       file: ci/.concourse/suse-buildpacks-ci/buildpack-version-bump/tasks/build.yaml
 
     - task: create-pr
-      privileged: true
       input_mapping:
         suse_final_release: suse-final-release-{{ $release.name }}
         built_image: built_image

--- a/.concourse/suse-buildpacks-ci/buildpack-version-bump/tasks/build.sh
+++ b/.concourse/suse-buildpacks-ci/buildpack-version-bump/tasks/build.sh
@@ -26,8 +26,9 @@ tar xvf s3.fissile-linux/fissile-*.tgz --directory "/usr/local/bin/"
 
 # Pull the stemcell image referenced in the KUBECF_VALUES
 # sle_version: e.g. SLE_15_SP1
-sle_version="$(cat s3.stemcell-version/"${STEMCELL_VERSIONED_FILE##*/}" | cut -d- -f1)"
+sle_version="$(cut -d- -f1 "s3.stemcell-version/${STEMCELL_VERSIONED_FILE##*/}")"
 # stemcell_version without the fissile version part, e.g. 27.8
+# shellcheck disable=SC2016
 stemcell_version=$(yq -r '.stacks.sle15.releases["$defaults"].stemcell.version' "kubecf/${KUBECF_VALUES}" | cut -d- -f1)
 stemcell_image="${STEMCELL_REPOSITORY}:${sle_version}-${stemcell_version}"
 docker pull "${stemcell_image}"

--- a/.concourse/suse-buildpacks-ci/buildpack-version-bump/tasks/build.sh
+++ b/.concourse/suse-buildpacks-ci/buildpack-version-bump/tasks/build.sh
@@ -28,7 +28,7 @@ tar xvf s3.fissile-linux/fissile-*.tgz --directory "/usr/local/bin/"
 # sle_version: e.g. SLE_15_SP1
 sle_version="$(cat s3.stemcell-version/"${STEMCELL_VERSIONED_FILE##*/}" | cut -d- -f1)"
 # stemcell_version without the fissile version part, e.g. 27.8
-stemcell_version=$(perl -0ne '/stemcell:\n\s+version: (\d+\.\d+)/g&&print "$1"' "kubecf/${KUBECF_VALUES}")
+stemcell_version=$(yq -r '.stacks.sle15.releases["$defaults"].stemcell.version' "kubecf/${KUBECF_VALUES}" | cut -d- -f1)
 stemcell_image="${STEMCELL_REPOSITORY}:${sle_version}-${stemcell_version}"
 docker pull "${stemcell_image}"
 

--- a/.concourse/suse-buildpacks-ci/buildpack-version-bump/tasks/build.sh
+++ b/.concourse/suse-buildpacks-ci/buildpack-version-bump/tasks/build.sh
@@ -25,9 +25,11 @@ echo "${REGISTRY_PASS}" | docker login "${REGISTRY_NAME}" --username "${REGISTRY
 tar xvf s3.fissile-linux/fissile-*.tgz --directory "/usr/local/bin/"
 
 # Pull the stemcell image referenced in the KUBECF_VALUES
+# sle_version: e.g. SLE_15_SP1
 sle_version="$(cat s3.stemcell-version/"${STEMCELL_VERSIONED_FILE##*/}" | cut -d- -f1)"
-stemcell_version=${sle_version}-$(perl -0ne '/stemcell:\n\s+version: (\d+\.\d+)/g&&print "$1"' "kubecf/${KUBECF_VALUES}")
-stemcell_image="${STEMCELL_REPOSITORY}:${stemcell_version}"
+# stemcell_version without the fissile version part, e.g. 27.8
+stemcell_version=$(perl -0ne '/stemcell:\n\s+version: (\d+\.\d+)/g&&print "$1"' "kubecf/${KUBECF_VALUES}")
+stemcell_image="${STEMCELL_REPOSITORY}:${sle_version}-${stemcell_version}"
 docker pull "${stemcell_image}"
 
 # Get version from the GitHub release that triggered this task

--- a/.concourse/suse-buildpacks-ci/buildpack-version-bump/tasks/build.sh
+++ b/.concourse/suse-buildpacks-ci/buildpack-version-bump/tasks/build.sh
@@ -24,8 +24,9 @@ echo "${REGISTRY_PASS}" | docker login "${REGISTRY_NAME}" --username "${REGISTRY
 # Extract the fissile binary.
 tar xvf s3.fissile-linux/fissile-*.tgz --directory "/usr/local/bin/"
 
-# Pull the stemcell image.
-stemcell_version="$(cat s3.stemcell-version/"${STEMCELL_VERSIONED_FILE##*/}")"
+# Pull the stemcell image referenced in the KUBECF_VALUES
+sle_version="$(cat s3.stemcell-version/"${STEMCELL_VERSIONED_FILE##*/}" | cut -d- -f1)"
+stemcell_version=${sle_version}-$(perl -0ne '/stemcell:\n\s+version: (\d+\.\d+)/g&&print "$1"' "kubecf/${KUBECF_VALUES}")
 stemcell_image="${STEMCELL_REPOSITORY}:${stemcell_version}"
 docker pull "${stemcell_image}"
 

--- a/.concourse/suse-buildpacks-ci/buildpack-version-bump/tasks/build.yaml
+++ b/.concourse/suse-buildpacks-ci/buildpack-version-bump/tasks/build.yaml
@@ -11,11 +11,13 @@ inputs:
 - name: s3.stemcell-version
 - name: s3.fissile-linux
 - name: suse_final_release
+- name: kubecf
 outputs:
 - name: built_image
 params:
   STEMCELL_REPOSITORY: ~
   STEMCELL_VERSIONED_FILE: ~
+  KUBECF_VALUES: ~
   REGISTRY_NAME: ~
   REGISTRY_ORG: ~
   REGISTRY_USER: ~

--- a/.concourse/suse-buildpacks-ci/buildpack-version-bump/tasks/create_pr.sh
+++ b/.concourse/suse-buildpacks-ci/buildpack-version-bump/tasks/create_pr.sh
@@ -40,7 +40,12 @@ git checkout -b "${GIT_BRANCH_NAME}"
 
 perl -i -0pe "s/      ${BUILDPACK_NAME}:\n        version: \"[\d.]+\"/      ${BUILDPACK_NAME}:\n        version: \"${RELEASE_VERSION}\"/" "${KUBECF_VALUES}"
 
-git commit "${KUBECF_VALUES}" -m "${COMMIT_TITLE}" || exit 0
+if [ -z "$(git status --porcelain)" ]; then
+  echo "Nothing to commit, no pr needed. Exiting gracefully ..."
+  exit 0
+fi
+
+git commit "${KUBECF_VALUES}" -m "${COMMIT_TITLE}"
 
 # Open a Pull Request
 PR_MESSAGE=$(echo -e "${COMMIT_TITLE}")

--- a/.concourse/suse-buildpacks-ci/buildpack-version-bump/tasks/create_pr.sh
+++ b/.concourse/suse-buildpacks-ci/buildpack-version-bump/tasks/create_pr.sh
@@ -40,7 +40,7 @@ git checkout -b "${GIT_BRANCH_NAME}"
 
 perl -i -0pe "s/      ${BUILDPACK_NAME}:\n        version: \"[\d.]+\"/      ${BUILDPACK_NAME}:\n        version: \"${RELEASE_VERSION}\"/" "${KUBECF_VALUES}"
 
-git commit "${KUBECF_VALUES}" -m "${COMMIT_TITLE}"
+git commit "${KUBECF_VALUES}" -m "${COMMIT_TITLE}" || exit 0
 
 # Open a Pull Request
 PR_MESSAGE=$(echo -e "${COMMIT_TITLE}")

--- a/.concourse/suse-buildpacks-ci/stemcell-version-bump/pipeline.yaml.gomplate
+++ b/.concourse/suse-buildpacks-ci/stemcell-version-bump/pipeline.yaml.gomplate
@@ -48,7 +48,6 @@ jobs:
     - get: kubecf
   - do:
     - task: prep
-      privileged: true
       params:
         RELEASES_YAML: ci/.concourse/suse-buildpacks-ci/releases.yaml
         KUBECF_VALUES_YAML: kubecf/chart/config/sle15.yaml
@@ -70,7 +69,6 @@ jobs:
       file: ci/.concourse/suse-buildpacks-ci/stemcell-version-bump/tasks/build.yaml
 
     - task: create-pr
-      privileged: true
       input_mapping:
         s3.stemcell-version: s3.fissile-stemcell-version
       params:

--- a/.concourse/suse-buildpacks-ci/stemcell-version-bump/tasks/create_pr.sh
+++ b/.concourse/suse-buildpacks-ci/stemcell-version-bump/tasks/create_pr.sh
@@ -40,7 +40,13 @@ git checkout -b "${GIT_BRANCH_NAME}"
 
 perl -i -0pe "s/        stemcell:\n          version: \d+\.\d+/        stemcell:\n          version: ${stemcell_version}/" "${KUBECF_VALUES}"
 
-git commit "${KUBECF_VALUES}" -m "${COMMIT_TITLE}" || exit 0
+
+if [ -z "$(git status --porcelain)" ]; then
+  echo "Nothing to commit, no pr needed. Exiting gracefully ..."
+  exit 0
+fi
+
+git commit "${KUBECF_VALUES}" -m "${COMMIT_TITLE}"
 
 # Open a Pull Request
 PR_MESSAGE=$(echo -e "${COMMIT_TITLE}")

--- a/.concourse/suse-buildpacks-ci/stemcell-version-bump/tasks/create_pr.sh
+++ b/.concourse/suse-buildpacks-ci/stemcell-version-bump/tasks/create_pr.sh
@@ -40,7 +40,7 @@ git checkout -b "${GIT_BRANCH_NAME}"
 
 perl -i -0pe "s/        stemcell:\n          version: \d+\.\d+/        stemcell:\n          version: ${stemcell_version}/" "${KUBECF_VALUES}"
 
-git commit "${KUBECF_VALUES}" -m "${COMMIT_TITLE}"
+git commit "${KUBECF_VALUES}" -m "${COMMIT_TITLE}" || exit 0
 
 # Open a Pull Request
 PR_MESSAGE=$(echo -e "${COMMIT_TITLE}")


### PR DESCRIPTION
## Description
Build images of updated buildpacks against the stemcell specified in sle15.yaml instead of taking the latest released stemcell.
The stemcell is update in a separate pipeline called `suse-buildpacks-stemcell-version-bump`.

## Motivation and Context
This change should prevent race conditions specified in #1164.

## How Has This Been Tested?
The pipeline was deployed and did already run successful.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
