### PR TITLE
Update the ssh-proxy-public service resource.

### DIFF
--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -151,7 +151,7 @@ metadata:
     {{- toYaml $service.annotations | nindent 4 }}
   {{- end }}
   labels:
-    app.kubernetes.io/component: ssh-proxy
+    app.kubernetes.io/component: scheduler
     app.kubernetes.io/instance: {{ $root.Release.Name | quote }}
     app.kubernetes.io/managed-by: {{ $root.Release.Service | quote }}
     app.kubernetes.io/name: {{ default $root.Chart.Name $root.Values.nameOverride | trunc 63 | trimSuffix "-" | quote }}
@@ -159,7 +159,7 @@ metadata:
     helm.sh/chart: {{ printf "%s-%s" $root.Chart.Name ($root.Chart.Version | replace "+" "_") | quote }}
 spec:
   selector:
-    app.kubernetes.io/component: ssh-proxy
+    app.kubernetes.io/component: scheduler
     app.kubernetes.io/instance: {{ $root.Release.Name | quote }}
   ports:
   - name: ssh


### PR DESCRIPTION
This is to address [#1509 ](https://github.com/cloudfoundry-incubator/kubecf/issues/1509)
This is relevant only for deployments that do not use the nginx ingress-controller.

## Description
The proposal is to update the ssh-proxy-public service resource to match the scheduler pods in kubecf with the correct label.
The scheduler pods in 2.5.8 have the following labels app.kubernetes.io/component=scheduler
So the spec.selector having a value of `app.kubernetes.io/component: ssh-proxy` matches nothing.

## Motivation and Context
Fix for #1509 

## How Has This Been Tested?
Deployed on AWS EKS and verified that the ssh-proxy-public matches the scheduler pod that contains the ssh-proxy container
Verified that `cf ssh` works and that one can ssh into a cf app container.
cf-operator version 6.1.17 was used with KubeCF 2.5.8

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
