### PR TITLE
fix: Remove blobstore settings from eirini-helm ops file

### DIFF
--- a/chart/assets/operations/instance_groups/eirini-helm.yaml
+++ b/chart/assets/operations/instance_groups/eirini-helm.yaml
@@ -17,15 +17,6 @@
   value: "https://eirini-opi.{{ .Release.Namespace }}.svc:8085"
 
 - type: replace
-  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/packages?/webdav_config?/private_endpoint?
-  value: "https://singleton-blobstore.{{ .Release.Namespace }}.svc:4443"
-- type: replace
-  path: /instance_groups/name=api/jobs/name=cloud_controller_ng/properties/cc/buildpacks?/webdav_config?/private_endpoint?
-  value: "https://singleton-blobstore.{{ .Release.Namespace }}.svc:4443"
-- type: replace
-  path: /variables/name=blobstore_tls/options/alternative_names?/-
-  value: "singleton-blobstore.{{ .Release.Namespace }}.svc"
-- type: replace
   path: /variables/name=cc_bridge_cc_uploader_server/options/alternative_names?/-
   value: "api.{{ .Release.Namespace }}.svc"
 - type: replace


### PR DESCRIPTION
## Description

These settings are not needed, and they will break when kubecf is configured to use an external blobstore because then the singleton-blobstore service doesn't even exist.

I suspect that more settings in this file are redundant, but want to have a minimal change to just fix Eirini with external
blobstore deployment.

## How Has This Been Tested?

I've only tested that Eirini continues to work on minikube. I have not tried to deploy with an external blobstore, so there may still be other undiscovered issues.
