### PR TITLE
fix: Update ingress.yaml

### DIFF
--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -151,7 +151,7 @@ metadata:
     {{- toYaml $service.annotations | nindent 4 }}
   {{- end }}
   labels:
-    app.kubernetes.io/component: ssh-proxy
+    app.kubernetes.io/component: scheduler
     app.kubernetes.io/instance: {{ $root.Release.Name | quote }}
     app.kubernetes.io/managed-by: {{ $root.Release.Service | quote }}
     app.kubernetes.io/name: {{ default $root.Chart.Name $root.Values.nameOverride | trunc 63 | trimSuffix "-" | quote }}
@@ -159,7 +159,7 @@ metadata:
     helm.sh/chart: {{ printf "%s-%s" $root.Chart.Name ($root.Chart.Version | replace "+" "_") | quote }}
 spec:
   selector:
-    app.kubernetes.io/component: ssh-proxy
+    app.kubernetes.io/component: scheduler
     app.kubernetes.io/instance: {{ $root.Release.Name | quote }}
   ports:
   - name: ssh


### PR DESCRIPTION
Updates to ingress.yaml that allow the pod selector to match the scheduler pod in KubeCF.
This is to address #1509 , where `ccf ssh` to apps does not work in cases where the ssh-proxy-public service uses a LoadBalancer instead of an nginx ingress-controller.

## Description
The scheduler pod has a label called `app.kubernetes.io/component=scheduler`
Whereas the service resource described in ingress.yaml, specifies a pod selector with a value `app.kubernetes.io/component=ssh-proxy`
The pull request modifies the label and the pod selector to `app.kubernetes.io/component=scheduler`, such that the service can match the ssh-proxy container in the pod

## Motivation and Context
This change allows the ssh-proxy-public service to select the appropriate kubecf pod, and enables the `cf ssh` capability to work when the services are deployed as LoadBalanced as opposed to being exposed via an ingress-controller.
Fixes #1509 

## How Has This Been Tested?
Deployed the charts from the pull request on AWS EKS as a backbone. (Diego deployment)
Deployed a simple cloud foundry app (python buildpack) to the deployment.
Verified that the `cf ssh` feature works by being able to ssh into the app container.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
