### PR TITLE
fix: Actions: force use of Python 3.8

### DIFF
--- a/.github/workflows/pull-request-ci.yaml
+++ b/.github/workflows/pull-request-ci.yaml
@@ -158,7 +158,9 @@ jobs:
       # Python setup
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.x'
+          # Force 3.8 because google-cloud-sdk is incompatible with 3.9
+          # https://issuetracker.google.com/issues/170125513
+          python-version: '3.8'
 
       # Caching tools like helm, jq, git, y2j, yamllint etc
       - name: cache.tools


### PR DESCRIPTION
## Description
This forces the use of Python 3.8 when running GitHub Actions (for catapult, needed by the Google Cloud SDK).
<!--- Describe your changes in detail -->

## Motivation and Context
The latest available google-cloud-sdk (315.0.0) is not yet compatible with Python 3.9.  There's a tracking bug at https://issuetracker.google.com/issues/170125513.

This was discovered while working on  #1144.

## How Has This Been Tested?
Ran a build on my fork, ensuring that the build proceeds past having a working Kubernetes cluster.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
