### PR TITLE
fix: deployment-name should be label not annotation

### DIFF
--- a/chart/templates/multiple_cluster_mode.yaml
+++ b/chart/templates/multiple_cluster_mode.yaml
@@ -91,8 +91,9 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Values.features.multiple_cluster_mode.provider_link_service.nats.secret_name }} 
+  labels:
+    quarks.cloudfoundry.org/deployment-name: "{{ include "kubecf.deployment-name" . }}" 
   annotations:
-    quarks.cloudfoundry.org/deployment-name: "{{ include "kubecf.deployment-name" . }}"
     quarks.cloudfoundry.org/provides: '{"name":"nats","type":"nats"}'
 stringData:
   link: {{- toYaml .Values.features.multiple_cluster_mode.provider_link_service.nats.link | nindent 4 }}
@@ -101,8 +102,9 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Values.features.multiple_cluster_mode.provider_link_service.nats_tls.secret_name }} 
+  labels:
+    quarks.cloudfoundry.org/deployment-name: "{{ include "kubecf.deployment-name" . }}" 
   annotations:
-    quarks.cloudfoundry.org/deployment-name: "{{ include "kubecf.deployment-name" . }}"
     quarks.cloudfoundry.org/provides: '{"name":"nats-tls","type":"nats-tls"}'
 stringData:
   link: {{- toYaml .Values.features.multiple_cluster_mode.provider_link_service.nats_tls.link | nindent 4 }} 
@@ -112,8 +114,9 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Values.features.multiple_cluster_mode.provider_link_service.routing_api.secret_name }} 
+  labels:
+    quarks.cloudfoundry.org/deployment-name: "{{ include "kubecf.deployment-name" . }}" 
   annotations:
-    quarks.cloudfoundry.org/deployment-name: "{{ include "kubecf.deployment-name" . }}"
     quarks.cloudfoundry.org/provides: '{"name":"routing_api","type":"routing_api"}'
 stringData:
   link: {{- toYaml .Values.features.multiple_cluster_mode.provider_link_service.routing_api.link | nindent 4 }} 
@@ -123,8 +126,9 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Values.features.multiple_cluster_mode.provider_link_service.doppler.secret_name }} 
+  labels:
+    quarks.cloudfoundry.org/deployment-name: "{{ include "kubecf.deployment-name" . }}" 
   annotations:
-    quarks.cloudfoundry.org/deployment-name: "{{ include "kubecf.deployment-name" . }}"
     quarks.cloudfoundry.org/provides: '{"name":"doppler","type":"doppler"}'
 stringData:
   link: {{- toYaml .Values.features.multiple_cluster_mode.provider_link_service.doppler.link | nindent 4 }} 
@@ -133,8 +137,9 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Values.features.multiple_cluster_mode.provider_link_service.loggregator.secret_name }} 
+  labels:
+    quarks.cloudfoundry.org/deployment-name: "{{ include "kubecf.deployment-name" . }}" 
   annotations:
-    quarks.cloudfoundry.org/deployment-name: "{{ include "kubecf.deployment-name" . }}"
     quarks.cloudfoundry.org/provides: '{"name":"loggregator","type":"loggregator"}'
 stringData:
   link: {{- toYaml .Values.features.multiple_cluster_mode.provider_link_service.loggregator.link | nindent 4 }} 
@@ -143,8 +148,9 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Values.features.multiple_cluster_mode.provider_link_service.cloud_controller.secret_name }}
+  labels:
+    quarks.cloudfoundry.org/deployment-name: "{{ include "kubecf.deployment-name" . }}" 
   annotations:
-    quarks.cloudfoundry.org/deployment-name: "{{ include "kubecf.deployment-name" . }}"
     quarks.cloudfoundry.org/provides: '{"name":"cloud_controller","type":"cloud_controller"}'
 stringData:
   link: {{- toYaml .Values.features.multiple_cluster_mode.provider_link_service.cloud_controller.link | nindent 4 }} 
@@ -153,8 +159,9 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Values.features.multiple_cluster_mode.provider_link_service.cf_network.secret_name }} 
+  labels:
+    quarks.cloudfoundry.org/deployment-name: "{{ include "kubecf.deployment-name" . }}" 
   annotations:
-    quarks.cloudfoundry.org/deployment-name: "{{ include "kubecf.deployment-name" . }}"
     quarks.cloudfoundry.org/provides: '{"name":"cf_network","type":"cf_network"}'
 stringData:
   link:  {{- toYaml .Values.features.multiple_cluster_mode.provider_link_service.cf_network.link | nindent 4 }}
@@ -163,8 +170,9 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Values.features.multiple_cluster_mode.provider_link_service.cloud_controller_container_networking_info.secret_name }} 
+  labels:
+    quarks.cloudfoundry.org/deployment-name: "{{ include "kubecf.deployment-name" . }}" 
   annotations:
-    quarks.cloudfoundry.org/deployment-name: "{{ include "kubecf.deployment-name" . }}"
     quarks.cloudfoundry.org/provides: '{"name":"cloud_controller_container_networking_info","type":"cloud_controller_container_networking_info"}'
 stringData:
   link: {{- toYaml .Values.features.multiple_cluster_mode.provider_link_service.cloud_controller_container_networking_info.link | nindent 4 }}
@@ -172,8 +180,9 @@ stringData:
 apiVersion: v1
 kind: Service
 metadata:
+  labels:
+    quarks.cloudfoundry.org/deployment-name: "{{ include "kubecf.deployment-name" . }}" 
   annotations:
-    quarks.cloudfoundry.org/deployment-name: "{{ include "kubecf.deployment-name" . }}"
     quarks.cloudfoundry.org/link-provider-name: nats
   name: {{ .Values.features.multiple_cluster_mode.provider_link_service.nats.service_name }} 
 spec:
@@ -183,8 +192,9 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  labels:
+    quarks.cloudfoundry.org/deployment-name: "{{ include "kubecf.deployment-name" . }}" 
   annotations:
-    quarks.cloudfoundry.org/deployment-name: "{{ include "kubecf.deployment-name" . }}"
     quarks.cloudfoundry.org/link-provider-name: nats-tls
   name: {{ .Values.features.multiple_cluster_mode.provider_link_service.nats_tls.service_name }}
 spec:
@@ -195,8 +205,9 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  labels:
+    quarks.cloudfoundry.org/deployment-name: "{{ include "kubecf.deployment-name" . }}" 
   annotations:
-    quarks.cloudfoundry.org/deployment-name: "{{ include "kubecf.deployment-name" . }}"
     quarks.cloudfoundry.org/link-provider-name: routing_api
   name: {{ .Values.features.multiple_cluster_mode.provider_link_service.routing_api.service_name }}
 spec:
@@ -207,8 +218,9 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  labels:
+    quarks.cloudfoundry.org/deployment-name: "{{ include "kubecf.deployment-name" . }}" 
   annotations:
-    quarks.cloudfoundry.org/deployment-name: "{{ include "kubecf.deployment-name" . }}"
     quarks.cloudfoundry.org/link-provider-name: doppler
   name: {{ .Values.features.multiple_cluster_mode.provider_link_service.doppler.service_name }}
 spec:
@@ -218,8 +230,9 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  labels:
+    quarks.cloudfoundry.org/deployment-name: "{{ include "kubecf.deployment-name" . }}" 
   annotations:
-    quarks.cloudfoundry.org/deployment-name: "{{ include "kubecf.deployment-name" . }}"
     quarks.cloudfoundry.org/link-provider-name: loggregator
   name: {{ .Values.features.multiple_cluster_mode.provider_link_service.loggregator.service_name }}
 spec:
@@ -229,8 +242,9 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  labels:
+    quarks.cloudfoundry.org/deployment-name: "{{ include "kubecf.deployment-name" . }}" 
   annotations:
-    quarks.cloudfoundry.org/deployment-name: "{{ include "kubecf.deployment-name" . }}"
     quarks.cloudfoundry.org/link-provider-name: cloud_controller
   name: {{ .Values.features.multiple_cluster_mode.provider_link_service.cloud_controller.service_name }}
 spec:
@@ -240,8 +254,9 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  labels:
+    quarks.cloudfoundry.org/deployment-name: "{{ include "kubecf.deployment-name" . }}" 
   annotations:
-    quarks.cloudfoundry.org/deployment-name: "{{ include "kubecf.deployment-name" . }}"
     quarks.cloudfoundry.org/link-provider-name: cloud_controller_container_networking_info
   name: {{ .Values.features.multiple_cluster_mode.provider_link_service.cloud_controller_container_networking_info.service_name }} 
 spec:
@@ -251,8 +266,9 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  labels:
+    quarks.cloudfoundry.org/deployment-name: "{{ include "kubecf.deployment-name" . }}" 
   annotations:
-    quarks.cloudfoundry.org/deployment-name: "{{ include "kubecf.deployment-name" . }}"
     quarks.cloudfoundry.org/link-provider-name: cf_network
   name: {{ .Values.features.multiple_cluster_mode.provider_link_service.cf_network.service_name }} 
 spec:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The deployment-name is supposed to be a label on a secret, not an annotation. Without this change the multiple cluster feature doesn't work

## Motivation and Context
See above

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- An important detail to include is the version of the used cf-operator -->
Tested using cf-operator 6.1.7 this progressed the deployment past a blocking issue

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
