### PR TITLE
fix: move tcp-router healthcheck port to avoid clash

### DIFF
--- a/chart/assets/operations/instance_groups/tcp-router.yaml
+++ b/chart/assets/operations/instance_groups/tcp-router.yaml
@@ -7,7 +7,7 @@
 
 - type: replace
   path: /instance_groups/name=tcp-router/jobs/name=tcp_router/properties/tcp_router?/health_check_port
-  value: 88
+  value: 8787
 
 - type: replace
   path: /instance_groups/name=tcp-router/jobs/name=tcp_router/properties/quarks?
@@ -15,7 +15,7 @@
     ports:
     - name: healthcheck
       protocol: TCP
-      internal: 88
+      internal: 8787
     {{- range $port := until (int (add 1 (sub $service.port_range.end $service.port_range.start))) }}
     {{- $port = add $port $service.port_range.start }}
     - name: "tcp-route-{{ $port }}"
@@ -27,7 +27,7 @@
         tcp_router:
           readiness:
             httpGet:
-              port: 88
+              port: 8787
               path: /health
 
 # Add necessary labels to the tcp-router instance group so that the service can select it to create

--- a/chart/assets/operations/instance_groups/tcp-router.yaml
+++ b/chart/assets/operations/instance_groups/tcp-router.yaml
@@ -6,12 +6,16 @@
   value: "{{ $service.port_range.start }}-{{ $service.port_range.end }}"
 
 - type: replace
+  path: /instance_groups/name=tcp-router/jobs/name=tcp_router/properties/tcp_router?/health_check_port
+  value: 88
+
+- type: replace
   path: /instance_groups/name=tcp-router/jobs/name=tcp_router/properties/quarks?
   value:
     ports:
     - name: healthcheck
       protocol: TCP
-      internal: 80
+      internal: 88
     {{- range $port := until (int (add 1 (sub $service.port_range.end $service.port_range.start))) }}
     {{- $port = add $port $service.port_range.start }}
     - name: "tcp-route-{{ $port }}"
@@ -23,7 +27,7 @@
         tcp_router:
           readiness:
             httpGet:
-              port: 80
+              port: 88
               path: /health
 
 # Add necessary labels to the tcp-router instance group so that the service can select it to create

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -203,8 +203,8 @@ spec:
   ports:
   - name: healthcheck
     protocol: TCP
-    port: 88
-    targetPort: 88
+    port: 8787
+    targetPort: 8787
   {{- range $port := until (int (add 1 (sub $service.port_range.end $service.port_range.start))) }}
   {{- $port = add $port $service.port_range.start }}
   - name: "tcp-route-{{ $port }}"

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -203,8 +203,8 @@ spec:
   ports:
   - name: healthcheck
     protocol: TCP
-    port: 80
-    targetPort: 80
+    port: 88
+    targetPort: 88
   {{- range $port := until (int (add 1 (sub $service.port_range.end $service.port_range.start))) }}
   {{- $port = add $port $service.port_range.start }}
   - name: "tcp-route-{{ $port }}"


### PR DESCRIPTION

The clash is in tcp-router and router both exporting port 80/http. Depending on racing in kubecf the wrong endpoint is exposed through the main service.

## Description

  - Reconfigured the tcp_router job to not listen on 80/http for healthcheck requests any longer, and use custom port 88 instead.
  - Modified the health check probe to use port 88.
  - Modified ingress as well.

## Motivation and Context

See #1199 

## How Has This Been Tested?

Minikube deployment, diego/SA. Roles are green, passed smoke and brain tests.
Use with ingress not tested.

This still needs testing on AWS, to be sure that the changed port is ok with AWS loadbalancers.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
