### PR TITLE
fix: CI: Remove deprecated set-env/add-path

### DIFF
--- a/.github/workflows/pull-request-ci.yaml
+++ b/.github/workflows/pull-request-ci.yaml
@@ -172,11 +172,9 @@ jobs:
       # Install tools
       - run: make tools-install
 
-      # Add Gomplate to path
-      - name: Add Gomplate to path
-        run: |
-          gomplate_path="${{ github.workspace }}/kubecf/output/bin"
-          echo "::add-path::${gomplate_path}"
+      # Add tools to path
+      - name: Add tools to path
+        run: echo "${{ github.workspace }}/kubecf/output/bin" >> "${GITHUB_PATH}"
 
       # Download chart bundle
       - id: download-bundle
@@ -196,15 +194,15 @@ jobs:
           ssh-add ssh-key
           echo "::add-mask::$(cat ssh-key.pub)"
           rm -f ssh-key ssh-key.pub
-          echo "::set-env name=SSH_AUTH_SOCK::${SSH_AUTH_SOCK}"
-          echo "::set-env name=SSH_AGENT_PID::${SSH_AGENT_PID}"
+          echo "SSH_AUTH_SOCK=${SSH_AUTH_SOCK}" >> "${GITHUB_ENV}"
+          echo "SSH_AGENT_PID=${SSH_AGENT_PID}" >> "${GITHUB_ENV}"
 
       # set GKE secret. TBD: use vault instead
       - name: set GKE_CRED_JSON
         run: |
           json_file="$(mktemp)"
           echo "$GKE_CRED_JSON" > "${json_file}"
-          echo "::set-env name=GKE_CRED_JSON::${json_file}"
+          echo "GKE_CRED_JSON=${json_file}" >> "${GITHUB_ENV}"
         env:
           GKE_CRED_JSON: ${{ secrets.GKE_CRED_JSON }}
 
@@ -232,7 +230,7 @@ jobs:
           set -o errexit -o nounset -o pipefail
           cd "build${BACKEND}"
           source .envrc
-          echo "::set-env name=KUBECONFIG::${KUBECONFIG}"
+          echo "KUBECONFIG=${KUBECONFIG}" >> "${GITHUB_ENV}"
           # Debugging aid; should be safe as the cluster will be torn down
           # at the end of the run.
           cat "${KUBECONFIG}" | gzip | base64 --wrap=0


### PR DESCRIPTION
## Description

They deprecated the (in-band) `set-env` and `add-path` commands; now things go to a file instead.

## Motivation and Context
Getting warnings when running Actions.

See [GitHub blob post](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/).

## How Has This Been Tested?
Ran action while working on #1144

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
