### PR TITLE
fix: external-database doc url

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -374,7 +374,7 @@ features:
       resource_directory_key: ~
 
   # Configuration for the external database; see also features.embedded_database.  Please refer to
-  # https://kubecf.io/docs/deployment/kubernetes-deploy/#external-database for details.
+  # https://kubecf.io/docs/deployment/advanced-topics/#external-database for details.
   external_database:
     enabled: false
     require_ssl: false


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix external-database doc url to point to correct location.

## Description
Fix `values.yaml` to have the right external-database doc url

## Motivation and Context
Wrong external-database url

## How Has This Been Tested?
Just went and looked for the right doc location

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
