### PR TITLE
fix: klog.sh: drop --export flag on kubectl get

### DIFF
--- a/dev/kube/klog.sh
+++ b/dev/kube/klog.sh
@@ -130,12 +130,12 @@ function get_pod_description() {
 
 function get_all_resources() {
   printf '  Resources ...\n'
-  kubectl get all --export=true --namespace "${NS}" --output=yaml > "${KLOG}/${NS}/resources.yaml"
+  kubectl get all --namespace "${NS}" --output=yaml > "${KLOG}/${NS}/resources.yaml"
 }
 
 function get_all_events() {
   printf '  Events ...\n'
-  kubectl get events --export=true --namespace "${NS}" --output=yaml > "${KLOG}/${NS}/events.yaml"
+  kubectl get events --namespace "${NS}" --output=yaml > "${KLOG}/${NS}/events.yaml"
 }
 
 rm -rf "${KLOG:?}/${NS:?}"


### PR DESCRIPTION
## Description
Remove the `--export` flag from `kubectl get` invocations in `klog.sh`, because it has been removed.  See https://github.com/kubernetes/kubernetes/pull/73787

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Trying to run `klog.sh` is failing for me:
```
Pod cf-operator-7b966b9dcf-tlvn8 = Running
  - job  cf-operator logs: Kube
  Descriptions ...
Pod cf-operator-quarks-job-cc575c654-sqspf = Running
  - job  quarks-job logs: Kube
  Descriptions ...
Pod cf-operator-quarks-secret-5959c95c49-hvqzb = Running
  - job  quarks-secret logs: Kube
  Descriptions ...
Global information...
  Resources ...
Error: unknown flag: --export
See 'kubectl get --help' for usage.
Error: Process completed with exit code 1.
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- An important detail to include is the version of the used cf-operator -->
Ran `klog.sh` on my minikube cluster to make sure I still get events.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
