### PR TITLE
fix: downgrade sle15 rootfs because the latest image does not exist

### DIFF
--- a/chart/config/sle15.yaml
+++ b/chart/config/sle15.yaml
@@ -13,7 +13,7 @@ stacks:
         stemcell:
           version: 27.10-7.0.0_374.gb8e8e6af
       sle15:
-        version: "24.81"
+        version: "24.79"
       suse-staticfile-buildpack:
         version: "1.5.12.1"
       suse-java-buildpack:


### PR DESCRIPTION
The 24.81 rootfs has only been build with the previous 27.8 stemcell. This issue will self-correct once there is another update to the rootfs, which happens pretty frequently.
