### PR TITLE
Fix '/instance_groups/name=api' not found when multiple_cluster_mode.control_plane is disabled

### DIFF
--- a/chart/templates/bosh_deployment.yaml
+++ b/chart/templates/bosh_deployment.yaml
@@ -78,12 +78,6 @@ spec:
     type: configmap
 {{- end }}
 
-# To support multi-clusters
-{{- if or .Values.features.multiple_cluster_mode.control_plane.enabled .Values.features.multiple_cluster_mode.cell_segment.enabled }}
-  - name: multiple-cluster-mode-operations
-    type: configmap
-{{- end }}
-
 # Custom operations
 {{- range $_, $ops := .Values.operations.custom }}
   - name: {{ $ops | quote }}
@@ -95,3 +89,9 @@ spec:
 {{- end }}
   - name: user-provided-properties
     type: configmap
+
+# To support multi-clusters, NOTE: this section must be the bottom of this file
+{{- if or .Values.features.multiple_cluster_mode.control_plane.enabled .Values.features.multiple_cluster_mode.cell_segment.enabled }}
+  - name: multiple-cluster-mode-operations
+    type: configmap
+{{- end }}


### PR DESCRIPTION
## Description
  The multiple-cluster-mode-operations removes '/instance_groups/name=api' when multiple_cluster_mode.control_plane is disabled, so any other operations after multiple-cluster-mode-operations gets error if they try to operate '/instance_groups/name=api'.

  The multiple-cluster-mode-operations must be the botton of chart/templates/bosh_deployment.yaml


## How Has This Been Tested?
Tested in a shard cluster with below values:

```
features:
  # To support multi-clusters, deploy diego-cell separately please set control_plane is false  and cell_segment is true
  multiple_cluster_mode:
    control_plane:
      enabled: false
    cell_segment:
      enabled: true
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
