### PR TITLE
fix: Build buildpacks/stack against two stemcells if necessary

### DIFF
--- a/.concourse/suse-buildpacks-ci/buildpack-version-bump/tasks/build.sh
+++ b/.concourse/suse-buildpacks-ci/buildpack-version-bump/tasks/build.sh
@@ -29,9 +29,13 @@ tar xvf s3.fissile-linux/fissile-*.tgz --directory "/usr/local/bin/"
 sle_version="$(cut -d- -f1 "s3.stemcell-version/${STEMCELL_VERSIONED_FILE##*/}")"
 # stemcell_version without the fissile version part, e.g. 27.8
 # shellcheck disable=SC2016
-stemcell_version=$(yq -r '.stacks.sle15.releases["$defaults"].stemcell.version' "kubecf/${KUBECF_VALUES}" | cut -d- -f1)
-stemcell_image="${STEMCELL_REPOSITORY}:${sle_version}-${stemcell_version}"
-docker pull "${stemcell_image}"
+stemcell_master_version=$(yq -r '.stacks.sle15.releases["$defaults"].stemcell.version' "kubecf/${KUBECF_VALUES}" | cut -d- -f1)
+stemcell_master_image="${STEMCELL_REPOSITORY}:${sle_version}-${stemcell_master_version}"
+stemcell_s3_version="$(cat s3.stemcell-version/"${STEMCELL_VERSIONED_FILE##*/}")"
+stemcell_s3_image="${STEMCELL_REPOSITORY}:${stemcell_s3_version}"
+
+docker pull "${stemcell_master_image}"
+docker pull "${stemcell_s3_image}"
 
 # Get version from the GitHub release that triggered this task
 pushd suse_final_release
@@ -43,4 +47,8 @@ popd
 tasks_dir="$(dirname "$0")"
 # shellcheck source=/dev/null
 source "${tasks_dir}"/build_release.sh
-build_release "${REGISTRY_NAME}" "${REGISTRY_ORG}" "${stemcell_image}" "${RELEASE_NAME}" "${RELEASE_URL}" "${RELEASE_VERSION}" "${RELEASE_SHA}"
+build_release "${REGISTRY_NAME}" "${REGISTRY_ORG}" "${stemcell_master_image}" "${RELEASE_NAME}" "${RELEASE_URL}" "${RELEASE_VERSION}" "${RELEASE_SHA}"
+
+if [ "${stemcell_master_version}" != "${stemcell_s3_version}" ]; then
+  build_release "${REGISTRY_NAME}" "${REGISTRY_ORG}" "${stemcell_s3_image}" "${RELEASE_NAME}" "${RELEASE_URL}" "${RELEASE_VERSION}" "${RELEASE_SHA}"
+fi

--- a/.concourse/suse-buildpacks-ci/buildpack-version-bump/tasks/build.sh
+++ b/.concourse/suse-buildpacks-ci/buildpack-version-bump/tasks/build.sh
@@ -29,8 +29,8 @@ tar xvf s3.fissile-linux/fissile-*.tgz --directory "/usr/local/bin/"
 sle_version="$(cut -d- -f1 "s3.stemcell-version/${STEMCELL_VERSIONED_FILE##*/}")"
 # stemcell_version without the fissile version part, e.g. 27.8
 # shellcheck disable=SC2016
-stemcell_master_version=$(yq -r '.stacks.sle15.releases["$defaults"].stemcell.version' "kubecf/${KUBECF_VALUES}" | cut -d- -f1)
-stemcell_master_image="${STEMCELL_REPOSITORY}:${sle_version}-${stemcell_master_version}"
+stemcell_master_version=${sle_version}-$(yq -r '.stacks.sle15.releases["$defaults"].stemcell.version' "kubecf/${KUBECF_VALUES}" | cut -d- -f1)
+stemcell_master_image="${STEMCELL_REPOSITORY}:${stemcell_master_version}"
 stemcell_s3_version="$(cat s3.stemcell-version/"${STEMCELL_VERSIONED_FILE##*/}")"
 stemcell_s3_image="${STEMCELL_REPOSITORY}:${stemcell_s3_version}"
 


### PR DESCRIPTION
## Description

There are potential race conditions that a stemcell update
is not yet merged to master in which case a in the meantime
updated buildpack is build against the old stemcell and not
the newer one.

With this commit the buildpack is build against both stemcells.

## How Has This Been Tested?
The stemcell was downgraded in the test branch and the pipeline was executed and verified that images were built against both stemcells.
After that the pipeline was run without the downgrade and it was verified that no issue appeared.
https://concourse.suse.dev/teams/main/pipelines/suse-buildpacks-buildpack-version-bump/jobs/build-image-binary-buildpack/builds/18


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
