### PR TITLE
fix: chart: Axe tcp-router-public if unavailable

### DIFF
--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -229,7 +229,7 @@ deploy_args: &deploy_args
   # Setup dns
   tcp_router_ip=$(kubectl get svc -n scf tcp-router-public -o json | jq -r .status.loadBalancer.ingress[].ip | head -n 1)
   # tcp-router svc may not exist, if so, use an rfc5737 example IP address
-  tcp_router_ip=${$tcp_router_ip:-192.0.2.0}
+  tcp_router_ip="${tcp_router_ip:-"192.0.2.0"}"
   public_router_ip=$(kubectl get svc -n scf router-public -o json | jq -r .status.loadBalancer.ingress[].ip | head -n 1)
   # ssh-proxy service is named differently in diego and eirini
   ssh_proxy_svc=$(kubectl get svc -n scf | grep ssh-proxy | awk '{print $1}' | head -n 1)

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -227,9 +227,9 @@ deploy_args: &deploy_args
   make kubeconfig kubecf
 
   # Setup dns
-  # tcp-router service may not exist, if that's the case, use an rfc5737 example
-  # IP address
-  tcp_router_ip=${$(kubectl get svc -n scf tcp-router-public -o json | jq -r .status.loadBalancer.ingress[].ip | head -n 1):-192.0.2.0}
+  tcp_router_ip=$(kubectl get svc -n scf tcp-router-public -o json | jq -r .status.loadBalancer.ingress[].ip | head -n 1)
+  # tcp-router svc may not exist, if so, use an rfc5737 example IP address
+  tcp_router_ip=${$tcp_router_ip:-192.0.2.0}
   public_router_ip=$(kubectl get svc -n scf router-public -o json | jq -r .status.loadBalancer.ingress[].ip | head -n 1)
   # ssh-proxy service is named differently in diego and eirini
   ssh_proxy_svc=$(kubectl get svc -n scf | grep ssh-proxy | awk '{print $1}' | head -n 1)

--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -227,7 +227,9 @@ deploy_args: &deploy_args
   make kubeconfig kubecf
 
   # Setup dns
-  tcp_router_ip=$(kubectl get svc -n scf tcp-router-public -o json | jq -r .status.loadBalancer.ingress[].ip | head -n 1)
+  # tcp-router service may not exist, if that's the case, use an rfc5737 example
+  # IP address
+  tcp_router_ip=${$(kubectl get svc -n scf tcp-router-public -o json | jq -r .status.loadBalancer.ingress[].ip | head -n 1):-192.0.2.0}
   public_router_ip=$(kubectl get svc -n scf router-public -o json | jq -r .status.loadBalancer.ingress[].ip | head -n 1)
   # ssh-proxy service is named differently in diego and eirini
   ssh_proxy_svc=$(kubectl get svc -n scf | grep ssh-proxy | awk '{print $1}' | head -n 1)

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -178,6 +178,7 @@ spec:
   {{- end }}
 {{- end }}
 {{- end }} {{/* not .features.eirini.enabled */}}
+{{- if .Values.features.routing_api.enabled }}
 ---
 {{- with $service := index .Values.services "tcp-router" }}
 apiVersion: v1
@@ -223,4 +224,5 @@ spec:
   loadBalancerIP: {{ $service.loadBalancerIP | quote }}
   {{- end }}
 {{- end }}
+{{- end }} {{/* .Values.features.routing_api.enabled  */}}
 {{- end }}


### PR DESCRIPTION
## Description
If routing-api is not enabled, then remove the tcp-router-public service (when not using ingress).  Otherwise we end up with a service that will never point at anything.

## Motivation and Context
Discovered while working on #1144.
We will never finish waiting for services to be ready if we have a service that can never be ready.

## How Has This Been Tested?
Tested locally (and in the WIP CI stuff); I can actually finish waiting now.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
