### PR TITLE
fix: CI: concourse: Use GHCR github-status image

### DIFF
--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -36,7 +36,7 @@ resource_types:
 - name: github-status
   type: docker-image
   source:
-    repository: resource/github-status
+    repository: ghcr.io/concourse-resource/github-status
     tag: release
 {{- end }}
 


### PR DESCRIPTION
## Description
Docker Hub has put in quotas for image pulling; this is causing an issue for our CI pipelines.  Copy the image to the GitHub container registry (which currently has no limits).  There is currently no pipeline to _push_ to the GitHub container registry; it's just the latest image on Docker Hub for now.

## Motivation and Context
See #1557 — this doesn't fix the whole issue yet, just one of the images.

## How Has This Been Tested?
Hasn't been tested yet; I _have_ confirmed that I can pull the image without logging in. (It appears that the docker client in OpenSUSE Leap 15.1 (19.03.11) cannot login to GHCR.)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
