### PR TITLE
fix: copy githubstatus and github-pr-resource images to ghcr

### DIFF
--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -29,14 +29,16 @@ resource_types:
 - name: pull-request
   type: docker-image
   source:
-    repository: splatform/github-pr-resource
+    # repository: splatform/github-pr-resource
+    repository: ghcr.io/jandubois/github-pr-resource
     tag: e92ede5
 
 {{- if $config.github_status }}
 - name: github-status
   type: docker-image
   source:
-    repository: resource/github-status
+    # repository: resource/github-status
+    repository: ghcr.io/jandubois/github-status
     tag: release
 {{- end }}
 


### PR DESCRIPTION
Just to avoid the pipeline from stalling after hitting the dockerhub bandwidth limit.

Moving them to my personal Github account it temporary until we figure out which org we can use for stable names.

The pipeline has already been deployed.