### PR TITLE
fix: autoscaler: Drop control script

### DIFF
--- a/chart/assets/operations/instance_groups/app-autoscaler.yaml
+++ b/chart/assets/operations/instance_groups/app-autoscaler.yaml
@@ -923,9 +923,10 @@
     bpm:
       processes:
       - name: golangapiserver
-        executable: /var/vcap/jobs/golangapiserver/bin/apiserver_ctl
+        executable: /var/vcap/packages/golangapiserver/api
         args:
-        - start
+        - -c
+        - /var/vcap/jobs/golangapiserver/config/apiserver.yml
     run:
       healthcheck:
         golangapiserver:


### PR DESCRIPTION
## Description
This drops the BOSH-style control script for the autoscaler golang apiserver, and uses BPM to directly launch the binary.

I suspect I may be missing features in that control script that the IBM folks are using; however GitHub doesn't seem to like me. @aqan213 — would you have some time to take a look?

## Motivation and Context
I suspect that the control script (having been designed for monit) uses a PID file, which doesn't work well when the container restarts.  I'm seeing issues on some deployments (on CI) where that pod gets stuck at an unready state (crashing repeatedly); deleting the pod and letting the deployment spin up a new one works around the issue.

## How Has This Been Tested?
This was cherry-picked out of my branch related to GitHub Actions work for #1144; I haven't had issues related to the autoscaler not being ready since I made the change.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
