### PR TITLE
fix: chart: bump resource limits

### DIFF
--- a/chart/config/resources.yaml
+++ b/chart/config/resources.yaml
@@ -118,7 +118,7 @@ resources:
   api:
     cloud_controller_ng:
       cloud_controller_ng: {memory: {limit: 2048, request: 1024}}
-      nginx: 192
+      nginx: 512
       # Template for all `local_worker_N` processes. Will be applied by _jobs.update.
       '$local_worker': {memory: {limit: 800, request: 400}}
     file_server: 96

--- a/chart/config/resources.yaml
+++ b/chart/config/resources.yaml
@@ -153,7 +153,7 @@ resources:
     cloud_controller_clock: 512
   singleton-blobstore:
     blobstore:
-      nginx: 400
+      nginx: 768
   smoke-tests: 1000
   tcp-router: 96
   uaa:


### PR DESCRIPTION
## Description
Bump the memory limit for the cloud controller nginx, as well as the blobstore nginx.  As we're only using those limits to prevent runaway memory consumption, this should be safe.  I did not touch the requests.

## Motivation and Context
My CI runs were failing because the containers were being OOMKilled in the middle of the run (which was only discovered upon examining the logs dumped at the end of a run).

## How Has This Been Tested?
Ran CATS &c runs on GitHub Actions; the tests have been passing since the changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
