### PR TITLE
fix: use images from Github Container Registry

### DIFF
--- a/chart/assets/operations/instance_groups/app-autoscaler.yaml
+++ b/chart/assets/operations/instance_groups/app-autoscaler.yaml
@@ -975,7 +975,9 @@
           readiness:
             exec:
               command:
-              - /var/vcap/packages/postgres-11.5/bin/pg_isready
+              - /bin/sh
+              - -c
+              - exec /var/vcap/packages/postgres-11.*/bin/pg_isready
     bpm:
       processes:
       - name: postgres

--- a/chart/config/cflinuxfs3.yaml
+++ b/chart/config/cflinuxfs3.yaml
@@ -12,14 +12,5 @@ stacks:
       # '$defaults' will be applied from config/releases.yaml
       cflinuxfs3:
         stemcell:
-          version: 27.2-7.0.0_374.gb8e8e6af
-        version: 0.203.0
-      # buildpack versions will be set from cf-deployment
-      nginx-buildpack:
-        stemcell:
-          version: 27.2-7.0.0_374.gb8e8e6af
-        version: ~
-      r-buildpack:
-        stemcell:
-          version: 27.2-7.0.0_374.gb8e8e6af
-        version: ~
+          version: 27.11-7.0.0_374.gb8e8e6af
+        version: 0.210.0

--- a/chart/config/releases.yaml
+++ b/chart/config/releases.yaml
@@ -53,11 +53,11 @@ releases:
     condition: false
   postgres:
     condition: features.autoscaler.enabled
-    version: "39"
+    version: "42"
   sync-integration-tests:
     # XXX SITS only makes sense when using Diego; add error check somewhere?
     condition: testing.sync_integration_tests.enabled
-    version: v0.0.3
+    version: v0.0.2
 
 unsupported:
   ? releases.defaults

--- a/chart/config/releases.yaml
+++ b/chart/config/releases.yaml
@@ -42,7 +42,7 @@ releases:
   database:
     # database (previously known as pxc) is not a BOSH release.
     image:
-      repository: docker.io/cfcontainerization/pxc
+      repository: ghcr.io/cloudfoundry-incubator/pxc
       tag: 0.9.11
   metrics-discovery:
     # metrics-agent add-on (new in cf-deployment 13.0) is not used by kubecf

--- a/chart/config/releases.yaml
+++ b/chart/config/releases.yaml
@@ -7,10 +7,10 @@
 releases:
   # The defaults for all releases, where we do not otherwise override them.
   '$defaults':
-    url: docker.io/cfcontainerization
+    url: ghcr.io/cloudfoundry-incubator
     stemcell:
       os: SLE_15_SP1
-      version: 27.5-7.0.0_374.gb8e8e6af
+      version: 27.11-7.0.0_374.gb8e8e6af
   app-autoscaler:
     condition: features.autoscaler.enabled
     version: 3.0.1

--- a/mixins/eirinix/config/eirinix.yaml
+++ b/mixins/eirinix/config/eirinix.yaml
@@ -7,7 +7,7 @@ eirinix:
   loggregator-bridge:
     replicaCount: 1
     image:
-      repository: splatform
+      repository: ghcr.io/cloudfoundry-incubator
       tag: v0.0.0-0.g7da9e04
       pullPolicy: IfNotPresent
     resources: {}
@@ -34,7 +34,7 @@ eirinix:
   persi:
     replicaCount: 1
     image:
-      repository: splatform
+      repository: ghcr.io/cloudfoundry-incubator
       tag: v0.0.0-73.g8201eba
       pullPolicy: IfNotPresent
     resources: {}
@@ -45,11 +45,11 @@ eirinix:
   persi-broker:
     replicaCount: 1
     image:
-      repository: splatform
+      repository: ghcr.io/cloudfoundry-incubator
       tag: v0.0.0-g0c241e7
       pullPolicy: IfNotPresent
     setup-image:
-      repository: splatform
+      repository: ghcr.io/cloudfoundry-incubator
       tag: v0.0.0-g9d08cc7
       pullPolicy: IfNotPresent
     resources: {}
@@ -78,7 +78,7 @@ eirinix:
   ssh:
     replicaCount: 1
     image:
-      repository: splatform
+      repository: ghcr.io/cloudfoundry-incubator
       tag: v0.0.0-0.g09b53c0
       pullPolicy: IfNotPresent
     resources: {}
@@ -92,11 +92,11 @@ eirinix:
   ssh-proxy:
     replicaCount: 1
     image:
-      repository: splatform
+      repository: ghcr.io/cloudfoundry-incubator
       tag: v0.0.0-0.g09b53c0
       pullPolicy: IfNotPresent
     setup-image:
-      repository: splatform
+      repository: ghcr.io/cloudfoundry-incubator
       tag: v0.0.0-g9d08cc7
       pullPolicy: IfNotPresent
     resources: {}


### PR DESCRIPTION
This PR uses the images on ghcr.io built with the latest stemcell.

The following images still reside on Dockerhub:

```
docker.io/cfcontainerization/coredns
```

Ref #1557