### PR TITLE
fix: Move Concourse resource images to ghcr.io/cloudfoundry-incubator

### DIFF
--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -29,14 +29,14 @@ resource_types:
 - name: pull-request
   type: docker-image
   source:
-    repository: splatform/github-pr-resource
+    repository: ghcr.io/cloudfoundry-incubator/github-pr-resource
     tag: e92ede5
 
 {{- if $config.github_status }}
 - name: github-status
   type: docker-image
   source:
-    repository: resource/github-status
+    repository: ghcr.io/cloudfoundry-incubator/github-status
     tag: release
 {{- end }}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Move Concourse's resource images to ghcr.io/cloudfoundry-incubator to avoid dockerhub bandwidth limits.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Avoid dockerhub.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- An important detail to include is the version of the used cf-operator -->

Already flown.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
