### PR TITLE
fix: CI: Scheduler: Use vault for secrets

### DIFF
--- a/.github/workflows/pull-request-schedule.yaml
+++ b/.github/workflows/pull-request-schedule.yaml
@@ -1,7 +1,7 @@
 name: Pull Request Scheduler
 on:
-  #schedule:
-  #- cron: '*/10 * * * *'
+  schedule:
+  - cron: '*/10 * * * *'
   workflow_dispatch: {}
 
 env:

--- a/.github/workflows/pull-request-schedule.yaml
+++ b/.github/workflows/pull-request-schedule.yaml
@@ -25,27 +25,43 @@ jobs:
     - name: Checkout KubeCF
       # This is only needed to find the GitHub script in the find-jobs step.
       uses: actions/checkout@v2
+      with:
+        persist-credentials: false
+
     - name: Checkout catapult
       uses: actions/checkout@v2
       with:
         repository: SUSE/catapult
         path: catapult
+        persist-credentials: false
 
-    # set GKE secret. TBD: use vault instead
+    - name: Get Cloud Provider Credentials
+      id: vault-cloud-provider
+      uses: hashicorp/vault-action@v2.0.1
+      with:
+        url: https://volt.cap.explore.suse.dev/
+        exportEnv: false
+        token: ${{ secrets.VAULT_TOKEN }}
+        secrets: |
+          secret/data/cloud-providers gke.GKE_CRED_JSON            | GKE_CRED_JSON ;
+          secret/data/cloud-providers gke.GKE_CRED_JSON.project_id | GKE_PROJECT_ID ;
+          secret/data/cloud-providers gke.`ci-location`            | GKE_LOCATION ;
+
     - name: Setup Cloud Provider Credentials
       run: |
+        set -o errexit -o pipefail -o nounset
         json_file="$(mktemp)"
         cat > "${json_file}" <<< "${GKE_CRED_JSON}"
         echo "GKE_CRED_JSON=${json_file}" >> "${GITHUB_ENV}"
       env:
-        GKE_CRED_JSON: ${{ secrets.GKE_CRED_JSON }}
+        GKE_CRED_JSON: ${{ steps.vault-cloud-provider.outputs.GKE_CRED_JSON }}
 
     - name: Find Clusters
       run: make buildir find-resources
       working-directory: catapult
       env:
-        GKE_LOCATION: ${{ secrets.GKE_LOCATION }}
-        GKE_PROJECT: ${{ secrets.GKE_PROJECT }}
+        GKE_LOCATION: ${{ steps.vault-cloud-provider.outputs.GKE_LOCATION }}
+        GKE_PROJECT: ${{ steps.vault-cloud-provider.outputs.GKE_PROJECT_ID }}
         OUTPUT_FILE: ${{ github.workspace }}/resources.json
 
     - name: Find Running Jobs
@@ -62,8 +78,8 @@ jobs:
       run: make buildir force-clean-cluster
       working-directory: catapult
       env:
-        GKE_LOCATION: ${{ secrets.GKE_LOCATION }}
-        GKE_PROJECT: ${{ secrets.GKE_PROJECT }}
+        GKE_LOCATION: ${{ steps.vault-cloud-provider.outputs.GKE_LOCATION }}
+        GKE_PROJECT: ${{ steps.vault-cloud-provider.outputs.GKE_PROJECT_ID }}
         RESOURCE_LIST: ${{ github.workspace }}/resources.json
         CLUSTER_SELECTOR: ${{ steps.find-jobs.outputs.result }}
         ACTUALLY_DELETE: "true"
@@ -92,6 +108,9 @@ jobs:
     - name: Checkout KubeCF
       # This is only needed to find the GitHub script in the next step.
       uses: actions/checkout@v2
+      with:
+        persist-credentials: false
+
     - name: Trigger Builds
       uses: actions/github-script@v3
       with:

--- a/.github/workflows/pull-request-schedule.yaml
+++ b/.github/workflows/pull-request-schedule.yaml
@@ -41,7 +41,7 @@ jobs:
       with:
         url: https://volt.cap.explore.suse.dev/
         exportEnv: false
-        token: ${{ secrets.VAULT_TOKEN }}
+        token: ${{ secrets.VAULT_TOKEN_CLOUD_PROVIDERS }}
         secrets: |
           secret/data/cloud-providers gke.GKE_CRED_JSON            | GKE_CRED_JSON ;
           secret/data/cloud-providers gke.GKE_CRED_JSON.project_id | GKE_PROJECT_ID ;


### PR DESCRIPTION
## Description
Use Vault instead of GitHub Secrets for credentials; this should make it easier for us to change them (as more people have access).

## Motivation and Context
We are attempting to centralize our secrets into a vault instance, so it is under our control.

## How Has This Been Tested?
Ran on my fork, https://github.com/mook-as/kubecf/actions/runs/366810108

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Note:
This should only be merged after we made sure we add a `VAULT_TOKEN` (GitHub) [secret](https://github.com/cloudfoundry-incubator/kubecf/settings/secrets/actions) that has access to the `cloud-providers` (vault) secret.