### PR TITLE
feat: Auto-adapt NOTES.txt to HA changes in underlying CF manifest.

### DIFF
--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -17,7 +17,8 @@
     to monitor continuously.
 
     {{- if not .Values.features.eirini.enabled }}
-    {{- $cell_count := .Values.sizing.diego_cell.instances | default (ternary 3 1 .Values.high_availability) }}
+    {{- $_ := include "_config.lookupManifest" (list $ "instance_groups/name=diego-cell/instances") }}
+    {{- $cell_count := .Values.sizing.diego_cell.instances | default (ternary $.kubecf.retval 1 .Values.high_availability) }}
     {{- $disk_size := .Values.sizing.diego_cell.ephemeral_disk.size }}
     {{- if .Values.sizing.diego_cell.storage_class }}
         {{- /* when using a storage class, we will reserve space for other uses. */}}


### PR DESCRIPTION
## Description

Used @jandubois ' proposal to read the HA cell count from the underlying CF manifest, replacing the hardwired `3`.

## Motivation and Context

See https://github.com/cloudfoundry-incubator/kubecf/pull/1591#discussion_r524586598

## How Has This Been Tested?

Local minikube.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
