### PR TITLE
fix: PXC: Always reset the root password on start

### DIFF
--- a/chart/assets/scripts/jobs/pxc/functions.sh
+++ b/chart/assets/scripts/jobs/pxc/functions.sh
@@ -28,7 +28,7 @@ EOF
 }
 
 # Wait for the MySQL instance meant for initialization only.
-# Exepcts `mysql()` to be set.
+# Expects `mysql()` to be set.
 wait_for_init_daemon() {
     for i in {30..0}; do
         if echo 'SELECT 1' | "${mysql[@]}" &> /dev/null; then

--- a/chart/templates/database/db-statefulset.yaml
+++ b/chart/templates/database/db-statefulset.yaml
@@ -31,6 +31,8 @@ spec:
         metadata:
           labels:
             {{- list . "database" | include "component.labels" | nindent 12 }}
+          annotations:
+            quarks.cloudfoundry.org/restart-on-update: "true"
         spec:
           {{- if $.Values.sizing.database.affinity }}
           affinity: {{ $.Values.sizing.database.affinity | toJson }}

--- a/chart/values.schema.yaml
+++ b/chart/values.schema.yaml
@@ -74,6 +74,7 @@ definitions:
         properties:
           repository: {type: string}
           tag: {type: string}
+          pullPolicy: {type: string}
         required: [repository]
         additionalProperties: false
       stemcell:


### PR DESCRIPTION
## Description
If the root password changes from under us (e.g. from a secret rotation), we need to tell MySQL about it so that things like the readiness probe will work with the new password.  A database seeder job will also be automatically triggered to take care of any of the other passwords changing.

## Motivation and Context
Fixes #1355

## How Has This Been Tested?
- Deployed locally
- Manually deleted the database pod to make sure that recovers correctly.
- [Rotated](https://quarks.suse.dev/docs/quarks-operator/concepts/rotation_and_restart/#rotation) the `var-pxc-root-password` secret, to ensure that  we can update the root password correctly.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Notes:
Probably should follow up to do the update-on-change thing; it didn't want to work for me…