### PR TITLE
fix: GitHub Actions improvements

### DIFF
--- a/.github/workflows/pull-request-ci.yaml
+++ b/.github/workflows/pull-request-ci.yaml
@@ -1,7 +1,7 @@
 name: Pull Request Tests
 on:
   # Trigger the workflow when PRs are labeled
-  pull_request_target:
+  pull_request:
     branches: [master]
     types: [labeled]
 
@@ -40,6 +40,7 @@ jobs:
           path: kubecf
           fetch-depth: 0
           submodules: recursive
+          persist-credentials: false
 
       # Python setup
       - uses: actions/setup-python@v2
@@ -109,6 +110,7 @@ jobs:
         with:
           path: kubecf
           submodules: recursive
+          persist-credentials: false
         timeout-minutes: 1
 
       # We need catapult to create Kubernetes clusters
@@ -117,6 +119,7 @@ jobs:
         with:
           repository: SUSE/catapult
           path: catapult
+          persist-credentials: false
         timeout-minutes: 1
 
       # Python setup

--- a/.github/workflows/pull-request-ci.yaml
+++ b/.github/workflows/pull-request-ci.yaml
@@ -335,7 +335,8 @@ jobs:
 
       # Fetch logs for debugging
       - name: Fetch logs
-        if: always()
+        id: fetch-logs
+        if: failure()
         run: |
           gcloud auth activate-service-account --key-file=${GKE_CRED_JSON}
           # Running klog.sh twice will grab logs from both namespaces
@@ -348,7 +349,7 @@ jobs:
       - name: Upload logs
         # Even if the fetch logs step failed, we may have _some_ logs from the
         # operator part; try to upload anyway.
-        if: always()
+        if: always() && steps.fetch-logs.outcome != 'skipped'
         uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.backend }}-klog.tgz

--- a/.github/workflows/pull-request-ci.yaml
+++ b/.github/workflows/pull-request-ci.yaml
@@ -108,6 +108,7 @@ jobs:
         with:
           path: kubecf
           submodules: recursive
+        timeout-minutes: 1
 
       # We need catapult to create Kubernetes clusters
       - name: Checkout catapult
@@ -115,6 +116,7 @@ jobs:
         with:
           repository: SUSE/catapult
           path: catapult
+        timeout-minutes: 1
 
       # Python setup
       - uses: actions/setup-python@v2
@@ -122,6 +124,7 @@ jobs:
           # Force 3.8 because google-cloud-sdk is incompatible with 3.9
           # https://issuetracker.google.com/issues/170125513
           python-version: '3.8'
+        timeout-minutes: 1
 
       # Caching tools like helm, jq, git, y2j, yamllint etc
       - name: cache.tools
@@ -129,13 +132,16 @@ jobs:
         with:
           path: ${{ github.workspace }}/tools
           key: ${{ runner.os }}-tools
+        timeout-minutes: 5
 
       # Install tools
       - run: make tools-install
+        timeout-minutes: 1 # this should take ~ 20 seconds
 
       # Add tools to path
       - name: Add tools to path
         run: echo "${{ github.workspace }}/kubecf/output/bin" >> "${GITHUB_PATH}"
+        timeout-minutes: 1
 
       # Download chart bundle
       - id: download-bundle
@@ -145,6 +151,7 @@ jobs:
           name: kubecf-bundle.tgz
           # The artifact upload/download creates an extra directory
           path: ${{ github.workspace }}/kubecf-bundle
+        timeout-minutes: 1
 
       # Start SSH agent for catapult
       - name: Start SSH agent
@@ -158,6 +165,7 @@ jobs:
           rm -f ssh-key ssh-key.pub
           echo "SSH_AUTH_SOCK=${SSH_AUTH_SOCK}" >> "${GITHUB_ENV}"
           echo "SSH_AGENT_PID=${SSH_AGENT_PID}" >> "${GITHUB_ENV}"
+        timeout-minutes: 1
 
       # set GKE secret. TBD: use vault instead
       - name: set GKE_CRED_JSON
@@ -168,6 +176,7 @@ jobs:
           echo "GKE_CRED_JSON=${json_file}" >> "${GITHUB_ENV}"
         env:
           GKE_CRED_JSON: ${{ secrets.GKE_CRED_JSON }}
+        timeout-minutes: 1
 
       # Cache catapult's common tools
       - name: cache.catapult-common-tools
@@ -175,6 +184,7 @@ jobs:
         with:
           path: ${{ github.workspace }}/catapult/modules/common/bin
           key: ${{ runner.os }}-catapult-common-tools
+        timeout-minutes: 1
 
       # Deploy k8s cluster
       - run: make k8s
@@ -187,6 +197,7 @@ jobs:
           GKE_PREEMPTIBLE: false
           GKE_INSTANCE_TYPE: n2d-highcpu-16
           EXTRA_LABELS: '{"ci": "${{ github.run_id }}"}'
+        timeout-minutes: 20 # This should take ~10 minutes.
 
       # Providing kubeconfig for debugging
       - name: export KUBECONFIG
@@ -199,20 +210,24 @@ jobs:
           # at the end of the run.
           cat "${KUBECONFIG}" | gzip | base64 --wrap=0
         working-directory: catapult
+        timeout-minutes: 1
 
       # TBD: Don't generate values.yaml
       - name: Generate KubeCF Configuration
         run: exec "${GITHUB_WORKSPACE}/kubecf/.github/workflows/pull-request-ci/kubecf-gen-config.sh"
         env:
           AUTOSCALER: "true"
+        timeout-minutes: 1
 
       # Helm install cf-operator
       - run: make cf-operator-apply
         env:
           CF_OPERATOR_URL: ${{ github.workspace }}/kubecf-bundle/cf-operator.tgz
+        timeout-minutes: 1 # This should take ~10 seconds.
 
       # Wait for cf-operator pods to be ready
       - run: make cf-operator-wait
+        timeout-minutes: 1 # This should take ~30 seconds.
 
       # Helm install kubecf
       - run: make kubecf-apply
@@ -220,18 +235,22 @@ jobs:
           CHART: ${{ github.workspace }}/kubecf-bundle/kubecf_release.tgz
           FEATURE_EIRINI: ${{ matrix.backend == 'eirini' }}
           VALUES: dev/kubecf/kubecf-values.yaml
+        timeout-minutes: 1 # This should take ~30 seconds.
 
       # Wait for kubecf pods to be ready
       - run: make kubecf-wait
+        timeout-minutes: 30 # This should take ~15 minutes.
 
       # Run smoke tests
       - run: make smoke-tests
+        timeout-minutes: 10
 
       # Run brain tests
       # - run: make brain-tests
 
       # Run sits tests
       - run: make sync-integration-tests
+        if: matrix.backend == 'diego'
 
       # Run CATs
       - run: make acceptance-tests

--- a/.github/workflows/pull-request-ci.yaml
+++ b/.github/workflows/pull-request-ci.yaml
@@ -265,6 +265,7 @@ jobs:
       # Run sits tests
       - run: make sync-integration-tests
         if: matrix.backend == 'diego'
+        timeout-minutes: 5
 
       # Run CATs
       - run: make acceptance-tests
@@ -294,6 +295,7 @@ jobs:
               kubectl get "${resource}" --namespace="${namespace}" --output=wide
             done
           done
+        timeout-minutes: 5
 
       # Upload kubecf's values.yaml for debugging
       - name: Upload config
@@ -302,6 +304,7 @@ jobs:
         with:
           name: ${{ matrix.backend }}-values.yaml
           path: ${{ github.workspace }}/kubecf/dev/kubecf/kubecf-values.yaml
+        timeout-minutes: 5
 
       # Fetch logs for debugging
       - name: Fetch logs
@@ -311,6 +314,7 @@ jobs:
           # Running klog.sh twice will grab logs from both namespaces
           dev/kube/klog.sh -f -r cf-operator
           dev/kube/klog.sh -f -r
+        timeout-minutes: 60
 
       # Upload logs for debugging
       - name: Upload logs
@@ -319,6 +323,7 @@ jobs:
         with:
           name: ${{ matrix.backend }}-klog.tgz
           path: ${{ github.workspace }}/kubecf/klog.tar.gz
+        timeout-minutes: 5
 
       # Teardown created k8s cluster
       - name: kubernetes:teardown
@@ -332,3 +337,4 @@ jobs:
         working-directory: catapult
         env:
           GKE_CLUSTER_NAME: kubecf-ci-${{ github.run_id }}-${{ matrix.backend }}
+        timeout-minutes: 20

--- a/.github/workflows/pull-request-ci.yaml
+++ b/.github/workflows/pull-request-ci.yaml
@@ -148,6 +148,7 @@ jobs:
 
       # Start SSH agent for catapult
       - name: Start SSH agent
+        if: env.BACKEND == 'aks'
         run: |
           set -o errexit -o pipefail -o nounset
           eval "$(ssh-agent -s)"
@@ -160,6 +161,7 @@ jobs:
 
       # set GKE secret. TBD: use vault instead
       - name: set GKE_CRED_JSON
+        if: env.BACKEND == 'gke'
         run: |
           json_file="$(mktemp)"
           echo "$GKE_CRED_JSON" > "${json_file}"

--- a/.github/workflows/pull-request-ci.yaml
+++ b/.github/workflows/pull-request-ci.yaml
@@ -225,6 +225,7 @@ jobs:
         run: exec "${GITHUB_WORKSPACE}/kubecf/.github/workflows/pull-request-ci/kubecf-gen-config.sh"
         env:
           AUTOSCALER: "true"
+          ENABLE_EIRINI: ${{ matrix.backend == 'eirini' }}
         timeout-minutes: 1
 
       # Helm install cf-operator
@@ -248,7 +249,7 @@ jobs:
         env:
           CHART: ${{ github.workspace }}/kubecf-bundle/kubecf_release.tgz
           FEATURE_EIRINI: ${{ matrix.backend == 'eirini' }}
-          VALUES: dev/kubecf/kubecf-values.yaml
+          VALUES: ${{ github.workspace }}/kubecf-values.yaml
         timeout-minutes: 1 # This should take ~30 seconds.
 
       # Wait for kubecf pods to be ready
@@ -303,7 +304,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.backend }}-values.yaml
-          path: ${{ github.workspace }}/kubecf/dev/kubecf/kubecf-values.yaml
+          path: ${{ github.workspace }}/kubecf-values.yaml
         timeout-minutes: 5
 
       # Fetch logs for debugging

--- a/.github/workflows/pull-request-ci.yaml
+++ b/.github/workflows/pull-request-ci.yaml
@@ -185,7 +185,7 @@ jobs:
           DEBUG_MODE: true
           GKE_NODE_COUNT: 1
           GKE_PREEMPTIBLE: false
-          GKE_INSTANCE_TYPE: n1-highcpu-16
+          GKE_INSTANCE_TYPE: n2d-highcpu-16
           EXTRA_LABELS: '{"ci": "${{ github.run_id }}"}'
 
       # Providing kubeconfig for debugging

--- a/.github/workflows/pull-request-ci.yaml
+++ b/.github/workflows/pull-request-ci.yaml
@@ -184,7 +184,7 @@ jobs:
           OWNER: ${{ github.repository_owner }}
           DEBUG_MODE: true
           GKE_NODE_COUNT: 1
-          GKE_PREEMPTIBLE: true
+          GKE_PREEMPTIBLE: false
           GKE_INSTANCE_TYPE: n1-highcpu-16
           EXTRA_LABELS: '{"ci": "${{ github.run_id }}"}'
 

--- a/.github/workflows/pull-request-ci.yaml
+++ b/.github/workflows/pull-request-ci.yaml
@@ -342,15 +342,19 @@ jobs:
           dev/kube/klog.sh -f -r cf-operator
           dev/kube/klog.sh -f -r
         timeout-minutes: 60
+        continue-on-error: true
 
       # Upload logs for debugging
       - name: Upload logs
+        # Even if the fetch logs step failed, we may have _some_ logs from the
+        # operator part; try to upload anyway.
         if: always()
         uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.backend }}-klog.tgz
           path: ${{ github.workspace }}/kubecf/klog.tar.gz
         timeout-minutes: 5
+        continue-on-error: true
 
       # Teardown created k8s cluster
       - name: kubernetes:teardown

--- a/.github/workflows/pull-request-ci.yaml
+++ b/.github/workflows/pull-request-ci.yaml
@@ -230,7 +230,13 @@ jobs:
         timeout-minutes: 1 # This should take ~30 seconds.
 
       # Helm install kubecf
-      - run: make kubecf-apply
+      - name: Install KubeCF
+        run: |
+          if [[ "${FEATURE_EIRINI}" != "true" ]]; then
+            # `make kubecf-apply` gets confused if the values is `false`.
+            unset FEATURE_EIRINI
+          fi
+          make kubecf-apply
         env:
           CHART: ${{ github.workspace }}/kubecf-bundle/kubecf_release.tgz
           FEATURE_EIRINI: ${{ matrix.backend == 'eirini' }}

--- a/.github/workflows/pull-request-ci.yaml
+++ b/.github/workflows/pull-request-ci.yaml
@@ -256,6 +256,32 @@ jobs:
       - run: make kubecf-wait
         timeout-minutes: 30 # This should take ~15 minutes.
 
+      - name: Wait for DNS
+        run: |
+          set -o errexit -o nounset
+          selector=(
+            'app.kubernetes.io/component=router'
+            '!quarks.cloudfoundry.org/instance-group-name'
+          )
+          jsonpath='{.items[].status.loadBalancer.ingress[].ip}'
+          filter=(
+            --namespace=kubecf
+            --selector="$(IFS=, ; echo "${selector[*]}")"
+          )
+          ip="$(kubectl get service "${filter[@]}" --output="jsonpath=${jsonpath}")"
+          system_domain="$(gomplate --context ".=${GITHUB_WORKSPACE}/kubecf-values.yaml" --in '{{ .system_domain }}')"
+          for host in api login; do
+            fqdn="${host}.${system_domain}"
+            printf "Waiting for %s to have IP address %s..." "${fqdn}" "${ip}"
+            while [[ "$(dig +short "${fqdn}")" != "${ip}" ]]; do
+              printf "."
+              sleep 10
+            done
+            printf "Done.\n"
+          done
+        timeout-minutes: 10
+        continue-on-error: true
+
       # Run smoke tests
       - run: make smoke-tests
         timeout-minutes: 10

--- a/.github/workflows/pull-request-ci.yaml
+++ b/.github/workflows/pull-request-ci.yaml
@@ -202,46 +202,7 @@ jobs:
 
       # TBD: Don't generate values.yaml
       - name: Generate KubeCF Configuration
-        run: |
-          set -o errexit -o nounset -o pipefail
-
-          make -C ${{ github.workspace }}/catapult kubecf-gen-config
-
-          cd ${{ github.workspace }}/catapult/build${BACKEND}
-
-          gomplate --context .=scf-config-values.yaml <<"EOF" \
-            > ${{ github.workspace }}/kubecf/dev/kubecf/kubecf-values.yaml
-          {{- /* Disable brain minibroker tests */}}
-          {{- define "minibroker-tests" }}
-          properties:
-            brain-tests:
-              acceptance-tests-brain:
-                tests:
-                  minibroker:
-                    {{- range slice "mariadb" "mongodb" "postgres" "redis" }}
-                    {{ . }}:
-                      enabled: false
-                    {{- end }}
-          {{- end }}
-          {{- $ = tmpl.Exec "minibroker-tests" | yaml | merge $ }}
-
-          {{- /* Disable registry overrides */}}
-          {{- $ = coll.Omit "kube" $ }}
-
-          {{- /* Set DNS annotations */}}
-          {{- define "svc_annotation" }}
-          services:
-            {{ index . 0 }}:
-              annotations:
-                "external-dns.alpha.kubernetes.io/hostname": {{ index . 1 }}
-          {{- end }}
-          {{- $d := .system_domain }}
-          {{- $ = printf "%s, *.%s" $d $d | slice "router" | tmpl.Exec "svc_annotation" | yaml | merge $ }}
-          {{- $ = printf "ssh.%s" $d | slice "ssh-proxy" | tmpl.Exec "svc_annotation" | yaml | merge $ }}
-          {{- $ = printf "tcp.%s, *.tcp.%s" $d $d | slice "tcp-router" | tmpl.Exec "svc_annotation" | yaml | merge $ }}
-
-          {{- $ | toYAML }}
-          EOF
+        run: exec "${GITHUB_WORKSPACE}/kubecf/.github/workflows/pull-request-ci/kubecf-gen-config.sh"
         env:
           AUTOSCALER: "true"
 

--- a/.github/workflows/pull-request-ci.yaml
+++ b/.github/workflows/pull-request-ci.yaml
@@ -88,6 +88,7 @@ jobs:
       # Note that credentials-related parts are in the individual steps
       BACKEND: gke
       DOWNLOAD_CATAPULT_DEPS: "false"
+      CLUSTER_NAME: ci-${{ github.run_id }}-${{ matrix.backend }}
     defaults:
       run:
         working-directory: kubecf
@@ -199,17 +200,24 @@ jobs:
           EXTRA_LABELS: '{"ci": "${{ github.run_id }}"}'
         timeout-minutes: 20 # This should take ~10 minutes.
 
+      - name: Set Up GKE Configuration Directory
+        if: env.BACKEND == 'gke'
+        working-directory: catapult/build${{ env.CLUSTER_NAME }}
+        run: |
+          . .envrc
+          echo "CLOUDSDK_CONFIG=${CLOUDSDK_CONFIG}" >> "${GITHUB_ENV}"
+        timeout-minutes: 1
+
       # Providing kubeconfig for debugging
       - name: export KUBECONFIG
         run: |
           set -o errexit -o nounset -o pipefail
-          cd "build${BACKEND}"
           source .envrc
           echo "KUBECONFIG=${KUBECONFIG}" >> "${GITHUB_ENV}"
           # Debugging aid; should be safe as the cluster will be torn down
           # at the end of the run.
-          cat "${KUBECONFIG}" | gzip | base64 --wrap=0
-        working-directory: catapult
+          kubectl config view --minify --flatten | gzip | base64 --wrap=0
+        working-directory: catapult/build${{ env.CLUSTER_NAME }}
         timeout-minutes: 1
 
       # TBD: Don't generate values.yaml
@@ -319,7 +327,7 @@ jobs:
           set +o errexit
           # Remove any terraform locks, because we don't care if the previous run
           # has finished successfully (e.g. on cancel).
-          find "build${BACKEND}" -name '.terraform.*.lock*' -delete
+          find "build${CLUSTER_NAME}" -name '.terraform.*.lock*' -delete
           make clean
         working-directory: catapult
         env:

--- a/.github/workflows/pull-request-ci/kubecf-gen-config.sh
+++ b/.github/workflows/pull-request-ci/kubecf-gen-config.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+# This is called in the `Generate KubeCF Configuration` step of `pull-request-ci.yaml`
+
+set -o errexit -o nounset -o pipefail
+
+make -C "${GITHUB_WORKSPACE}/catapult" kubecf-gen-config
+
+cd "${GITHUB_WORKSPACE}/catapult/build${BACKEND}"
+
+gomplate --context .=scf-config-values.yaml <<"EOF" \
+> "${GITHUB_WORKSPACE}/kubecf/dev/kubecf/kubecf-values.yaml"
+{{- /* Disable brain minibroker tests */}}
+{{- define "minibroker-tests" }}
+properties:
+    brain-tests:
+        acceptance-tests-brain:
+            tests:
+                minibroker:
+                    {{- range slice "mariadb" "mongodb" "postgres" "redis" }}
+                    {{ . }}:
+                        enabled: false
+                    {{- end }}
+{{- end }}
+{{- $ = tmpl.Exec "minibroker-tests" | yaml | merge $ }}
+
+{{- /* Disable registry overrides */}}
+{{- $ = coll.Omit "kube" $ }}
+
+{{- /* Set DNS annotations */}}
+{{- define "svc_annotation" }}
+services:
+    {{ index . 0 }}:
+        annotations:
+            "external-dns.alpha.kubernetes.io/hostname": {{ index . 1 }}
+    {{- end }}
+{{- $d := .system_domain }}
+{{- $ = printf "%s, *.%s" $d $d | slice "router" | tmpl.Exec "svc_annotation" | yaml | merge $ }}
+{{- $ = printf "ssh.%s" $d | slice "ssh-proxy" | tmpl.Exec "svc_annotation" | yaml | merge $ }}
+{{- $ = printf "tcp.%s, *.tcp.%s" $d $d | slice "tcp-router" | tmpl.Exec "svc_annotation" | yaml | merge $ }}
+
+{{- $ | toYAML }}
+EOF
+
+echo "::group::scf-config-values.yaml"
+cat "${GITHUB_WORKSPACE}/kubecf/dev/kubecf/kubecf-values.yaml"
+echo "::endgroup"

--- a/.github/workflows/pull-request-ci/kubecf-gen-config.sh
+++ b/.github/workflows/pull-request-ci/kubecf-gen-config.sh
@@ -6,7 +6,7 @@ set -o errexit -o nounset -o pipefail
 
 make -C "${GITHUB_WORKSPACE}/catapult" kubecf-gen-config
 
-cd "${GITHUB_WORKSPACE}/catapult/build${BACKEND}"
+cd "${GITHUB_WORKSPACE}/catapult/build${CLUSTER_NAME:-${BACKEND}}"
 
 gomplate --context .=scf-config-values.yaml <<"EOF" \
 > "${GITHUB_WORKSPACE}/kubecf/dev/kubecf/kubecf-values.yaml"
@@ -44,4 +44,4 @@ EOF
 
 echo "::group::scf-config-values.yaml"
 cat "${GITHUB_WORKSPACE}/kubecf/dev/kubecf/kubecf-values.yaml"
-echo "::endgroup"
+echo "::endgroup::"

--- a/.github/workflows/pull-request-ci/kubecf-gen-config.sh
+++ b/.github/workflows/pull-request-ci/kubecf-gen-config.sh
@@ -6,42 +6,64 @@ set -o errexit -o nounset -o pipefail
 
 make -C "${GITHUB_WORKSPACE}/catapult" kubecf-gen-config
 
-cd "${GITHUB_WORKSPACE}/catapult/build${CLUSTER_NAME:-${BACKEND}}"
+cd "${GITHUB_WORKSPACE}"
+cp "${GITHUB_WORKSPACE}/catapult/build${CLUSTER_NAME:-${BACKEND}}/scf-config-values.yaml" \
+   kubecf-values.yaml
 
-gomplate --context .=scf-config-values.yaml <<"EOF" \
-> "${GITHUB_WORKSPACE}/kubecf/dev/kubecf/kubecf-values.yaml"
-{{- /* Disable brain minibroker tests */}}
-{{- define "minibroker-tests" }}
-properties:
-    brain-tests:
-        acceptance-tests-brain:
-            tests:
-                minibroker:
-                    {{- range slice "mariadb" "mongodb" "postgres" "redis" }}
-                    {{ . }}:
-                        enabled: false
-                    {{- end }}
-{{- end }}
-{{- $ = tmpl.Exec "minibroker-tests" | yaml | merge $ }}
+# Usage: merge < (YAML data)
+function merge() {
+    gomplate --datasource 'merged=merge:additional|original' \
+        --datasource original=kubecf-values.yaml \
+        --datasource additional=stdin:///additional.yaml \
+        --in '{{ datasource "merged" | toYAML }}' \
+        --out kubecf-values-merged.yaml
+    mv kubecf-values-merged.yaml kubecf-values.yaml
+}
 
-{{- /* Disable registry overrides */}}
-{{- $ = coll.Omit "kube" $ }}
+# Run ginkgo in parallel for faster tests
+merge <<< '
+        properties:
+            acceptance-tests:
+                acceptance-tests:
+                    acceptance_tests:
+                        ginkgo:
+                            nodes: 3
+    '
 
-{{- /* Set DNS annotations */}}
-{{- define "svc_annotation" }}
-services:
-    {{ index . 0 }}:
-        annotations:
-            "external-dns.alpha.kubernetes.io/hostname": {{ index . 1 }}
-    {{- end }}
-{{- $d := .system_domain }}
-{{- $ = printf "%s, *.%s" $d $d | slice "router" | tmpl.Exec "svc_annotation" | yaml | merge $ }}
-{{- $ = printf "ssh.%s" $d | slice "ssh-proxy" | tmpl.Exec "svc_annotation" | yaml | merge $ }}
-{{- $ = printf "tcp.%s, *.tcp.%s" $d $d | slice "tcp-router" | tmpl.Exec "svc_annotation" | yaml | merge $ }}
+# Set Eirini overrides
+if [ "${ENABLE_EIRINI}" == "true" ]; then
+    # This is what upstream Eirini was running and was green:
+    # https://github.com/cloudfoundry-incubator/eirini-ci/blob/09dcce6d9e900f693dfc1a6da70b5a526cf7de18/pipelines/dhall-modules/jobs/run-core-cats.dhall#L52-L86
 
-{{- $ | toYAML }}
-EOF
+    # Normally, it only makes sense to disable test groups that are enabled by
+    # default and enable those that aren't:
+    # https://github.com/cloudfoundry/cf-acceptance-tests#test-configuration
+    # Below we keep the full (explicit) list though, to make it easier to switch
+    # groups on and off.
+    suites=(
+        apps
+        capi_no_bridge
+        container_networking
+        detect
+        docker
+        internet_dependent
+        routing
+        sso
+        v3
+        zipkin
+        ssh
+    )
+    merge <<<"
+        properties:
+            acceptance-tests:
+                acceptance-tests:
+                    acceptance_tests:
+                        include: '$(IFS=, ; echo "=${suites[*]}")'
+                        stacks: [ sle15 ]
+                        credhub_mode: skip-tests
+    "
+fi
 
-echo "::group::scf-config-values.yaml"
-cat "${GITHUB_WORKSPACE}/kubecf/dev/kubecf/kubecf-values.yaml"
+echo "::group::kubecf-config-values.yaml"
+cat "${GITHUB_WORKSPACE}/kubecf-values.yaml"
 echo "::endgroup::"


### PR DESCRIPTION
## Description
Various small CI changes to make running tests more stable; see commits for details.

### Cloud Provider Changes
- Skip AKS steps on GKE, etc.
- Bump on GKE cluster size, and use non-preempt for CI.
  - They should be cleaned up correctly by the [scheduler workflow](https://github.com/cloudfoundry-incubator/kubecf/blob/master/.github/workflows/pull-request-schedule.yaml), so there's less pressure to keep things cheap in case they get orphaned
- Set up the GKE config directory (the way it is set it catapult), so that `kubectl` can automatically refresh the access token if a build takes a long time (e.g. running CATS).

### Workflow Changes
- The actions need to run against the PR branch, still, so that it checks out the correct source to test against.
- Move the config values generation to a shell script, because it was rather unwieldy
  - Various changes to bring it up to date
- Add timeouts to most steps, so we don't get stuck runs taking too long that would never succeed.
- Fix interaction with how we determine if we're running Eirini
- Wait for DNS to be set up before running tests, as that can take a long time if there are too many entries.
- Retry smoke tests if it fails; it appears that some clusters can fail the first run, for unknown reasons.
- Don't try to get logs if everything succeeded; that can take ~20 minutes (due to the size), which is better spent running tests for the next PR.

## Motivation and Context
Part of #1144 in trying to move our CI to GitHub Actions.

This PR is **not** sufficient for parity; we will still need to look at:
- [ ] brain tests (this blocks closing #1144)
- [ ] upgrade tests (#1147)
- [ ] internetless (#1148)
- [ ] ccdb rotation

## How Has This Been Tested?
Been running on my GitHub fork for a few days (manually triggered); it seems to have gotten to a point where most runs succeed now.  The last test run (of the whole thing, complete with internal PR) was https://github.com/mook-as/kubecf/actions/runs/369237207.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has security implications.
  - Need to ensure that people don't run CI until the code has been reviewed.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
