### PR TITLE
fix: don't define Eirini cluster role when deploying Diego

### DIFF
--- a/mixins/eirini/templates/eirini-cluster-role.yaml
+++ b/mixins/eirini/templates/eirini-cluster-role.yaml
@@ -1,10 +1,12 @@
+{{- include "_config.load" $ }}
+{{- if .Values.features.eirini.enabled }}
 ---
 # This cluster role should not be required
 # https://github.com/cloudfoundry-incubator/eirini/issues/110
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: eirini-cluster-role
+  name: "{{ .Release.Namespace }}-eirini-cluster-role"
 rules:
 - apiGroups:
   - batch
@@ -55,12 +57,13 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: eirini-cluster-rolebinding
+  name: "{{ .Release.Namespace }}-eirini-cluster-rolebinding"
 roleRef:
   kind: ClusterRole
-  name: eirini-cluster-role
+  name: "{{ .Release.Namespace }}-eirini-cluster-role"
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount
   name: opi
   namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/mixins/eirini/templates/metrics-service-account.yml
+++ b/mixins/eirini/templates/metrics-service-account.yml
@@ -115,7 +115,7 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
-  name: eirini-nodes-policy
+  name: "{{ .Release.Namespace }}-eirini-nodes-policy-role"
 rules:
 - apiGroups:
   - ""
@@ -129,14 +129,14 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: eirini-metrics
+  name: "{{ .Release.Namespace }}-eirini-nodes-policy-rolebinding"
 subjects:
 - kind: ServiceAccount
   name: eirini-metrics
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: eirini-nodes-policy
+  name: "{{ .Release.Namespace }}-eirini-nodes-policy-role"
   apiGroup: rbac.authorization.k8s.io
 {{- end }}
 {{- end }}


### PR DESCRIPTION
There is no need to define the Eirini cluster role and role binding when we are not using them.

Also prefixes the cluster roles and rolebindings with the release namespace name to allow installation of multiple instances within the same cluster.

Fixes #1582