### PR TITLE
feat: CI: GHA: brains, internetless, and CCDB rotation

### DIFF
--- a/.github/workflows/pull-request-ci.yaml
+++ b/.github/workflows/pull-request-ci.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches: [master]
     types: [labeled]
+  workflow_dispatch: {}
 
 env:
   GIT_PAGER: cat
@@ -14,13 +15,16 @@ jobs:
   # If it doesn't have it, the flow stops. If it does, we remove it (approval is good for one run only).
   dequeue:
     name: Dequeue
-    if: contains(github.event.pull_request.labels.*.name, 'pr-test-trigger')
+    if: >
+      github.event_name == 'workflow_dispatch'
+      || contains(github.event.pull_request.labels.*.name, 'pr-test-trigger')
     runs-on: ubuntu-20.04
     steps:
       - uses: actions-ecosystem/action-remove-labels@556e306
         with:
           github_token: ${{ secrets.github_token }}
           labels: pr-test-trigger
+        if: github.event_name == 'pull_request'
 
   build:
     name: Build

--- a/.github/workflows/pull-request-ci.yaml
+++ b/.github/workflows/pull-request-ci.yaml
@@ -291,7 +291,8 @@ jobs:
         timeout-minutes: 10
 
       # Run brain tests
-      # - run: make brain-tests
+      - run: make brain-tests
+        timeout-minutes: 25
 
       # Run sits tests
       - run: make sync-integration-tests

--- a/.github/workflows/pull-request-ci.yaml
+++ b/.github/workflows/pull-request-ci.yaml
@@ -103,8 +103,10 @@ jobs:
       matrix:
         include:
           - backend: diego
+            internetless: true
             ccdb-rotate: true
           - backend: eirini
+            internetless: false
             ccdb-rotate: false
       fail-fast: false
 
@@ -306,6 +308,43 @@ jobs:
       # Run CATs
       - run: make acceptance-tests
         timeout-minutes: 180
+
+      - name: Set Up Network Isolation
+        id: internetless-cats-isolate
+        run: >
+          exec
+          "${GITHUB_WORKSPACE}/kubecf/.github/workflows/pull-request-ci/isolate-network.sh"
+          --enable
+        continue-on-error: ${{ !matrix.internetless }}
+        timeout-minutes: 1
+
+      - name: Override CATS Configuration
+        id: internetless-cats-config
+        if: steps.internetless-cats-isolate.outcome == 'success'
+        run: >
+          exec
+          "${GITHUB_WORKSPACE}/kubecf/.github/workflows/pull-request-ci/override-cats-properties.sh"
+          <<< '
+            { acceptance_tests:
+              { include: "=internetless", credhub_mode: skip-tests }
+            }'
+        continue-on-error: ${{ !matrix.internetless }}
+        timeout-minutes: 1
+
+      - name: Internetless Acceptance Tests
+        run: make acceptance-tests
+        if: steps.internetless-cats-config.outcome == 'success'
+        continue-on-error: ${{ !matrix.internetless }}
+        timeout-minutes: 10
+
+      - name: Tear Down Network Isolation
+        if: always() && steps.internetless-cats-isolate.outcome != 'skipped'
+        run: >
+          exec
+          "${GITHUB_WORKSPACE}/kubecf/.github/workflows/pull-request-ci/isolate-network.sh"
+          --disable
+        continue-on-error: ${{ !matrix.internetless }}
+        timeout-minutes: 1
 
       # Rotate CLoud Controller Database
       - name: Rotate CCDB

--- a/.github/workflows/pull-request-ci.yaml
+++ b/.github/workflows/pull-request-ci.yaml
@@ -83,7 +83,6 @@ jobs:
   tests:
     name: Tests
     runs-on: ubuntu-20.04
-    continue-on-error: ${{ matrix.experimental }}
     needs: build
     env:
       # For KubeCF
@@ -104,9 +103,10 @@ jobs:
       matrix:
         include:
           - backend: diego
-            experimental: false
+            ccdb-rotate: true
           - backend: eirini
-            experimental: false
+            ccdb-rotate: false
+      fail-fast: false
 
     steps:
       # Checkout kubecf
@@ -306,6 +306,27 @@ jobs:
       # Run CATs
       - run: make acceptance-tests
         timeout-minutes: 180
+
+      # Rotate CLoud Controller Database
+      - name: Rotate CCDB
+        id: ccdb-rotate
+        run: |
+          source ${GITHUB_WORKSPACE}/catapult/build${CLUSTER_NAME}/.envrc
+          testing/ccdb_key_rotation/rotate-ccdb-keys-test.sh
+
+          echo "::group::Wait for KubeCF to be ready again"
+          make kubecf-wait
+          echo "::endgroup::"
+        env:
+          CHART: ${{ github.workspace }}/kubecf-bundle/kubecf_release.tgz
+        continue-on-error: ${{ !matrix.ccdb-rotate }}
+        timeout-minutes: 20
+
+      - name: Post-rotation Smoke Tests
+        run: make smoke-tests
+        if: ${{ steps.ccdb-rotate.outcome == 'success' }}
+        continue-on-error: ${{ !matrix.ccdb-rotate }}
+        timeout-minutes: 10
 
       # Get resource info for debugging
       - name: Get Resource Info

--- a/.github/workflows/pull-request-ci/isolate-network.sh
+++ b/.github/workflows/pull-request-ci/isolate-network.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+# This script will add (or remove) a network policy to isolate traffic to a
+# KubeCF deployment for CI purposes.
+
+# Usage: ${0} <--enable|--disable>
+# --enable turns on the isolation; --disable resets it.
+
+set -o errexit -o nounset -o pipefail
+: "${KUBECF_NAMESPACE:=kubecf}"
+
+case "${1:-}" in
+    --enable)
+        true;;
+    --disable)
+        kubectl delete NetworkPolicies --namespace "${KUBECF_NAMESPACE}" \
+            --ignore-not-found cats-internetless
+        exit 0;;
+    *)
+        >&2 echo "Usage: ${0} < --enable | --disable>"
+        exit 1;;
+esac
+
+# enable isolation
+# ingress - allows all incoming traffic
+# egress  - allows dns traffic anywhere
+#         - allows traffic to all ports, pods, namespaces
+#           (but no whitelisting of external ips!)
+# references
+# - BASE = https://github.com/ahmetb/kubernetes-network-policy-recipes
+# - (BASE)/blob/master/02a-allow-all-traffic-to-an-application.md
+# - (BASE)/blob/master/14-deny-external-egress-traffic.md
+# - See also https://www.youtube.com/watch?v=3gGpMmYeEO8 (31min)
+#   - Egress info wrt disallow external see 17:20-17:52
+#
+# __ATTENTION__
+# Requires a networking plugin to enforce, else ignored
+# (if not directly supported by platform)
+# - Example plugins: Calico, WeaveNet, Romana
+#
+# GKE: Uses Calico, Use `--enable-network-policy` when
+# creating a cluster (`gcloud`).
+# Minikube needs special setup.
+# KinD used by our Drone setup may have support.
+
+kubectl apply -f - <<-EOF
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: cats-internetless
+  namespace: ${KUBECF_NAMESPACE}
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  - {}
+  egress:
+    - ports:
+      - port: 53
+        protocol: UDP
+      - port: 53
+        protocol: TCP
+    - to:
+      - namespaceSelector: {}
+EOF

--- a/.github/workflows/pull-request-ci/override-cats-properties.sh
+++ b/.github/workflows/pull-request-ci/override-cats-properties.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+
+# This script edits the CATS QuarksJob to have different properties set; this is
+# used to be able to change the tests without redeploying the whole cluster.
+
+# Usage: echo '{foo: bar}' | ${0}
+# The input is YAML text for the properties to set / override; the `properties.`
+# prefix is implied.
+
+set -o errexit -o nounset -o pipefail
+
+# The name of the namespace that KubeCF was deployed into.
+: "${KUBECF_NAMESPACE:=kubecf}"
+
+# The name of the new secret to create
+: "${NEW_SECRET_NAME:=cats-overrides}"
+
+# Find the name of the secret currently configured in the acceptance-tests QJob
+# for the ig-resolved mount.
+get_resolved_secret_name() {
+    local jsonpath=(
+        spec template spec template spec
+        'volumes[?(@.name == "ig-resolved")]'
+        secret secretName
+    )
+    kubectl get QuarksJob acceptance-tests \
+        --namespace "${KUBECF_NAMESPACE}" \
+        --output=jsonpath="{.$(IFS=. ; echo "${jsonpath[*]}")}"
+}
+
+# Create a copy of the ig-resolved secret that has updated properties set.
+create_new_secret() {
+    local overrides secret_name properties properties_yaml
+    # Read the properties we want to read from stdin
+    overrides="$(gomplate --context=.=stdin:///overrides.yaml \
+        --in '{{ toJSON . }}')"
+    # Get the existing secret to override
+    secret_name="$(get_resolved_secret_name)"
+    # Read the existing secret and convert to JSON
+    properties="$(kubectl get secret --namespace="${KUBECF_NAMESPACE}" \
+        "${secret_name}" --output=jsonpath='{.data.properties\.yaml}' \
+        | base64 -d \
+        | gomplate --context=.=stdin:///properties.yaml --in '{{ toJSON . }}')"
+    # Update the properties in-place with the overrides
+    properties="$(jq <<<"${properties}" '(
+        .instance_groups[] | select(.name == "acceptance-tests") |
+        .jobs[] | select(.name == "acceptance-tests") |
+        .properties) *= ($ARGS.positional[0] // {})' \
+        --jsonargs "${overrides}")"
+    # Convert the properties from JSON to YAML
+    properties_yaml="$(<<<"${properties}" \
+        gomplate --context=.=stdin:///f.json --in='{{ toYAML . }}')"
+    # Create (or update) the secret with the overrides set
+    kubectl create secret generic --namespace="${KUBECF_NAMESPACE}" \
+        "${NEW_SECRET_NAME}" --from-file=properties.yaml=/dev/stdin \
+        --dry-run=client --output=yaml <<<"${properties_yaml}" \
+        | kubectl apply -f -
+}
+
+# Update the acceptance-tests QuarksJob to use the new secret
+mount_new_secret() {
+    # QJob's spec...volumes doesn't support JSON merge, so we need to fetch the
+    # existing volumes and update it instead.
+
+    # Get the original set of volumes
+    local original_volumes
+    original_volumes="$(kubectl get QuarksJob acceptance-tests \
+        --namespace="${KUBECF_NAMESPACE}" \
+        --output=json | jq -r '.spec.template.spec.template.spec.volumes')"
+
+    # Mutate it to mount the new secret for ig-resolved
+    local updated_volumes
+    updated_volumes="$(<<<"${original_volumes}" \
+        jq -r "map((select(.name==\"ig-resolved\") | .secret.secretName) |=
+            \"${NEW_SECRET_NAME}\")")"
+
+    # Generate a JSON merge struct with our change
+    local patch
+    patch="$(jq -r <<<'{}' \
+        ".spec.template.spec.template.spec.volumes |= ${updated_volumes}")"
+
+    # Actually patch it
+    kubectl patch QuarksJob acceptance-tests --namespace "${KUBECF_NAMESPACE}" \
+        --type merge --patch "${patch}"
+}
+
+create_new_secret
+mount_new_secret

--- a/testing/ccdb_key_rotation/rotate-ccdb-keys-test.sh
+++ b/testing/ccdb_key_rotation/rotate-ccdb-keys-test.sh
@@ -175,16 +175,18 @@ ccdb:
 EOF
 
 # Get the deployed chart (tarball)
-make kubecf-build
-chart_file="$(find output -name 'kubecf-*.tgz' -type f -printf "%T+ %p\n" \
-                   | sort | tail -1 | tr -s ' ' | cut -d ' ' -f 2)"
+if [[ -z "${CHART:-}" ]]; then
+    make kubecf-build
+    CHART="$(find output -name 'kubecf-*.tgz' -type f -printf "%T+ %p\n" \
+                    | sort | tail -1 | tr -s ' ' | cut -d ' ' -f 2)"
+fi
 
 echo
-echo "Chart file ... $(blue "${chart_file}")"
+echo "Chart file ... $(blue "${CHART}")"
 echo
 
 # Upgrade deployment to the modified key labels.
-helm upgrade "${KUBECF_INSTALL_NAME}" "${chart_file}" \
+helm upgrade "${KUBECF_INSTALL_NAME}" "${CHART}" \
       --namespace "${KUBECF_NAMESPACE}" \
       --reuse-values \
       --values "${VALUES_FILE}"


### PR DESCRIPTION
## Description
This adds some of the missing parts of the existing concourse-based pipeline to GitHub Actions:
- Runs the brains tests
- Runs the CCDB rotation tests
- Runs the internetless tests (#1148)

## Motivation and Context
This should be the last part of #1144

## How Has This Been Tested?
Deployed & ran on my fork on KubeCF.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Additional information:
- The network policy stuff for internetless tests is from catapult.
- So is the technique for patching the runtime properties for the CATS QuarksJob to run just the internetless suite.
  - I changed it a bit so the property patching is separate from what properties to patch; we could perhaps later change the Eirini config generation to use normal + a step to patch the test suites (so that it is more visible).
- I'm splitting out the experimental flags to separate flags, so that it is easier to adjust them individually if needed.
