### PR TITLE
fix: CI: Actions: Fix PR triggering

### DIFF
--- a/.github/workflows/pull-request-ci.yaml
+++ b/.github/workflows/pull-request-ci.yaml
@@ -20,11 +20,12 @@ jobs:
       - uses: actions-ecosystem/action-remove-labels@556e306
         with:
           github_token: ${{ secrets.github_token }}
-          labels: pr-test-queue
+          labels: pr-test-trigger
 
   build:
     name: Build
     runs-on: ubuntu-20.04
+    needs: dequeue
     env:
       PINNED_TOOLS: true
       TOOLS_DIR: ${{ github.workspace }}/tools

--- a/.github/workflows/pull-request-schedule.yaml
+++ b/.github/workflows/pull-request-schedule.yaml
@@ -111,6 +111,16 @@ jobs:
       with:
         persist-credentials: false
 
+    - name: Fetch Credentials
+      id: vault-kubecf
+      uses: hashicorp/vault-action@v2.0.1
+      with:
+        url: https://volt.cap.explore.suse.dev/
+        exportEnv: false
+        token: ${{ secrets.VAULT_TOKEN }}
+        secrets: |
+          secret/data/kubecf `github-access-token` | GITHUB_TOKEN ;
+
     - name: Trigger Builds
       uses: actions/github-script@v3
       with:
@@ -120,3 +130,4 @@ jobs:
           await script({github, context});
       env:
         CAPACITY: ${{ needs.determine-capacity.outputs.capacity }}
+        GITHUB_TOKEN: ${{ steps.vault-kubecf.outputs.GITHUB_TOKEN }}

--- a/.github/workflows/pull-request-schedule/trigger-builds.js
+++ b/.github/workflows/pull-request-schedule/trigger-builds.js
@@ -57,9 +57,15 @@ module.exports = async ({ github, context }) => {
 
     console.log(`Found ${pulls.length} PRs.`);
 
+    // Create an alternative Octokit client instance that can be used to set
+    // labels on the PR, using a different GitHub token.  This is required as
+    // the tokens passed in by GitHub Actions will not trigger further actions.
+    const Octokit = github.constructor;
+    const triggeringClient = new Octokit({ auth: process.env.GITHUB_TOKEN });
+
     for (let pr of pulls.slice(0, process.env.CAPACITY)) {
         console.log(`Queuing PR#${pr.number}`);
-        github.issues.addLabels({
+        triggeringClient.issues.addLabels({
             owner: context.repo.owner,
             repo: context.repo.repo,
             issue_number: pr.number,


### PR DESCRIPTION
## Description
The automated CI runs were not quite working correctly:
- The CI run was removing the wrong label
- The CI run was proceeding even with no labels set
- The scheduler wasn't triggering correctly, because the GitHub Actions provided token cannot be used to trigger further runs.  Workaround is to use a token from the vault.

## Motivation and Context
CI triggering was busted.

## How Has This Been Tested?
Ran on my fork, manually running the scheduler and seeing that:
- `pr-test-queue` was removed
- `pr-test-trigger` was added
- The CI run actually happened
- `pr-test-trigger` was removed again.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Notes

As a precaution, I'm only using the token from the vault where necessary; that's to avoid chewing up the API request quota, since the GitHub Actions token should be ephemeral (and hopefully gets a different quota; at least it would be a different user).