### PR TITLE
fix: avoid generating ops that reference instance groups that don't exist

### DIFF
--- a/chart/templates/_config.tpl
+++ b/chart/templates/_config.tpl
@@ -72,6 +72,7 @@
     {{- include "_jobs.update" . }}
     {{- include "_resources.update" . }}
     {{- include "_database.update" . }}{{/* database/_database.tpl */}}
+    {{- include "_multicluster.update" . }}
 
     {{- range $condition, $message := $.Values.unsupported }}
       {{- if eq "true" (include "_config.condition" (list $ $condition)) }}

--- a/chart/templates/_multicluster.tpl
+++ b/chart/templates/_multicluster.tpl
@@ -1,0 +1,31 @@
+{{- /*
+==========================================================================================
+| _multicluster.update $
++-----------------------------------------------------------------------------------------
+| Remove property settings for instance groups that will not be instantiated.
+==========================================================================================
+*/}}
+{{- define "_multicluster.update" }}
+  {{- if $.Values.features.multiple_cluster_mode.control_plane.enabled }}
+    {{- $_ := unset $.Values.properties "diego-cell" }}
+  {{- end }}
+  {{- if $.Values.features.multiple_cluster_mode.cell_segment.enabled }}
+    {{- $_ := unset $.Values.properties "acceptance-tests" }}
+    {{- $_ := unset $.Values.properties "api" }}
+    {{- $_ := unset $.Values.properties "auctioneer" }}
+    {{- $_ := unset $.Values.properties "brain-tests" }}
+    {{- $_ := unset $.Values.properties "cc-worker" }}
+    {{- $_ := unset $.Values.properties "diego-api" }}
+    {{- $_ := unset $.Values.properties "doppler" }}
+    {{- $_ := unset $.Values.properties "log-api" }}
+    {{- $_ := unset $.Values.properties "log-cache" }}
+    {{- $_ := unset $.Values.properties "nats" }}
+    {{- $_ := unset $.Values.properties "rotate-cc-database-key" }}
+    {{- $_ := unset $.Values.properties "router" }}
+    {{- $_ := unset $.Values.properties "scheduler" }}
+    {{- $_ := unset $.Values.properties "singleton-blobstore" }}
+    {{- $_ := unset $.Values.properties "smoke-tests" }}
+    {{- $_ := unset $.Values.properties "sync-integration-tests" }}
+    {{- $_ := unset $.Values.properties "uaa" }}
+  {{- end }}
+{{- end }}

--- a/chart/templates/multiple_cluster_mode.yaml
+++ b/chart/templates/multiple_cluster_mode.yaml
@@ -49,6 +49,8 @@ data:
     - type: remove
       path: /instance_groups/name=rotate-cc-database-key
     - type: remove
+      path: /instance_groups/name=brain-tests?
+    - type: remove
       path: /instance_groups/name=smoke-tests?
     - type: remove
       path: /instance_groups/name=acceptance-tests?


### PR DESCRIPTION
Right now these are just property settings for `api` and `cc-worker` that are set in `chart/config/api.yaml` and `chart/config/jobs.yaml`, but this commit pre-emptively handles all groups that are removed in `chart/templates/multiple_cluster_mode.yaml`.

Ideally this would all be handled by conditions defined in `chart/config/jobs.yaml`, but the required logic becomes too complex, so special-casing this issue seems warranted.

This commit also adds an op for `brain-tests`, which seems to be missing because of an oversight.

This PR should supersede #1543