### PR TITLE
fix: script: Update waiting for operator

### DIFF
--- a/scripts/cf-operator-wait.sh
+++ b/scripts/cf-operator-wait.sh
@@ -19,7 +19,12 @@ for crd in "${crds[@]}" ; do
 done
 
 # Wait for the operator deployments to be ready
-deployments=( cf-operator cf-operator-quarks-job )
+deployments=(
+    cf-operator-quarks
+    cf-operator-quarks-job
+    cf-operator-quarks-secret
+    cf-operator-quarks-statefulset
+)
 for deployment in "${deployments[@]}" ; do
     RETRIES=60 DELAY=5 retry kubectl wait --for=condition=Available \
         --namespace=cf-operator --timeout=600s "deployment/${deployment}"


### PR DESCRIPTION
## Description
The operator has differently named deployments now; update the wait
script to match.  Otherwise we will wait forever (before failing).

## Motivation and Context
My GitHub Actions runs were failing because that uses `make cf-operator-wait`.

## How Has This Been Tested?
Deployed locally.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
