### PR TITLE
feat: CI: change instance type to standard-8

### DIFF
--- a/.github/workflows/pull-request-ci.yaml
+++ b/.github/workflows/pull-request-ci.yaml
@@ -206,7 +206,7 @@ jobs:
           DEBUG_MODE: true
           GKE_NODE_COUNT: 1
           GKE_PREEMPTIBLE: false
-          GKE_INSTANCE_TYPE: n2d-highcpu-16
+          GKE_INSTANCE_TYPE: n2d-standard-8
           EXTRA_LABELS: '{"ci": "${{ github.run_id }}"}'
         timeout-minutes: 20 # This should take ~10 minutes.
 


### PR DESCRIPTION
## Description
This gives us ~double the memory, but half of the CPU (at a bit over half the price).  We appear to be memory-constrained; we're getting kubelet-level OOMs.

This bumps the memory on the cluster to 32GB (instead of the previous 16GB); to control costs, I have also reduced the CPU from 16 to 8.

## Motivation and Context
🐱 runs were failing on GitHub Actions; hijacking a running test cluster show that the node had events that looked suspicious:
> `System OOM encountered, victim process: log-cache, pid: 123378`

## How Has This Been Tested?
Ran more 🐱 tests on my fork.  Double checked to make sure the duration of the steps were not too far off.  The only major difference is `make kubecf-wait` now takes ~18 minutes (out of a limit of 30).  In general though this _is_ slower: previously the pipeline took ~90 minutes, it now takes ~120.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
