### PR TITLE
fix: CI: Add owner name to cluster name

### DIFF
--- a/.github/workflows/pull-request-ci.yaml
+++ b/.github/workflows/pull-request-ci.yaml
@@ -80,10 +80,24 @@ jobs:
           name: kubecf-bundle.tgz
           path: ${{ github.workspace }}/bundle
 
+  build-info:
+    name: Get Build Information
+    runs-on: ubuntu-latest
+    outputs:
+      owner: ${{ steps.get-owner-name.outputs.owner }}
+    steps:
+      - name: Get Owner Name
+        id: get-owner-name
+        run: |
+          OWNER="$(tr --delete --complement A-Za-z0-9 <<< "${OWNER}")"
+          printf "::set-output name=owner::%s\n" "${OWNER}"
+        env:
+          OWNER: ${{ github.repository_owner }}
+
   tests:
     name: Tests
     runs-on: ubuntu-20.04
-    needs: build
+    needs: [build, build-info]
     env:
       # For KubeCF
       PINNED_TOOLS: true
@@ -93,7 +107,7 @@ jobs:
       # Note that credentials-related parts are in the individual steps
       BACKEND: gke
       DOWNLOAD_CATAPULT_DEPS: "false"
-      CLUSTER_NAME: ci-${{ github.run_id }}-${{ matrix.backend }}
+      CLUSTER_NAME: kubecf-ci-${{ needs.build-info.outputs.owner}}-${{ github.run_id }}-${{ matrix.backend }}
     defaults:
       run:
         working-directory: kubecf
@@ -201,7 +215,7 @@ jobs:
       - run: make k8s
         working-directory: catapult
         env:
-          GKE_CLUSTER_NAME: kubecf-ci-${{ github.run_id }}-${{ matrix.backend }}
+          GKE_CLUSTER_NAME: ${{ env.CLUSTER_NAME }}
           OWNER: ${{ github.repository_owner }}
           DEBUG_MODE: true
           GKE_NODE_COUNT: 1
@@ -437,5 +451,5 @@ jobs:
           make clean
         working-directory: catapult
         env:
-          GKE_CLUSTER_NAME: kubecf-ci-${{ github.run_id }}-${{ matrix.backend }}
+          GKE_CLUSTER_NAME: ${{ env.CLUSTER_NAME }}
         timeout-minutes: 20


### PR DESCRIPTION
## Description
This attaches the (sanitized) owner name to the cluster name; this does _not_ remove the existing owner label on the cluster.

## Motivation and Context
This is necessary because we don't get any information other than the cluster name with looking through DNS record sets; so we need something there to be able to identify entries that are safe to remove.

## How Has This Been Tested?
Deployed locally a few times (via GitHub Actions, of course).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
