### PR TITLE
feat: mechanism for hooking and fix for deployment updater upgrade

### DIFF
--- a/chart/hooks/pre-upgrade/remove-deployment-updater-readiness.sh
+++ b/chart/hooks/pre-upgrade/remove-deployment-updater-readiness.sh
@@ -12,4 +12,4 @@ spec:
           $patch: delete
 "
 
-kubectl patch statefulset --namespace $NAMESPACE scheduler --patch "$patch"
+kubectl patch statefulset --namespace "$NAMESPACE" scheduler --patch "$patch"

--- a/chart/hooks/pre-upgrade/remove-deployment-updater-readiness.sh
+++ b/chart/hooks/pre-upgrade/remove-deployment-updater-readiness.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
-set -ex
+set -o errexit -o nounset -o pipefail -o xtrace
+
+# Remove the cc-deployment-updater readiness probes; they are incorrectly
+# constructed for an active/passive job, and cause the scheduler to show as
+# unready, and therefore blocking upgrades. See 
+# https://github.com/cloudfoundry-incubator/kubecf/issues/1589 for details.
+
+# Patch the StatefulSet so that any new instances we create will not have the
+# probe.
 
 # shellcheck disable=SC2016
 patch='
@@ -14,3 +22,9 @@ spec:
 '
 
 kubectl patch statefulset --namespace "$NAMESPACE" scheduler --patch "$patch"
+
+# Delete all existing scheduler pods; we can't just patch them as changing
+# existing readiness probes is not allowed.
+
+kubectl delete pods --namespace="${NAMESPACE}" \
+  --selector "quarks.cloudfoundry.org/instance-group-name=scheduler"

--- a/chart/hooks/pre-upgrade/remove-deployment-updater-readiness.sh
+++ b/chart/hooks/pre-upgrade/remove-deployment-updater-readiness.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -ex
+
+patch="
+---
+spec:
+  template:
+    spec:
+      containers:
+      - name: cc-deployment-updater-cc-deployment-updater
+        readinessProbe:
+          $patch: delete
+"
+
+kubectl patch statefulset --namespace $NAMESPACE scheduler --patch "$patch"

--- a/chart/hooks/pre-upgrade/remove-deployment-updater-readiness.sh
+++ b/chart/hooks/pre-upgrade/remove-deployment-updater-readiness.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
 
-patch="
+patch='
 ---
 spec:
   template:
@@ -10,6 +10,6 @@ spec:
       - name: cc-deployment-updater-cc-deployment-updater
         readinessProbe:
           $patch: delete
-"
+'
 
 kubectl patch statefulset --namespace "$NAMESPACE" scheduler --patch "$patch"

--- a/chart/hooks/pre-upgrade/remove-deployment-updater-readiness.sh
+++ b/chart/hooks/pre-upgrade/remove-deployment-updater-readiness.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -ex
 
+# shellcheck disable=SC2016
 patch='
 ---
 spec:

--- a/chart/templates/hooks.yaml
+++ b/chart/templates/hooks.yaml
@@ -14,51 +14,6 @@ metadata:
     "helm.sh/hook-weight": "-2"
     "helm.sh/hook-delete-policy": before-hook-creation
 ---
-{{- if $.Values.global.rbac.create }}
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  annotations:
-    "helm.sh/hook": {{$hook}}
-    "helm.sh/hook-weight": "-2"
-    "helm.sh/hook-delete-policy": before-hook-creation
-  name: kubecf-{{$hook}}-helm-hook
-rules:
-- apiGroups:
-  - admissionregistration.k8s.io
-  resources:
-  - mutatingwebhookconfigurations
-  verbs:
-  - delete
----
-apiVersion: v1
-kind: List
-metadata:
-  annotations:
-    rbac.authorization.kubernetes.io/autoupdate: "true"
-    "helm.sh/hook": {{$hook}}
-    "helm.sh/hook-weight": "-2"
-    "helm.sh/hook-delete-policy": before-hook-creation
-items:
-  - apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRoleBinding
-    metadata:
-      name: {{$hook}}-helm-hook
-      annotations:
-        rbac.authorization.kubernetes.io/autoupdate: "true"
-        "helm.sh/hook": {{$hook}}
-        "helm.sh/hook-weight": "-2"
-        "helm.sh/hook-delete-policy": before-hook-creation
-    subjects:
-    - kind: ServiceAccount
-      name: {{$hook}}-helm-hook
-      namespace: {{ $.Release.Namespace }}
-    roleRef:
-      kind: ClusterRole
-      name: kubecf-{{$hook}}-helm-hook
-      apiGroup: rbac.authorization.k8s.io
-{{- end }}
----
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/chart/templates/hooks.yaml
+++ b/chart/templates/hooks.yaml
@@ -4,25 +4,26 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{$hook}}-helm-hook
+  name: {{ $hook }}-helm-hook
   namespace: {{ $.Release.Namespace | quote }}
   labels:
     app.kubernetes.io/instance: {{ $.Release.Name | quote }}
     app.kubernetes.io/managed-by: {{ $.Release.Service | quote }}
   annotations:
-    "helm.sh/hook": {{$hook}}
+    "helm.sh/hook": {{ $hook }}
     "helm.sh/hook-weight": "-2"
     "helm.sh/hook-delete-policy": before-hook-creation
 ---
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "{{ $.Release.Name }}-{{$hook}}-hook"
+  name: "{{ $.Release.Name }}-{{ $hook }}-hook"
+  namespace: {{ $.Release.Namespace | quote }}
   labels:
     app.kubernetes.io/managed-by: {{ $.Release.Service | quote }}
     app.kubernetes.io/instance: {{ $.Release.Name | quote }}
   annotations:
-    "helm.sh/hook": {{$hook}}
+    "helm.sh/hook": {{ $hook }}
     "helm.sh/hook-weight": "-1"
     "helm.sh/hook-delete-policy": hook-succeeded
 spec:
@@ -35,9 +36,9 @@ spec:
         helm.sh/chart: {{ include "kubecf.chart" $ }}
     spec:
       restartPolicy: Never
-      serviceAccountName: {{$hook}}-helm-hook
+      serviceAccountName: {{ $hook }}-helm-hook
       containers:
-      - name: {{$hook}}-job
+      - name: {{ $hook }}-job
         image: {{ $.Values.hooks.image | quote }}
         env:
         - name: NAMESPACE
@@ -48,7 +49,7 @@ spec:
         args: 
         - |
            for f in /hooks/*.sh; do 
-            bash "$f" -H || break
+            bash "$f" || exit 1
            done
         volumeMounts:
         - name: hooks
@@ -57,7 +58,7 @@ spec:
       volumes:
       - name: hooks
         configMap:
-          name: {{$hook}}-hook-scripts
+          name: {{ $hook }}-hook-scripts
 ---
 {{- $path := printf "hooks/%s/*" $hook }}
 apiVersion: "v1"
@@ -68,9 +69,10 @@ metadata:
     app.kubernetes.io/instance: {{ $.Release.Name | quote }}
   annotations:
     "helm.sh/hook-weight": "-2"
-    "helm.sh/hook": {{$hook}}
+    "helm.sh/hook": {{ $hook }}
     "helm.sh/hook-delete-policy": before-hook-creation
-  name: {{$hook}}-hook-scripts
+  name: {{ $hook }}-hook-scripts
+  namespace: {{ $.Release.Namespace | quote }}
 data:
   {{- ($.Files.Glob $path).AsConfig | nindent 2 }}
 {{- end }}

--- a/chart/templates/hooks.yaml
+++ b/chart/templates/hooks.yaml
@@ -1,0 +1,121 @@
+# generate helm hooks from contents in the `hooks` folder
+{{ range $_, $hook := tuple "pre-delete" "pre-upgrade" }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{$hook}}-helm-hook
+  namespace: {{ $.Release.Namespace | quote }}
+  labels:
+    app.kubernetes.io/instance: {{ $.Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service | quote }}
+  annotations:
+    "helm.sh/hook": {{$hook}}
+    "helm.sh/hook-weight": "-2"
+    "helm.sh/hook-delete-policy": before-hook-creation
+---
+{{- if $.Values.global.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    "helm.sh/hook": {{$hook}}
+    "helm.sh/hook-weight": "-2"
+    "helm.sh/hook-delete-policy": before-hook-creation
+  name: kubecf-{{$hook}}-helm-hook
+rules:
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  verbs:
+  - delete
+---
+apiVersion: v1
+kind: List
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+    "helm.sh/hook": {{$hook}}
+    "helm.sh/hook-weight": "-2"
+    "helm.sh/hook-delete-policy": before-hook-creation
+items:
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: {{$hook}}-helm-hook
+      annotations:
+        rbac.authorization.kubernetes.io/autoupdate: "true"
+        "helm.sh/hook": {{$hook}}
+        "helm.sh/hook-weight": "-2"
+        "helm.sh/hook-delete-policy": before-hook-creation
+    subjects:
+    - kind: ServiceAccount
+      name: {{$hook}}-helm-hook
+      namespace: {{ $.Release.Namespace }}
+    roleRef:
+      kind: ClusterRole
+      name: kubecf-{{$hook}}-helm-hook
+      apiGroup: rbac.authorization.k8s.io
+{{- end }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ $.Release.Name }}-{{$hook}}-hook"
+  labels:
+    app.kubernetes.io/managed-by: {{ $.Release.Service | quote }}
+    app.kubernetes.io/instance: {{ $.Release.Name | quote }}
+  annotations:
+    "helm.sh/hook": {{$hook}}
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  template:
+    metadata:
+      name: "{{ $.Release.Name }}"
+      labels:
+        app.kubernetes.io/managed-by: {{ $.Release.Service | quote }}
+        app.kubernetes.io/instance: {{ $.Release.Name | quote }}
+        helm.sh/chart: {{ include "kubecf.chart" $ }}
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{$hook}}-helm-hook
+      containers:
+      - name: {{$hook}}-job
+        image: {{ $.Values.hooks.image | quote }}
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        command: ["/bin/bash","-cex"]
+        args: 
+        - |
+           for f in /hooks/*.sh; do 
+            bash "$f" -H || break
+           done
+        volumeMounts:
+        - name: hooks
+          mountPath: "/hooks"
+          readOnly: true
+      volumes:
+      - name: hooks
+        configMap:
+          name: {{$hook}}-hook-scripts
+---
+{{- $path := printf "hooks/%s/*" $hook }}
+apiVersion: "v1"
+kind: "ConfigMap"
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: {{ $.Release.Service | quote }}
+    app.kubernetes.io/instance: {{ $.Release.Name | quote }}
+  annotations:
+    "helm.sh/hook-weight": "-2"
+    "helm.sh/hook": {{$hook}}
+    "helm.sh/hook-delete-policy": before-hook-creation
+  name: {{$hook}}-hook-scripts
+data:
+  {{- ($.Files.Glob $path).AsConfig | nindent 2 }}
+{{- end }}

--- a/chart/templates/hooks.yaml
+++ b/chart/templates/hooks.yaml
@@ -27,6 +27,9 @@ rules:
 - apiGroups: [ apps ]
   resources: [ statefulsets ]
   verbs: [ get, patch ]
+- apiGroups: [ "" ]
+  resources: [ pods ]
+  verbs: [ list, delete ]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/chart/templates/hooks.yaml
+++ b/chart/templates/hooks.yaml
@@ -12,7 +12,40 @@ metadata:
   annotations:
     "helm.sh/hook": {{ $hook }}
     "helm.sh/hook-weight": "-2"
-    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $hook }}-helm-hook-role
+  namespace: {{ $.Release.Namespace | quote }}
+  annotations:
+    "helm.sh/hook": {{ $hook }}
+    "helm.sh/hook-weight": "-2"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+rules:
+- apiGroups: [ apps ]
+  resources: [ statefulsets ]
+  verbs: [ get, patch ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  creationTimestamp: null
+  name: {{ $hook }}-helm-hook-role-binding
+  namespace: {{ $.Release.Namespace | quote }}
+  annotations:
+    "helm.sh/hook": {{ $hook }}
+    "helm.sh/hook-weight": "-2"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $hook }}-helm-hook-role
+subjects:
+- kind: ServiceAccount
+  name: {{ $hook }}-helm-hook
+  namespace: {{ $.Release.Namespace | quote }}
 ---
 apiVersion: batch/v1
 kind: Job
@@ -25,7 +58,7 @@ metadata:
   annotations:
     "helm.sh/hook": {{ $hook }}
     "helm.sh/hook-weight": "-1"
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   template:
     metadata:
@@ -71,7 +104,7 @@ metadata:
   annotations:
     "helm.sh/hook-weight": "-2"
     "helm.sh/hook": {{ $hook }}
-    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   name: {{ $hook }}-hook-scripts
   namespace: {{ $.Release.Namespace | quote }}
 data:

--- a/chart/templates/hooks.yaml
+++ b/chart/templates/hooks.yaml
@@ -29,7 +29,7 @@ rules:
   verbs: [ get, patch ]
 - apiGroups: [ "" ]
   resources: [ pods ]
-  verbs: [ list, delete ]
+  verbs: [ list, get, delete ]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/chart/templates/hooks.yaml
+++ b/chart/templates/hooks.yaml
@@ -46,9 +46,10 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         command: ["/bin/bash","-cex"]
-        args: 
+        args:
         - |
-           for f in /hooks/*.sh; do 
+           shopt -s nullglob
+           for f in /hooks/*.sh; do
             bash "$f" || exit 1
            done
         volumeMounts:

--- a/chart/values.schema.yaml
+++ b/chart/values.schema.yaml
@@ -561,6 +561,11 @@ properties:
       - type: string
       - type: object
 
+  hooks:
+    type: object
+    properties:
+      image: { type: string }
+
   # mixin configs
   bits: {type: object}
   eirini: {type: object}

--- a/chart/values.schema.yaml
+++ b/chart/values.schema.yaml
@@ -565,6 +565,7 @@ properties:
     type: object
     properties:
       image: { type: string }
+    additionalProperties: false
 
   # mixin configs
   bits: {type: object}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -496,6 +496,9 @@ operations:
   #       type: password
   inline: []
 
+hooks:
+  image: ghcr.io/cfcontainerizationbot/kubecf-kubectl:v1.19.2
+
 eirinix:
   persi-broker:
     # Service plans for Eirini persistant storage support

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -497,6 +497,7 @@ operations:
   inline: []
 
 hooks:
+  # Image that contains kubectl to be used in helm upgrade and delete hook scripts
   image: ghcr.io/cfcontainerizationbot/kubecf-kubectl:v1.19.2
 
 eirinix:


### PR DESCRIPTION
## Description
Adds a mechanism for hooking into the upgrade and deletion process of kubecf.
Removes the readiness probe for the CC deployment updater.
fixes #1589 

## Motivation and Context
The readiness probe prevents the scheduler from being upgraded.

## How Has This Been Tested?
No local tests, waiting for the pipelines.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
