### PR TITLE
fix: releases: bump postgres to 43

### DIFF
--- a/chart/config/releases.yaml
+++ b/chart/config/releases.yaml
@@ -53,7 +53,7 @@ releases:
     condition: false
   postgres:
     condition: features.autoscaler.enabled
-    version: "42"
+    version: "43"
   sync-integration-tests:
     # XXX SITS only makes sense when using Diego; add error check somewhere?
     condition: testing.sync_integration_tests.enabled


### PR DESCRIPTION
## Description
Not sure what happened to the postgres 42 image, but it doesn't seem to be there anymore.

## Motivation and Context
Doing any deployment is now failing (because the postgres 42 release image is missing) when deploying with autoscaler.

## How Has This Been Tested?
Deployed locally.  Did not attempt smoke tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
