### PR TITLE
fix: bump garden-runc to 1.19.17

### DIFF
--- a/bosh/releases/pre_render_scripts/diego-cell/garden/jobs/patch_pre-start.sh
+++ b/bosh/releases/pre_render_scripts/diego-cell/garden/jobs/patch_pre-start.sh
@@ -15,14 +15,14 @@ fi
 patch --verbose "${target}" <<'EOT'
 --- jobs/garden/templates/bin/pre-start
 +++ jobs/garden/templates/bin/pre-start
-@@ -1,7 +1,3 @@
- #!/bin/bash
+@@ -4,7 +4,5 @@ set -e
 
- set -e
--
+ source /var/vcap/jobs/garden/bin/envs
+ source /var/vcap/jobs/garden/bin/grootfs-utils
 -source /var/vcap/packages/greenskeeper/bin/system-preparation
--
+
 -permit_device_control
+ invoke_thresholder
 EOT
 
 sha256sum "${target}" > "${sentinel}"

--- a/chart/config/releases.yaml
+++ b/chart/config/releases.yaml
@@ -44,6 +44,8 @@ releases:
     image:
       repository: ghcr.io/cloudfoundry-incubator/pxc
       tag: 0.9.11
+  garden-runc:
+    version: 1.19.17
   metrics-discovery:
     # metrics-agent add-on (new in cf-deployment 13.0) is not used by kubecf
     condition: false


### PR DESCRIPTION
Bumps containerd to 1.4.3, which addresses CVE-2020-15257.
