### PR TITLE
fix: GHA: CI: Checkout PRs code on CI jobs and fix lint errors on wait-for-ip.sh and 

### DIFF
--- a/.github/workflows/pull-request-ci.yaml
+++ b/.github/workflows/pull-request-ci.yaml
@@ -42,6 +42,7 @@ jobs:
       - name: Checkout KubeCF
         uses: actions/checkout@v2
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           path: kubecf
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/pull-request-ci/wait-for-ip.sh
+++ b/.github/workflows/pull-request-ci/wait-for-ip.sh
@@ -11,8 +11,8 @@ selector=(
     )
 jsonpath='{.items[].status.loadBalancer.ingress[].ip}'
 filter=(
-      --namespace=kubecf
-      --selector="$(IFS=, ; echo "${selector[*]}")"
+      '--namespace=kubecf'
+      '--selector='"$(IFS=, ; echo "${selector[*]}")"
     )
 ip="$(kubectl get service "${filter[@]}" --output="jsonpath=${jsonpath}")"
 system_domain="$(gomplate --context ".=${GITHUB_WORKSPACE}/kubecf-values.yaml" --in '{{ .system_domain }}')"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Fix shellcheck lint errors in `pull-request-ci/wait-for-ip.sh `.
These errors where not detected by the PR tests:
  https://github.com/cloudfoundry-incubator/kubecf/runs/1499748939
  https://concourse.suse.dev/builds/42248
nor the [master run](https://concourse.suse.dev/teams/main/pipelines/kubecf/jobs/lint-master/builds/234). Both of them just call `make lint`.
They are detected by [GH Actions runs](https://github.com/viccuad/kubecf/runs/1511161957?check_suite_focus=true) on my fork, though. This is a bit puzzling.

In the process of fixing it, I realized that I couldn't get GH Actions to consume the fix, as it always checks outs Master from what it looks like.

There seems to not be any problem on checking out PR's branch on the pull-request-ci.yaml workflow, hence https://github.com/cloudfoundry-incubator/kubecf/commit/edec61515d71544d79f0ea5f0487e48d63b6ec3d. Note that I didn't change the lint workflow.

Note that because of `pull_request_target`, the changes in behavior for GHA may not get applied in the test of this PR.
https://github.com/cloudfoundry-incubator/kubecf/blob/4dd38e7123a0a04d4f6f1129b0257d49546b7d48/.github/workflows/pull-request-lint.yaml#L8 
`pull_request_target`  (instead of `pull_request`) makes GHA check out master, and not the branch code. This is needed for security reasons, as lint tests are run without approval for all PRs, hence they need to run from code already in master.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I want to iterate on GHA, but I can't because of the linting errors. And since GHA is checking out master instead of HEAD, I can't fix it in the same branch.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- An important detail to include is the version of the used cf-operator -->

Here: https://github.com/viccuad/kubecf/runs/1511162182?check_suite_focus=true
I used `pull_request` there and no `pull_request_target`. But that only meant that it run 2 lint jobs, one for master and one for the PR's branch, so I couldn't continue past linting even if 1 of those jobs succeeded.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
