### PR TITLE
fix: CC: use native DNS resolver for gRPC

### DIFF
--- a/bosh/releases/pre_render_scripts/api/cloud_controller_ng/bpm/patch_bpm.sh
+++ b/bosh/releases/pre_render_scripts/api/cloud_controller_ng/bpm/patch_bpm.sh
@@ -17,11 +17,12 @@ fi
 #   - We don't enable New Relic.
 #   - NGINX maintenance shouldn't run.
 patch --verbose "${target}" <<'EOT'
-@@ -20,7 +20,6 @@
+@@ -20,7 +20,7 @@
      "BUNDLE_GEMFILE" => "/var/vcap/packages/cloud_controller_ng/cloud_controller_ng/Gemfile",
      "CLOUD_CONTROLLER_NG_CONFIG" => "/var/vcap/jobs/cloud_controller_ng/config/cloud_controller_ng.yml",
      "C_INCLUDE_PATH" => "/var/vcap/packages/libpq/include",
 -    "DYNO" => "#{spec.job.name}-#{spec.index}",
++    "GRPC_DNS_RESOLVER" => "native",
      "HOME" => "/home/vcap",
      "LANG" => "en_US.UTF-8",
      "LIBRARY_PATH" => "/var/vcap/packages/libpq/lib",


### PR DESCRIPTION
## Description

When the log-cache pod goes down, the gRPC endpoint used by CC goes down; it appears that the default c-ares DNS resolver used does not correctly recover when DNS successfully resolves again.  Switching to using the native DNS resolver instead appears to cause it to do proper exponential backoff instead, meaning that it will eventually recover.

## Motivation and Context
This fixes issues where we become unable to restart applications after the log-cache role goes down; see #1547 for details.

## How Has This Been Tested?
- Started minikube
- Pushed an app (to ensure things are working)
- Scaled `log-cache` to 0 instances
- Restart the app (see issues about Statsd unavailable; this is expected)
- Scaled `log-cache` back up to 1 instance
- Wait a bit
- Restart the app, things work.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
