### PR TITLE
fix: prevent credhub from consuming the postgres bosh-link from auto-scaler postgres

### DIFF
--- a/bosh/releases/pre_render_scripts/credhub/credhub/ig_resolver/patch_job_mf.sh
+++ b/bosh/releases/pre_render_scripts/credhub/credhub/ig_resolver/patch_job_mf.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset
+
+release="credhub"
+job="credhub"
+job_mf="/var/vcap/all-releases/jobs-src/${release}/${job}/job.MF"
+patch --verbose "${job_mf}" <<'EOT'
+@@ -76,11 +76,6 @@ provides:
+   - credhub.data_storage.type
+   - credhub.data_storage.username
+
+-consumes:
+-- name: postgres
+-  type: database
+-  optional: true
+-
+ properties:
+   credhub.port:
+     description: "Listening port for the CredHub API"
+EOT

--- a/chart/assets/operations/instance_groups/credhub.yaml
+++ b/chart/assets/operations/instance_groups/credhub.yaml
@@ -105,6 +105,10 @@
     name: credhub_setup_client_secret
     type: password
 
+{{- range $bytes := .Files.Glob "assets/operations/pre_render_scripts/credhub_*" }}
+{{ $bytes | toString }}
+{{- end }}
+
 {{- else }}
 
 # Remove directly from the cf-deployment.yml YAML file.

--- a/chart/templates/_config.tpl
+++ b/chart/templates/_config.tpl
@@ -73,6 +73,7 @@
     {{- include "_resources.update" . }}
     {{- include "_database.update" . }}{{/* database/_database.tpl */}}
     {{- include "_multicluster.update" . }}
+    {{- include "_credhub.update" . }}
 
     {{- range $condition, $message := $.Values.unsupported }}
       {{- if eq "true" (include "_config.condition" (list $ $condition)) }}

--- a/chart/templates/_credhub.tpl
+++ b/chart/templates/_credhub.tpl
@@ -1,0 +1,16 @@
+{{- /*
+==========================================================================================
+| _credhub.update $
++-----------------------------------------------------------------------------------------
+| kubecf credhub customization
+| - disable consumption of `postgres` bosh-link. It is optional, and we do not
+|   wish to reconfigure credhub when autoscaler comes online or is switched off.
+|   I.e. autoscaler provides a postgres link, and we we wish to ignore it.
+==========================================================================================
+*/}}
+{{- define "_credhub.update" }}
+{{- $_ := include "_config.lookupManifest" (list $ "instance_groups/name=credhub/jobs/name=credhub") }}
+{{- if $.kubecf.retval }}
+{{- $_ := set $.kubecf.retval "consumes" (fromYaml "postgres: null") }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
## Description

2 changes:

  1. Disable the link via explicit nulling in the manifest. This part requires a quarks fix to work.
  2. Patch the credhub spec with a ig-resolver pre-render script to remove the link from it.

Item 2 can be removed when quarks support item 1.

## Motivation and Context

See #1649 

## How Has This Been Tested?

Minikube deployment, kubecf with autoscaler. Checked the resolved manifest for credhub to not use the postgres database.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
