### PR TITLE
fix: lint: yamllint: force locale

### DIFF
--- a/scripts/yamllint.sh
+++ b/scripts/yamllint.sh
@@ -37,6 +37,7 @@ find_args=(
     \( -name '*.yaml' -or -name '*.yml' \)
 )
 
+export LC_ALL=en_US.UTF-8
 # shellcheck disable=SC2046
 # We want word splitting with find.
 yamllint -d "{extends: relaxed, rules: {line-length: {max: 120}}}" \


### PR DESCRIPTION
## Description
If the locale was set incorrectly, yaml linting will fail as the GitHub pipelines are using UTF-8.  As we can't guarantee Python 3.7 yet, we have to override `LC_ALL` rather than just set `PYTHONUTF8=1` (see PEP 540).

## Motivation and Context
I had `LC_ALL=C` set for some insane reason, and linting was failing.

## How Has This Been Tested?
Ran `make yamllint` before & after changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
