### PR TITLE
fix: kubecf upgrade failure due to can't find multi-az scheduler

### DIFF
--- a/chart/hooks/pre-upgrade/remove-deployment-updater-readiness.sh
+++ b/chart/hooks/pre-upgrade/remove-deployment-updater-readiness.sh
@@ -19,7 +19,11 @@ spec:
         readinessProbe: ~
 '
 
-kubectl patch statefulset --namespace "$NAMESPACE" scheduler --patch "$patch"
+scheduler_list=$(kubectl get statefulsets --namespace "$NAMESPACE" | grep scheduler | cut -d " " -f 1)
+
+for i in ${scheduler_list}; do
+  kubectl patch statefulset --namespace "$NAMESPACE" $i --patch "$patch"
+done
 
 # Delete all existing scheduler pods; we can't just patch them as changing
 # existing readiness probes is not allowed.

--- a/chart/hooks/pre-upgrade/remove-deployment-updater-readiness.sh
+++ b/chart/hooks/pre-upgrade/remove-deployment-updater-readiness.sh
@@ -31,7 +31,7 @@ if [ "${scheduler_list}" == "" ]; then
 fi
 
 for scheduler in ${scheduler_list}; do
-  kubectl patch statefulset --namespace "$NAMESPACE" $scheduler --patch "$patch"
+  kubectl patch statefulset --namespace "$NAMESPACE" "${scheduler}" --patch "$patch"
 done
 
 # Delete all existing scheduler pods; we can't just patch them as changing

--- a/chart/hooks/pre-upgrade/remove-deployment-updater-readiness.sh
+++ b/chart/hooks/pre-upgrade/remove-deployment-updater-readiness.sh
@@ -18,8 +18,14 @@ spec:
       - name: cc-deployment-updater-cc-deployment-updater
         readinessProbe: ~
 '
-
+set +o pipefail
 scheduler_list=$(kubectl get statefulsets --namespace "$NAMESPACE" | grep scheduler | cut -d " " -f 1)
+set -o pipefail
+
+if [ "${scheduler_list}" == "" ]; then
+  echo "No scheduler statefulset found."
+  exit 0
+fi
 
 for i in ${scheduler_list}; do
   kubectl patch statefulset --namespace "$NAMESPACE" $i --patch "$patch"

--- a/chart/templates/hooks.yaml
+++ b/chart/templates/hooks.yaml
@@ -26,7 +26,7 @@ metadata:
 rules:
 - apiGroups: [ apps ]
   resources: [ statefulsets ]
-  verbs: [ get, patch ]
+  verbs: [ list, get, patch ]
 - apiGroups: [ "" ]
   resources: [ pods ]
   verbs: [ list, get, delete ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
kubecf with multi-az upgrade failed from version v2.6.1 to v2.7.1.

## Motivation and Context
https://github.com/cloudfoundry-incubator/kubecf/issues/1662

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
run helm upgrade kubecf with the updated code, upgrade process moves on and all schedulers get upgrade successfully.
```
$ k get pod -n kubecf
NAME                                     READY   STATUS                  RESTARTS   AGE
api-z0-0                                 17/17   Running                 1          17m
api-z1-0                                 17/17   Running                 8          17m
auctioneer-0                             6/6     Running                 1          18m
bosh-dns-55f949b56d-6vbbq                1/1     Running                 0          4d20h
bosh-dns-55f949b56d-tgg5w                1/1     Running                 0          4d20h
cc-worker-z0-0                           6/6     Running                 0          18m
cc-worker-z1-0                           6/6     Running                 0          18m
cf-apps-dns-59f9f659f5-t94mh             1/1     Running                 0          27m
coredns-quarks-6db68476bd-ks6cj          1/1     Running                 0          3h32m
coredns-quarks-6db68476bd-pz5dn          1/1     Running                 0          3h32m
database-0                               2/2     Running                 0          27m
database-seeder-7a19efc54ebbb714-pqtbg   0/2     Completed               0          31d
database-seeder-d49344d80353dd73-gmljj   0/2     Completed               0          31d
diego-api-z0-0                           9/9     Running                 2          17m
diego-api-z1-0                           9/9     Running                 2          17m
diego-cell-z0-0                          0/12    Init:CrashLoopBackOff   6          17m
diego-cell-z1-0                          0/12    Init:CrashLoopBackOff   7          17m
doppler-z0-0                             6/6     Running                 0          18m
doppler-z1-0                             6/6     Running                 0          18m
log-api-z0-0                             9/9     Running                 0          17m
log-api-z1-0                             9/9     Running                 0          18m
log-cache-0                              10/10   Running                 0          17m
nats-z0-0                                7/7     Running                 0          18m
nats-z1-0                                7/7     Running                 0          18m
router-z0-0                              7/7     Running                 0          18m
router-z1-0                              7/7     Running                 4          18m
scheduler-z0-0                           12/12   Running                 1          17m
scheduler-z1-0                           12/12   Running                 1          17m
singleton-blobstore-z0-0                 8/8     Running                 0          18m
uaa-z0-0                                 8/8     Running                 0          18m
uaa-z1-0                                 8/8     Running                 0          18m
```


<!--- Include details of your testing environment, and the tests you ran to -->
<!--- An important detail to include is the version of the used cf-operator -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
