### PR TITLE
fix: add pre-check on scheduler statefulset before patch it

### DIFF
--- a/chart/hooks/pre-upgrade/remove-deployment-updater-readiness.sh
+++ b/chart/hooks/pre-upgrade/remove-deployment-updater-readiness.sh
@@ -30,8 +30,13 @@ if [ "${scheduler_list}" == "" ]; then
   exit 0
 fi
 
+query='{.spec.template.spec.containers[*].name}'
+
 for scheduler in ${scheduler_list}; do
-  kubectl patch statefulset --namespace "$NAMESPACE" "${scheduler}" --patch "$patch"
+  probe="$(kubectl get statefulsets --namespace="${NAMESPACE}" "${scheduler}" --output=jsonpath="${query}")"
+  if [[ "${probe}" =~ "cc-deployment-updater-cc-deployment-updater" ]]; then
+    kubectl patch statefulset --namespace "$NAMESPACE" "${scheduler}" --patch "$patch"
+  fi
 done
 
 # Delete all existing scheduler pods; we can't just patch them as changing


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
add a pre-check before patch scheduler statefulset during kubecf upgrade.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/cloudfoundry-incubator/kubecf/issues/1675

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- An important detail to include is the version of the used cf-operator -->
This has been tested in kubecf v2.7.1, re-run helm upgrade, no incorrect patch to scheduler statefulsets.

```
$ k get pod -n kubecf
NAME                                     READY   STATUS      RESTARTS   AGE
api-z0-0                                 17/17   Running     16         3h49m
api-z1-0                                 17/17   Running     16         3h49m
auctioneer-0                             6/6     Running     1          3h50m
cc-worker-z0-0                           6/6     Running     0          3h49m
cc-worker-z1-0                           6/6     Running     0          3h50m
cf-apps-dns-59f9f659f5-c4z5g             1/1     Running     0          3h54m
coredns-quarks-6db68476bd-4pjvh          1/1     Running     0          4h42m
coredns-quarks-6db68476bd-cdqtm          1/1     Running     0          4h42m
database-0                               2/2     Running     0          3h53m
database-seeder-10807f69f53c6e0f-hpxmr   0/2     Completed   0          2d
database-seeder-7a19efc54ebbb714-pqtbg   0/2     Completed   0          48d
database-seeder-c400c55f793c774c-5ltcb   0/2     Completed   0          5h27m
database-seeder-d49344d80353dd73-gmljj   0/2     Completed   0          48d
database-seeder-e421e917deb27f22-mps4r   0/2     Completed   0          4h42m
diego-api-z0-0                           9/9     Running     2          3h49m
diego-api-z1-0                           9/9     Running     2          3h49m
diego-cell-z0-0                          12/12   Running     9          3h49m
diego-cell-z1-0                          12/12   Running     9          3h49m
doppler-z0-0                             6/6     Running     0          3h50m
doppler-z1-0                             6/6     Running     0          3h50m
ian-nsenter-10.240.64.24                 0/1     Completed   0          7d2h
log-api-z0-0                             9/9     Running     0          3h49m
log-api-z1-0                             9/9     Running     0          3h49m
log-cache-0                              10/10   Running     0          3h50m
nats-z0-0                                7/7     Running     0          3h50m
nats-z1-0                                7/7     Running     0          3h50m
router-z0-0                              7/7     Running     0          3h50m
router-z1-0                              7/7     Running     0          3h50m
scheduler-z0-0                           12/12   Running     1          13m
scheduler-z1-0                           12/12   Running     1          14m
singleton-blobstore-z0-0                 8/8     Running     0          3h50m
uaa-z0-0                                 8/8     Running     0          3h50m
uaa-z1-0                                 8/8     Running     0          3h50m
```
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
