### PR TITLE
Revert "feat: Bump suse-go-buildpack release to 1.9.24.1"

### DIFF
--- a/chart/config/sle15.yaml
+++ b/chart/config/sle15.yaml
@@ -25,7 +25,7 @@ stacks:
       suse-nodejs-buildpack:
         version: "1.7.35.1"
       suse-go-buildpack:
-        version: "1.9.24.1"
+        version: "1.9.23.1"
       suse-python-buildpack:
         version: "1.7.26.1"
       suse-php-buildpack:


### PR DESCRIPTION
Image doesn't exist.
Reverts cloudfoundry-incubator/kubecf#1665