### PR TITLE
feat: Use cflinuxfs3 as default stack

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -4,7 +4,7 @@
 # List of stacks to install; the first one will be used as the default.
 # A stack is a prebuilt root file system that supports a specific
 # operating system with a corresponding set of buildpacks.
-install_stacks: [sle15, cflinuxfs3]
+install_stacks: [cflinuxfs3, sle15]
 
 # Set or override job properties. The first level of the map is the instance group name. The second
 # level of the map is the job name. E.g.:

--- a/doc/stacks.md
+++ b/doc/stacks.md
@@ -7,7 +7,7 @@ There are 2 stacks built in: The `cflinuxfs3` stack is defined by Cloud Foundry,
 The `install_buildpacks` list in `values.yaml` determines which stacks will be installed when the kubecf helm chart is deployed. The first stack in the list will be the default stack:
 
 ```
-install_buildpacks: [sle15, cflinuxfs3]
+install_buildpacks: [cflinuxfs3, sle15]
 ```
 
 ## Stack definitions


### PR DESCRIPTION
to make sure the latest upstream buildpacks can be used by default.