### PR TITLE
Split out locket from diego-api as it should be independant

### DIFF
--- a/chart/assets/operations/instance_groups/database.yaml
+++ b/chart/assets/operations/instance_groups/database.yaml
@@ -43,10 +43,10 @@
   value: &pxc-cluster-ca ((pxc_tls.ca))
 
 - type: replace
-  path: /instance_groups/name=diego-api/jobs/name=locket/properties/diego/locket/sql/db_host?
+  path: /instance_groups/name=locket/jobs/name=locket/properties/diego/locket/sql/db_host?
   value: *pxc-cluster-address
 - type: replace
-  path: /instance_groups/name=diego-api/jobs/name=locket/properties/diego/locket/sql/ca_cert?
+  path: /instance_groups/name=locket/jobs/name=locket/properties/diego/locket/sql/ca_cert?
   value: *pxc-cluster-ca
 
 - type: replace
@@ -477,35 +477,35 @@
   value: {{ .Values.features.external_database.require_ssl }}
 
 - type: replace
-  path: /instance_groups/name=diego-api/jobs/name=locket/properties/diego/locket/sql/db_driver
+  path: /instance_groups/name=locket/jobs/name=locket/properties/diego/locket/sql/db_driver
   value: {{ .Values.features.external_database.type | quote }}
 - type: replace
-  path: /instance_groups/name=diego-api/jobs/name=locket/properties/diego/locket/sql/db_port
+  path: /instance_groups/name=locket/jobs/name=locket/properties/diego/locket/sql/db_port
   value: {{ .Values.features.external_database.port }}
 - type: replace
-  path: /instance_groups/name=diego-api/jobs/name=locket/properties/diego/locket/sql/db_schema
+  path: /instance_groups/name=locket/jobs/name=locket/properties/diego/locket/sql/db_schema
   value: {{ .Values.features.external_database.databases.locket.name | quote }}
 - type: replace
-  path: /instance_groups/name=diego-api/jobs/name=locket/properties/diego/locket/sql/db_host?
+  path: /instance_groups/name=locket/jobs/name=locket/properties/diego/locket/sql/db_host?
   value: {{ .Values.features.external_database.host | quote }}
 {{- if not .Values.features.external_database.seed }}
 - type: replace
-  path: /instance_groups/name=diego-api/jobs/name=locket/properties/diego/locket/sql/db_password
+  path: /instance_groups/name=locket/jobs/name=locket/properties/diego/locket/sql/db_password
   value: {{ .Values.features.external_database.databases.locket.password | quote }}
 - type: replace
-  path: /instance_groups/name=diego-api/jobs/name=locket/properties/diego/locket/sql/db_username
+  path: /instance_groups/name=locket/jobs/name=locket/properties/diego/locket/sql/db_username
   value: {{ .Values.features.external_database.databases.locket.username | quote }}
 {{- end }}{{/* not .Values.features.external_database.seed */}}
 {{- if .Values.features.external_database.ca_cert }}
 - type: replace
-  path: /instance_groups/name=diego-api/jobs/name=locket/properties/diego/locket/sql/ca_cert?
+  path: /instance_groups/name=locket/jobs/name=locket/properties/diego/locket/sql/ca_cert?
   value: {{- toYaml .Values.features.external_database.ca_cert | indent 2 }}
 {{- else }}
 - type: remove
-  path: /instance_groups/name=diego-api/jobs/name=locket/properties/diego/locket/sql/ca_cert?
+  path: /instance_groups/name=locket/jobs/name=locket/properties/diego/locket/sql/ca_cert?
 {{- end}}
 - type: replace
-  path: /instance_groups/name=diego-api/jobs/name=locket/properties/diego/locket/sql/require_ssl?
+  path: /instance_groups/name=locket/jobs/name=locket/properties/diego/locket/sql/require_ssl?
   value: {{ .Values.features.external_database.require_ssl }}
 
 {{- if .Values.features.credhub.enabled }}

--- a/chart/assets/operations/instance_groups/diego-api.yaml
+++ b/chart/assets/operations/instance_groups/diego-api.yaml
@@ -1,51 +1,18 @@
 # Override the addresses for the jobs under the diego-api instance group.
 - type: replace
-  path: /instance_groups/name=diego-api/jobs/name=bbs/properties/diego/bbs/locket?/api_location
-  value: 127.0.0.1:8891
-- type: replace
   path: /instance_groups/name=diego-api/jobs/name=bbs/properties/diego/bbs/health_addr?
   value: 0.0.0.0:8890
 - type: replace
   path: /instance_groups/name=diego-api/jobs/name=cfdot/properties/bbs?/hostname
   value: 127.0.0.1
 - type: replace
-  path: /instance_groups/name=diego-api/jobs/name=cfdot/properties/locket?/hostname
-  value: 127.0.0.1
-- type: replace
   path: /variables/name=diego_bbs_server/options?/alternative_names?/-
-  value: '127.0.0.1'
-- type: replace
-  path: /variables/name=diego_locket_server/options?/alternative_names?/-
   value: '127.0.0.1'
 
 # Disable tuning /proc/sys kernel parameters as locket and bbs are running on containers.
 - type: replace
-  path: /instance_groups/name=diego-api/jobs/name=locket/properties/set_kernel_parameters?
-  value: false
-- type: replace
   path: /instance_groups/name=diego-api/jobs/name=bbs/properties/set_kernel_parameters?
   value: false
-
-# Add quarks properties for locket.
-- type: replace
-  path: /instance_groups/name=diego-api/jobs/name=locket/properties/quarks?
-  value:
-    ports:
-    - name: locket
-      protocol: TCP
-      internal: 8891
-    run:
-      healthcheck:
-        locket:
-          readiness:
-            exec:
-              command:
-              - /var/vcap/packages/cfdot/bin/cfdot
-              - locks
-              - --locketAPILocation=127.0.0.1:8891
-              - --caCertFile=/var/vcap/jobs/cfdot/config/certs/cfdot/ca.crt
-              - --clientCertFile=/var/vcap/jobs/cfdot/config/certs/cfdot/client.crt
-              - --clientKeyFile=/var/vcap/jobs/cfdot/config/certs/cfdot/client.key
 
 # Add quarks properties for bbs.
 - type: replace

--- a/chart/assets/operations/instance_groups/locket.yaml
+++ b/chart/assets/operations/instance_groups/locket.yaml
@@ -1,0 +1,43 @@
+# Set instance count to 2; the default inherited from diego-api is 2
+- type: replace
+  path: /instance_groups/name=locket/instances
+  value: 2
+
+# Disable tuning /proc/sys kernel parameters as locket is running on containers.
+- type: replace
+  path: /instance_groups/name=locket/jobs/name=locket/properties/set_kernel_parameters?
+  value: false
+
+# Add quarks properties for locket.
+- type: replace
+  path: /instance_groups/name=locket/jobs/name=locket/properties/quarks?
+  value:
+    ports:
+    - name: locket
+      protocol: TCP
+      internal: 8891
+    run:
+      healthcheck:
+        locket:
+          readiness:
+            exec:
+              command:
+                - "/usr/bin/nc"
+                - "-z"
+                - "127.0.0.1"
+                - "8891"
+      #         - /var/vcap/packages/cfdot/bin/cfdot
+      #         - locks
+      #         - --skipCertVerify
+      #         - --locketAPILocation=127.0.0.1:8891
+      #         - --caCertFile=/var/vcap/jobs/cfdot/config/certs/cfdot/ca.crt
+      #         - --clientCertFile=/var/vcap/jobs/cfdot/config/certs/cfdot/client.crt
+      #         - --clientKeyFile=/var/vcap/jobs/cfdot/config/certs/cfdot/client.key
+
+- type: replace
+  path: /addons/name=bosh-dns-aliases/jobs/name=bosh-dns-aliases/properties/aliases/domain=locket.service.cf.internal/targets/0/instance_group
+  value: locket
+
+{{- range $bytes := .Files.Glob "assets/operations/pre_render_scripts/locket_*" }}
+{{ $bytes | toString }}
+{{- end }}

--- a/chart/assets/operations/instance_groups/locket.yaml
+++ b/chart/assets/operations/instance_groups/locket.yaml
@@ -1,8 +1,3 @@
-# Set instance count to 2; the default inherited from diego-api is 2
-- type: replace
-  path: /instance_groups/name=locket/instances
-  value: 2
-
 # Disable tuning /proc/sys kernel parameters as locket is running on containers.
 - type: replace
   path: /instance_groups/name=locket/jobs/name=locket/properties/set_kernel_parameters?

--- a/chart/assets/operations/sequencing.yaml
+++ b/chart/assets/operations/sequencing.yaml
@@ -28,13 +28,17 @@
 #            --> tcp-router                (feature: routing-api)
 #            --> credhub                   (feature: credhub)
 #            --> diego-cell                (feature: not eirini)
-# deigo-api  --> auctioneer                (feature: not eirini)
+# locket     --> diego-api
+#            --> auctioneer
+#            --> scheduler
+# diego-api  --> auctioneer                (feature: not eirini)
 # asdatabase --> asactors                  (feature: autoscaler)
 #            --> asapi                     (feature: autoscaler)
 #            --> asmetrics   --> asnozzle  (feature: autoscaler)
 
 {{- template "wait-for" list "cc-worker" "api" }}
 {{- template "wait-for" list "scheduler" "api" }}
+{{- template "wait-for" list "scheduler" "locket" }}
 {{- template "wait-for" list "log-api"   "nats" }}
 {{- template "wait-for" list "log-cache" "uaa" }}
 
@@ -49,7 +53,8 @@
 {{- end }}
 
 {{- if not .Values.features.eirini.enabled }}
-  {{- template "wait-for" list "auctioneer" "diego-api" }}
+  {{- template "wait-for" list "diego-api" "locket" }}
+  {{- template "wait-for" list "auctioneer" "locket" }}
   {{- template "wait-for" list "diego-cell" "uaa" }}
 {{- end }}
 

--- a/chart/assets/operations/sizing.yaml
+++ b/chart/assets/operations/sizing.yaml
@@ -3,7 +3,7 @@
 {{- /* Core instance groups that always exist */}}
 {{- $instance_groups = append $instance_groups "api" }}
 {{- $instance_groups = append $instance_groups "cc-worker" }}
-{{- $instance_groups = append $instance_groups "diego-api" }}
+{{- $instance_groups = append $instance_groups "locket" }}
 {{- $instance_groups = append $instance_groups "doppler" }}
 {{- $instance_groups = append $instance_groups "log-api" }}
 {{- $instance_groups = append $instance_groups "nats" }}
@@ -33,6 +33,7 @@
 {{- /* Instances groups where existence depends on whether Eirini is enabled */}}
 {{- if not .Values.features.eirini.enabled }}
 {{- $instance_groups = append $instance_groups "auctioneer" }}
+{{- $instance_groups = append $instance_groups "diego-api" }}
 {{- if not .Values.features.multiple_cluster_mode.control_plane.enabled }}
 {{- $instance_groups = append $instance_groups "diego-cell" }}
 {{- end }}{{/* if control_plane */}}

--- a/chart/config/jobs.yaml
+++ b/chart/config/jobs.yaml
@@ -17,6 +17,8 @@ move_jobs:
     log-cache-nozzle: log-cache
     log-cache-cf-auth-proxy: log-cache
     route_registrar: log-cache
+  diego-api:
+    locket: locket
 
 # Include default settings for `number_of_worker` properties because
 # they are not set in cf-deployment, and spec files are not available

--- a/chart/config/jobs.yaml
+++ b/chart/config/jobs.yaml
@@ -127,6 +127,7 @@ jobs:
     # database instance group is replaced by native release
     '$default': false
   diego-api:
+    '$default': '!features.eirini.enabled && !features.multiple_cluster_mode.control_plane.enabled'
     cfdot:
       processes: []
   diego-cell:

--- a/chart/config/resources.yaml
+++ b/chart/config/resources.yaml
@@ -143,6 +143,7 @@ resources:
   log-api: 128
   log-cache:
     log-cache: 2048
+  locket: 64
   nats: ~
   rotate-cc-database-key:
     rotate_cc_database_key:

--- a/chart/templates/_multicluster.tpl
+++ b/chart/templates/_multicluster.tpl
@@ -19,6 +19,7 @@
     {{- $_ := unset $.Values.properties "doppler" }}
     {{- $_ := unset $.Values.properties "log-api" }}
     {{- $_ := unset $.Values.properties "log-cache" }}
+    {{- $_ := unset $.Values.properties "locket" }}
     {{- $_ := unset $.Values.properties "nats" }}
     {{- $_ := unset $.Values.properties "rotate-cc-database-key" }}
     {{- $_ := unset $.Values.properties "router" }}

--- a/chart/templates/multiple_cluster_mode.yaml
+++ b/chart/templates/multiple_cluster_mode.yaml
@@ -37,6 +37,8 @@ data:
     - type: remove
       path: /instance_groups/name=log-cache
     - type: remove
+      path: /instance_groups/name=locket
+    - type: remove
       path: /instance_groups/name=nats
     - type: remove
       path: /instance_groups/name=router

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -109,6 +109,8 @@ sizing:
       size: 20Gi
   diego_api:
     instances: ~
+  locket:
+    instances: ~
   diego_cell:
     ephemeral_disk:
       # Size of the ephemeral disk used to store applications in MB


### PR DESCRIPTION
Locket should be independant from diego-api.  Colocating them makes it less resilient and causes other instances to be incorrectly dependant on diego-api.

## Description
Moving the locket from diego-api to it's own pod.

## Motivation and Context
It solves issues with diego-api being only able to talk to the single locket co-located.  It also allows for better separation of the two independant processes.

Fixes #1410

## How Has This Been Tested?
Deployed in IBM hybrid testing environments.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

Can you point me to the docs I would need to update and I can add those to the PR.
