### PR TITLE
fix: master into release-2.7

### DIFF
--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -120,7 +120,7 @@ resources:
   source:
     uri: https://github.com/SUSE/catapult
   version:
-    ref: 95a2cac09058c7a7661e5cc2c6cae4e962b99a8e
+    ref: b139eaef2468c9a777509d1ff14dc7f5777f1e6b
 
 - name: s3.kubecf-ci
   type: s3


### PR DESCRIPTION
Changes are bumps to sle15 and suse-java-buildpack, as well as a bump to quarks-operator-7.2.1