### PR TITLE
Renable cc_deployment_updater and fix readiness check

### DIFF
--- a/bosh/releases/pre_render_scripts/scheduler/cc_deployment_updater/jobs/patch_cc_deployment_updater_erb.sh
+++ b/bosh/releases/pre_render_scripts/scheduler/cc_deployment_updater/jobs/patch_cc_deployment_updater_erb.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset
+
+target="/var/vcap/all-releases/jobs-src/capi/cc_deployment_updater/templates/bin/cc_deployment_updater.erb"
+sentinel="${target}.patch_sentinel"
+if [[ -f "${sentinel}" ]]; then
+  if sha256sum --check "${sentinel}" ; then
+    echo "Patch already applied. Skipping"
+    exit 0
+  fi
+  echo "Sentinel mismatch, re-patching"
+fi
+
+# Advertise our spec address.
+patch --verbose "${target}" <<'EOT'
+@@ -1,5 +1,8 @@
+ #!/usr/bin/env bash
+
++# CAPI makes cf4k8s assumptions when running on k8s that are not correct for kubecf
++unset KUBERNETES_SERVICE_HOST
++
+ source /var/vcap/jobs/cc_deployment_updater/bin/ruby_version.sh
+ cd /var/vcap/packages/cloud_controller_ng/cloud_controller_ng
+ exec bundle exec rake deployment_updater:start
+EOT
+
+sha256sum "${target}" > "${sentinel}"

--- a/chart/assets/operations/instance_groups/database.yaml
+++ b/chart/assets/operations/instance_groups/database.yaml
@@ -78,6 +78,13 @@
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/ccdb/ca_cert?
   value: *pxc-cluster-ca
 
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cc_deployment_updater/properties/ccdb/address?
+  value: *pxc-cluster-address
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cc_deployment_updater/properties/ccdb/ca_cert?
+  value: *pxc-cluster-ca
+
 {{- if .Values.features.credhub.enabled }}
 - type: replace
   path: /instance_groups/name=credhub/jobs/name=credhub/properties/credhub/data_storage/host?
@@ -344,6 +351,38 @@
 {{- end }}
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=cloud_controller_clock/properties/ccdb/ssl_verify_hostname?
+  value: {{ .Values.features.external_database.require_ssl }}
+
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cc_deployment_updater/properties/ccdb/db_scheme
+  value: *external_cc_database_scheme
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cc_deployment_updater/properties/ccdb/port
+  value: *external_cc_database_port
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cc_deployment_updater/properties/ccdb/databases/tag=cc/name
+  value: *external_cc_database_name
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cc_deployment_updater/properties/ccdb/address?
+  value: *external_cc_database_address
+{{- if not .Values.features.external_database.seed }}
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cc_deployment_updater/properties/ccdb/roles/name=cloud_controller/password
+  value: *external_cc_database_password
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cc_deployment_updater/properties/ccdb/roles/name=cloud_controller/name
+  value: *external_cc_database_username
+{{- end }}{{/* not .Values.features.external_database.seed */}}
+{{- if .Values.features.external_database.ca_cert }}
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cc_deployment_updater/properties/ccdb/ca_cert?
+  value: {{- toYaml .Values.features.external_database.ca_cert | indent 2 }}
+{{- else }}
+- type: remove
+  path: /instance_groups/name=scheduler/jobs/name=cc_deployment_updater/properties/ccdb/ca_cert?
+{{- end }}
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cc_deployment_updater/properties/ccdb/ssl_verify_hostname?
   value: {{ .Values.features.external_database.require_ssl }}
 
 - type: replace

--- a/chart/assets/operations/instance_groups/scheduler.yaml
+++ b/chart/assets/operations/instance_groups/scheduler.yaml
@@ -6,6 +6,18 @@
       exec:
         command: ["pgrep", "--full", "clock:start"]
 
+# Set readiness port based on port used in cc.readiness_port.deployment_updater property being set in the manifest
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cc_deployment_updater/properties?/cc/readiness_port/deployment_updater?
+  value: 4445
+
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=cc_deployment_updater/properties/quarks?/run/healthcheck/cc_deployment_updater
+  value:
+    readiness:
+      tcpSocket:
+        port: 4445
+
 - type: replace
   path: /instance_groups/name=scheduler/jobs/name=statsd_injector/properties/quarks?/run/healthcheck/statsd_injector/readiness/exec/command
   value: ["/bin/sh", "-c", "ss -nlu src localhost:8125 | grep :8125"]
@@ -84,9 +96,6 @@
     - name: binding-cache
       protocol: TCP
       internal: 9000
-
-- type: remove
-  path: /instance_groups/name=scheduler/jobs/name=cc_deployment_updater
 
 {{- range $bytes := .Files.Glob "assets/operations/pre_render_scripts/scheduler_*" }}
 {{ $bytes | toString }}

--- a/chart/config/jobs.yaml
+++ b/chart/config/jobs.yaml
@@ -139,7 +139,6 @@ jobs:
   routing-api:
     '$default': 'features.routing_api.enabled'
   scheduler:
-    cc_deployment_updater: false
     cfdot:
       processes: []
     ssh_proxy: '!features.eirini.enabled'

--- a/chart/config/resources.yaml
+++ b/chart/config/resources.yaml
@@ -149,6 +149,7 @@ resources:
       rotate: {memory: {limit: 512, request: 192}}
   router: 200
   scheduler:
+    cc_deployment_updater: 320
     cloud_controller_clock: 512
   singleton-blobstore:
     blobstore:

--- a/chart/templates/_capi.tpl
+++ b/chart/templates/_capi.tpl
@@ -28,6 +28,7 @@
 
   {{- /* The buildpacks properties are only defined for the ng/worker/clock jobs */}}
   {{- if not (hasPrefix "buildpacks" $property) }}
+    {{- $_ := set $ig "cc_deployment_updater"   "scheduler" }}
     {{- /* XXX cc_route_syncer is not in cf-deployment; see CF-K8s-Networking */}}
     {{- /* $_ := set $ig "cc_route_syncer" "???" */}}
   {{- end }}


### PR DESCRIPTION
Add back the cc_deployment updater to the scheduler pod.

## Description
Basically this reverted commit dfcc97d441efab31ec49a07b3cf87062baf7aeac.  But also fixed the readiness check

## Motivation and Context
This will allow the cc_deployment_updater to run and reenable the zero downtime functionality in CF.

## How Has This Been Tested?
Deployed this in a full kubecf env and ran the CATs tests which validate this functionality

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
