### PR TITLE
Bump catapult to latest version

### DIFF
--- a/.concourse/pipeline.yaml.gomplate
+++ b/.concourse/pipeline.yaml.gomplate
@@ -120,7 +120,7 @@ resources:
   source:
     uri: https://github.com/SUSE/catapult
   version:
-    ref: b139eaef2468c9a777509d1ff14dc7f5777f1e6b
+    ref: f2c1a1b31db60769da5e8d3f8f73bb7d18856179
 
 - name: s3.kubecf-ci
   type: s3


### PR DESCRIPTION
Relevant changes:
* use `wait_for_kubecf` is more robust and doesn't return early
* don't deploy metrics-server chart if metrics-server is already running.
