### PR TITLE
Add eirini/bits nodeselector

### DIFF
--- a/mixins/bits/config/bits.yaml
+++ b/mixins/bits/config/bits.yaml
@@ -16,3 +16,5 @@ bits:
     BLOBSTORE_PASSWORD: blobstore
 
   tls_secret_name: bits-service-ssl
+
+  nodeSelector: {}

--- a/mixins/bits/templates/bits.yaml
+++ b/mixins/bits/templates/bits.yaml
@@ -48,6 +48,8 @@ spec:
           mountPath: /workspace/jobs/bits-service/config
         - name: bits-cert
           mountPath: /workspace/jobs/bits-service/certs
+      nodeSelector:
+        {{- toYaml .Values.bits.nodeSelector | nindent 8 }}
 # Service
 ---
 apiVersion: v1

--- a/mixins/eirini/config/eirini.yaml
+++ b/mixins/eirini/config/eirini.yaml
@@ -24,6 +24,7 @@ eirini:
     disk_limit_mb: 2048
     namespace: eirini
     version: 0.0.0
+    nodeSelector: {}
 
     cc_api:
       # The service that the CC API listens on; may be a FQDN instead.

--- a/mixins/eirini/templates/deployment.yaml
+++ b/mixins/eirini/templates/deployment.yaml
@@ -75,4 +75,6 @@ spec:
           requests:
             cpu: 20m
             memory: 20Mi
+      nodeSelector:
+        {{- toYaml .Values.eirini.opi.nodeSelector | nindent 8 }}
 {{- end }}

--- a/mixins/eirini/templates/events.yaml
+++ b/mixins/eirini/templates/events.yaml
@@ -60,5 +60,7 @@ spec:
           requests:
             cpu: 15m
             memory: 15Mi
+      nodeSelector:
+        {{- toYaml .Values.eirini.opi.nodeSelector | nindent 8 }}
 {{- end }}
 {{- end }}

--- a/mixins/eirini/templates/metrics.yaml
+++ b/mixins/eirini/templates/metrics.yaml
@@ -60,5 +60,7 @@ spec:
           requests:
             cpu: 15m
             memory: 15Mi
+      nodeSelector:
+        {{- toYaml .Values.eirini.opi.nodeSelector | nindent 8 }}
 {{- end }}
 {{- end }}

--- a/mixins/eirini/templates/routing.yaml
+++ b/mixins/eirini/templates/routing.yaml
@@ -90,5 +90,7 @@ spec:
           requests:
             cpu: 30m
             memory: 45Mi
+      nodeSelector:
+        {{- toYaml .Values.eirini.opi.nodeSelector | nindent 8 }}
 {{- end }}
 {{- end }}

--- a/mixins/eirini/templates/staging-reporter.yaml
+++ b/mixins/eirini/templates/staging-reporter.yaml
@@ -63,5 +63,7 @@ spec:
                 items:
                 - key: "{{ .Values.eirini.opi.events.tls.capi.caPath }}"
                   path: cc.ca
+      nodeSelector:
+        {{- toYaml .Values.eirini.opi.nodeSelector | nindent 8 }}
 {{- end }}
 {{- end }}

--- a/mixins/eirinix/templates/dns-aliases/deployment.yaml
+++ b/mixins/eirinix/templates/dns-aliases/deployment.yaml
@@ -37,4 +37,6 @@ spec:
           ports:
           - name: webhook
             containerPort: 8443
+      nodeSelector:
+        {{- toYaml .Values.eirini.opi.nodeSelector | nindent 8 }}
 {{- end }}


### PR DESCRIPTION
## Description
Add setting of eirini/bits nodeselector configuration.

## Motivation and Context
Add setting of eirini/bits nodeselector configuration. This follows the same pattern as the eirinix components where a nodeselector can be set for each component.

E.g.
https://github.com/cloudfoundry-incubator/kubecf/blob/master/mixins/eirinix/config/eirinix.yaml#L14
https://github.com/cloudfoundry-incubator/kubecf/blob/master/mixins/eirinix/templates/loggregator-bridge.yaml#L86-L87

## How Has This Been Tested?
Tested using updated kubecf helm chart v2.7.13. Set a node `xxx.xxx.xxx.165` with a test label and set the nodeselector to select that node.

## Screenshots (if appropriate):
<img width="932" alt="Screenshot 2021-06-23 at 12 29 31" src="https://user-images.githubusercontent.com/47635090/123090482-174e9500-d420-11eb-9988-4e75e16712cf.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has security implications.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
